### PR TITLE
docs(privacy): privacy-redaction + data-retention rule files (S10, #1920)

### DIFF
--- a/.claude/rules/data-retention.md
+++ b/.claude/rules/data-retention.md
@@ -1,0 +1,155 @@
+# Data retention — regulatory-expiry stamp-at-write
+
+> Every code path that creates a `Call` row MUST route through
+> `lib/privacy/stamp-regulatory-expiry.ts::stampRegulatoryExpiry({...})`
+> to derive the row's `regulatoryExpiresAt` from the preset (when the
+> #1925 cascade lands) or the `RETENTION_CALLER_DATA_DAYS` env fallback.
+> Backfill of existing rows MUST be NULL — computed dates pick the wrong
+> preset, drift on later preset changes, and extend DSR-pending callers.
+>
+> Sibling to [`privacy-redaction.md`](./privacy-redaction.md) (read-side
+> tier projection) and [`ai-to-db-guard.md`](./ai-to-db-guard.md) (validate-
+> before-execute). This file holds the **write-side regulatory-expiry**
+> discipline.
+>
+> Catalogued in [`docs/lattice-chains.md`](../../docs/lattice-chains.md)
+> §Privacy / consent. Enforces CHAIN-CONTRACTS.md §6a I-PR3. Born of epic
+> #1915 child #1917.
+
+## Rule
+
+When you write a code path that creates a `Call` row:
+
+1. Import the helper:
+   ```typescript
+   import { stampRegulatoryExpiry } from "@/lib/privacy/stamp-regulatory-expiry";
+   ```
+2. Resolve the expiry **before** the `prisma.call.create` call:
+   ```typescript
+   const regulatoryExpiresAt = stampRegulatoryExpiry({
+     presetRetentionDays: null, // wired by #1925 cascade when it lands
+   });
+   ```
+3. Spread it conditionally into the create payload:
+   ```typescript
+   ...(regulatoryExpiresAt ? { regulatoryExpiresAt } : {}),
+   ```
+
+Three reasons we spread conditionally, not as a NULL field:
+
+- Keeps the row write clean when no retention policy resolves (preset
+  null AND env zero → no field touched, default DB NULL applies).
+- Avoids accidentally OVERWRITING a stamp on a row that already had one
+  (relevant for the `upsert` path, not `create` — but the spread shape
+  is the same).
+- Matches the rest of the canonical voice `Call.create` shape (every
+  optional FK is spread the same way).
+
+## Why this is at write-time, not read-time
+
+A row's regulatory window is fixed when the data is COLLECTED, not when
+it is READ. The preset in effect at create-time is what the learner was
+told their data would be governed by (Art 13 transparency obligation).
+Computing the window later from `createdAt + RETENTION_CALLER_DATA_DAYS`
+is wrong because:
+
+1. The env var may have changed since enrolment.
+2. A future preset switch (Basic → GDPR-EU) would retroactively change
+   the deletion date for already-collected data — drift between what
+   the learner agreed to and what the system enforces.
+3. A DSR-pending caller would get their data EXTENDED by a retroactive
+   stamp, defeating the erasure window.
+
+NULL on existing rows is the safe identity element. The caller-level
+cleanup in `POST /api/admin/retention/cleanup` continues to handle
+legacy dormant callers; the row-level expiry purge applies only to rows
+with a non-NULL `regulatoryExpiresAt`.
+
+## Backfill discipline
+
+**Backfill of existing rows MUST be NULL.** The migration body documents
+the three reasons (above) for any future reader. Do not write a backfill
+script that computes a retroactive date — even one that uses
+`COALESCE(env, default)` — without an ADR explaining why the three
+reasons no longer apply.
+
+When `#1925` lands the `privacyPresetId` cascade, a SEPARATE story may
+selectively re-stamp historical rows from the preset that has been in
+effect since their `createdAt`. That's a deliberate, preset-aware
+backfill — distinct from the migration-time backfill this rule prohibits.
+
+## Column naming discipline
+
+The column is **`regulatoryExpiresAt`**, NOT `retentionExpiry` or
+`expiresAt`. The `CallerMemory` model already carries an `expiresAt`
+column at `prisma/schema.prisma:2304` for content decay ("traveling next
+week"). The two have completely different semantics:
+
+| Column | Semantic | Driven by |
+|---|---|---|
+| `CallerMemory.expiresAt` | Content decay (this fact stops being true) | Memory extractor at write |
+| `Call.regulatoryExpiresAt` | Regulatory purge date (we must delete by this date) | Preset / env fallback at write |
+
+A future code path that conflates them (e.g. queries `expiresAt` across
+both tables for a unified retention sweep) would silently delete
+in-effect memories AND retroactively expire calls. The discipline of
+giving the regulatory concept a distinctive name is the structural
+prevention.
+
+## Sibling-writer survey (Lattice mandatory)
+
+11 `prisma.call.create` sites exist in the codebase (per the 2026-06-18
+S5a survey). Three canonical voice paths are wired today:
+
+- `lib/voice/route-handlers.ts:924` (inbound webhook fresh-arrival)
+- `app/api/voice/calls/start/route.ts:187` (WebRTC + JS SDK start)
+- `app/api/voice/calls/outbound-dial/route.ts:214` (PSTN outbound)
+
+8 lower-priority writers (import paths, sim-runner, test-harness,
+admin-debug, scripts) adopt incrementally as touched. When you modify
+any of them, route the new write through `stampRegulatoryExpiry`.
+
+Partial-update writers (`prosody-runner`, `compose-next-prompt`,
+`persistEndOfCall` UPDATE branch) are safe by default — Prisma writes
+only specified fields, so they don't touch `regulatoryExpiresAt`.
+
+## Existing enforcement
+
+| Location | Mechanism | What it prevents |
+|---|---|---|
+| `lib/privacy/stamp-regulatory-expiry.ts` (PR #1939, #1917) | Single chokepoint helper | Drift between adoption sites — every site uses the same layered resolution |
+| `prisma/migrations/20260618120000_1917_call_regulatory_expires_at` | Migration body documents NULL-backfill rationale | Future reader running a retroactive backfill script "to clean things up" |
+| `app/api/admin/retention/cleanup/route.ts` | Cleanup cron's new deleteMany branch | Stamped expiries actually purge — the row-level enforcer |
+| `scripts/check-fk-consistency.ts` Query 12 | WARN-only detector | NULL-expiry rows older than the grace window are surfaced (rollout-state observability) |
+| CHAIN-CONTRACTS.md §6a I-PR3 (PR #1938) | Cross-stage privacy invariant | Discoverability — the contract names the structural enforcer |
+
+## When this rule does NOT apply
+
+- `prisma.call.update` calls — UPDATE paths only touch specified fields;
+  `regulatoryExpiresAt` is set at CREATE, not on every field write.
+- Test fixtures and seed scripts under `prisma/fixtures/` — fixtures are
+  deterministic; stamping a retention-driven date in a fixture would
+  break test stability.
+- One-off forensic scripts under `scripts/` that read but don't write
+  `Call` rows.
+
+## Escalation
+
+If you're writing a new `Call.create` path and can't adopt the helper
+in the same PR, add a `// TODO(data-retention):` comment explaining
+why. These are tracked by `broken-windows` agent. The detector at
+`check-fk-consistency.ts` Query 12 will keep the NULL-expiry trend
+observable until the path adopts.
+
+## Related
+
+- [`privacy-redaction.md`](./privacy-redaction.md) — sibling rule on the
+  read side
+- [`response-redaction.md`](./response-redaction.md) — the underlying
+  generic redaction pattern
+- [`ai-to-db-guard.md`](./ai-to-db-guard.md) — sibling write-side
+  discipline for AI-driven entity creation
+- [`docs/CHAIN-CONTRACTS.md#6a`](../../docs/CHAIN-CONTRACTS.md) — §6a
+  I-PR3 invariant
+- [`docs/lattice-chains.md`](../../docs/lattice-chains.md) — §Privacy /
+  consent matrix row for this rule

--- a/.claude/rules/privacy-redaction.md
+++ b/.claude/rules/privacy-redaction.md
@@ -126,3 +126,4 @@ will pin the deferred work; `broken-windows` agent surfaces the TODO.
   consent matrix row for this rule
 - [`docs/kb/guard-registry.md`](../../docs/kb/guard-registry.md) —
   registry row for `require-tiered-redactor` + `tier-visibility-coverage`
+

--- a/.claude/rules/privacy-redaction.md
+++ b/.claude/rules/privacy-redaction.md
@@ -1,0 +1,128 @@
+# Privacy redaction — codified PII discipline
+
+> Every route that returns PII alongside non-PII fields, while admitting
+> sessions below the field's natural read tier, MUST route through a
+> resource-specific `redact<Resource>ForTier(raw, viewerTier, preset?)`
+> projection. The redactor decides what each tier sees; the route never
+> branches on role.
+>
+> Sibling to [`response-redaction.md`](./response-redaction.md) (the
+> generic tier-redaction pattern) and [`data-retention.md`](./data-retention.md)
+> (regulatory-expiry stamp-at-write). This file is the **privacy-specific
+> framing** of the response-redaction discipline — it points back at the
+> generic pattern and adds the privacy invariants that make the discipline
+> mandatory rather than convention.
+>
+> Catalogued in [`docs/lattice-chains.md`](../../docs/lattice-chains.md)
+> §RBAC / API and §Privacy / consent. Enforces CHAIN-CONTRACTS.md §6a
+> I-PR7. Born of epic #1915 child #1920.
+
+## Rule
+
+The structural pattern lives in
+[`response-redaction.md`](./response-redaction.md). This file enumerates
+the **PII-specific triggers** that make redaction non-negotiable, where
+the generic rule is opt-in via the `@tieredVisibility` JSDoc tag.
+
+When ANY of the following are true for a GET route under
+`apps/admin/app/api/`:
+
+1. Response carries a PII-bearing field (caller name / email / phone,
+   transcript excerpt, evidence text, reasoning string, decay factor,
+   confidence numeric, recommendation rationale, scoredBy attribution),
+   AND
+2. Route admits STUDENT or VIEWER tier sessions (role level 1) — the
+   shape contains operator-only fields that a STUDENT shouldn't see.
+
+Then the route MUST:
+
+- Add the `@tieredVisibility` tag to its JSDoc header (enables the
+  `hf-rbac/require-tiered-redactor` ESLint rule to enforce wiring).
+- Import + invoke `visibilityTierForRole(role)` from `@/lib/rbac/visibility`.
+- Import + invoke a `redact<Resource>ForTier(raw, viewerTier)` function
+  from `@/lib/rbac/policies/<resource>.ts`.
+- Register the route in `TIER_SENSITIVE_ROUTES` in
+  `apps/admin/tests/api/tier-visibility-coverage.test.ts`.
+
+## Why this is privacy, not just RBAC
+
+A STUDENT session reading another learner's `confidence` numeric or
+`reasoning` rationale is a confirmed **leak class** (5 routes pinned by
+the tier-visibility-coverage exempt list ratchet:
+`/api/callers/[id]/{skills-evidence, lo-mastery, uplift, memories, insights}`).
+These aren't just permission gaps — they expose operator analysis,
+behavioural scoring, and learner-evidence-source attribution that the
+STUDENT-tier consumer was never authorised to see. That makes redaction
+a Lattice-level privacy invariant, not an RBAC nice-to-have.
+
+CHAIN-CONTRACTS.md §6a I-PR7 (epic #1915) catalogues this as a privacy
+invariant. The `tier-visibility-coverage.test.ts` ratchet is the
+load-bearing Coverage-pillar gate that prevents further drift.
+
+## Pattern: route → resolver → projection → response
+
+```typescript
+import { visibilityTierForRole } from "@/lib/rbac/visibility";
+import { redactSkillsEvidenceForTier } from "@/lib/rbac/policies/skills-evidence";
+
+/**
+ * @api GET /api/callers/[callerId]/skills-evidence
+ * @scope callers:read
+ * @tieredVisibility — required: skills-evidence carries reasoning + confidence
+ */
+export async function GET(req, { params }) {
+  const auth = await requireAuth("VIEWER");
+  if (isAuthError(auth)) return auth.error;
+  // ... scope check ...
+
+  const viewerTier = visibilityTierForRole(auth.session.user.role);
+  const raw = await computeRawSkillsEvidence(callerId);
+  return NextResponse.json(redactSkillsEvidenceForTier(raw, viewerTier));
+}
+```
+
+The redactor signature today is `(raw, tier)`. When `#1924` ships
+`PrivacyPolicyPreset` and `#1925` ships the `privacyPresetId` cascade
+scalar, the signature extends to `(raw, tier, preset)` per `#1923`
+(deferred). HIPAA preset strips more than Basic on the same route.
+
+## Existing enforcement
+
+| Location | Mechanism | What it prevents |
+|---|---|---|
+| `eslint-rules/require-tiered-redactor.mjs` | Edit-time, opt-in via `@tieredVisibility` JSDoc tag | Routes that opt in but forget the import or invocation |
+| `tests/api/tier-visibility-coverage.test.ts` | Coverage-pillar ratchet (currently 5 exempt) | New routes shipping without redactor when the existing 5 leaks haven't yet been wired (#1922) |
+| `lib/rbac/policies/adaptations.ts::redactAdaptationsForTier` (PR #1710) | Canonical reference implementation | Drift in the pattern — copy this file's shape when wiring new resources |
+| `lib/rbac/visibility.ts::visibilityTierForRole` | Tier resolver | Role-to-tier mapping changes in one place, not per-route |
+| CHAIN-CONTRACTS.md §6a I-PR7 (PR #1938) | Cross-stage privacy invariant | Discoverability — the contract names the structural enforcer |
+
+## When this rule does NOT apply
+
+- Routes that return uniformly safe fields (status, category, slug
+  identifiers, public catalogue data) — nothing to redact.
+- Routes admitting only OPERATOR+ — no tier confusion possible.
+- Routes whose response is uniformly operator-only AND admitted only to
+  OPERATOR+ — no learner consumer.
+- Section-level rather than field-level differences — consider separate
+  routes if the redacted shape barely overlaps the full shape.
+
+## Escalation
+
+If you're writing a new route that has tier-sensitive fields and can't
+add a redactor in the same PR, add a `// TODO(privacy-redaction):`
+comment describing what the lower-tier shape should be AND register the
+route in `TIER_VISIBILITY_EXEMPT` with a one-line reason. The ratchet
+will pin the deferred work; `broken-windows` agent surfaces the TODO.
+
+## Related
+
+- [`response-redaction.md`](./response-redaction.md) — the generic
+  tier-redaction pattern this rule references
+- [`data-retention.md`](./data-retention.md) — sibling privacy rule on
+  the write/retention side
+- [`docs/CHAIN-CONTRACTS.md#6a`](../../docs/CHAIN-CONTRACTS.md) — §6a
+  I-PR7 invariant
+- [`docs/lattice-chains.md`](../../docs/lattice-chains.md) — §Privacy /
+  consent matrix row for this rule
+- [`docs/kb/guard-registry.md`](../../docs/kb/guard-registry.md) —
+  registry row for `require-tiered-redactor` + `tier-visibility-coverage`

--- a/docs/lattice-chains.md
+++ b/docs/lattice-chains.md
@@ -194,6 +194,8 @@ Three structural patterns, in order of preference:
 | `tier-visibility-coverage.md` | `tests/api/tier-visibility-coverage.test.ts` (#1855) | ✅ PROTECTED |
 | `parameter-coverage.md` | `tests/lib/measurement/parameter-coverage.test.ts` (#1856) | ✅ PROTECTED |
 | `fixture-type-coverage.md` | `tests/lib/wizard/fixture-type-coverage.test.ts` (#1910) | ✅ PROTECTED |
+| `privacy-redaction.md` | ESLint `require-tiered-redactor` + `tier-visibility-coverage` (#1855) — same enforcer as `response-redaction.md`; this file is the privacy-specific framing | ✅ PROTECTED (5 leak ratchet, #1922) |
+| `data-retention.md` | `lib/privacy/stamp-regulatory-expiry.ts` chokepoint (#1917) + retention cron + `scripts/check-fk-consistency.ts` Query 12 | ✅ PROTECTED (3 voice paths adopted; 8 lower-priority writers adopt as touched) |
 | `vm-migration-lock.md` | `scripts/vm-migrate.sh` wrapper + session-start check | ✅ PROTECTED |
 | `pipeline-and-prompt.md` | `qmd search` mandate + docs cross-ref | ⚠️ CONVENTION-ONLY |
 | `database-patterns.md` | Author discipline | ⚠️ CONVENTION-ONLY |

--- a/docs/lattice-chains.md
+++ b/docs/lattice-chains.md
@@ -195,7 +195,7 @@ Three structural patterns, in order of preference:
 | `parameter-coverage.md` | `tests/lib/measurement/parameter-coverage.test.ts` (#1856) | ✅ PROTECTED |
 | `fixture-type-coverage.md` | `tests/lib/wizard/fixture-type-coverage.test.ts` (#1910) | ✅ PROTECTED |
 | `privacy-redaction.md` | ESLint `require-tiered-redactor` + `tier-visibility-coverage` (#1855) — same enforcer as `response-redaction.md`; this file is the privacy-specific framing | ✅ PROTECTED (5 leak ratchet, #1922) |
-| `data-retention.md` | `lib/privacy/stamp-regulatory-expiry.ts` chokepoint (#1917) + retention cron + `scripts/check-fk-consistency.ts` Query 12 | ✅ PROTECTED (3 voice paths adopted; 8 lower-priority writers adopt as touched) |
+| `data-retention.md` | `lib/privacy/stamp-regulatory-expiry.ts` chokepoint (#1917) + retention cron + `apps/admin/scripts/check-fk-consistency.ts` Query 12 | ✅ PROTECTED (3 voice paths adopted; 8 lower-priority writers adopt as touched) |
 | `vm-migration-lock.md` | `scripts/vm-migrate.sh` wrapper + session-start check | ✅ PROTECTED |
 | `pipeline-and-prompt.md` | `qmd search` mandate + docs cross-ref | ⚠️ CONVENTION-ONLY |
 | `database-patterns.md` | Author discipline | ⚠️ CONVENTION-ONLY |


### PR DESCRIPTION
## Summary

Codifies the two patterns Sprint 1 shipped so the lattice-survey discipline auto-surfaces privacy obligations the same way `response-redaction.md` and `ai-to-db-guard.md` surface theirs.

- **`.claude/rules/privacy-redaction.md`** — privacy-specific framing of the response-redaction pattern. Points at `@tieredVisibility` + `redact<X>ForTier` as the structural enforcers of CHAIN-CONTRACTS.md §6a I-PR7.
- **`.claude/rules/data-retention.md`** — write-side regulatory-expiry stamp-at-write discipline. Points at `lib/privacy/stamp-regulatory-expiry.ts` (shipped in PR #1939) as the chokepoint. Documents NULL-backfill rationale + naming discipline against silent conflation with `CallerMemory.expiresAt`.
- **`docs/lattice-chains.md`** — 2 inventory rows added in §Convention rules → enforcement so both new rules classify as PROTECTED.

## Why two files, not three

The original epic draft proposed a third `consent-versioning.md` file. NOT shipped here — it would cite a chokepoint that won't exist until #1927 (S7) lands. **Do not ship rule files that cite pending enforcers** — they rot fast and mislead future readers.

## File-order discipline

S10 ships LAST in Sprint 1 (after #1916, #1917, #1918) so the rule files cite real enforcers, not pending stories. PR sequence:

1. PR #1938 — §6a I-PR1..I-PR8 contracts
2. PR #1939 — `lib/privacy/stamp-regulatory-expiry.ts` chokepoint + adopt at 3 voice paths + retention cron + detector
3. PR #1941 — voice-call-recording disclosure copy + bootstrap delivery
4. **PR (this)** — rule files cite all of the above

## Test plan

- [x] `tests/lib/lattice-self-maintenance.test.ts` orphan-count regex inspected — adding rule files **with** inventory rows keeps the orphan count unchanged (ratchet at 17 stays valid)
- [x] Both new files cite ONLY enforcers that exist on disk today (response-redaction.md, ai-to-db-guard.md, eslint-rules/require-tiered-redactor.mjs, tests/api/tier-visibility-coverage.test.ts, lib/privacy/stamp-regulatory-expiry.ts from PR #1939, retention cleanup route, check-fk-consistency.ts Query 12)
- [x] Cross-references to CHAIN-CONTRACTS.md §6a I-PR3/I-PR7 invariants (shipped in PR #1938)
- [ ] CI green (lattice-self-maintenance test passes; no new orphans)

## Verified by

- `find .claude/rules/ -name "privacy*" -o -name "data-retention*" -o -name "consent*"` pre-edit → empty (confirms greenfield for S10)
- `tests/lib/lattice-self-maintenance.test.ts:283-294` (`.claude/rules/*.md` orphan ratchet) inspected — adding files with inventory rows is net-zero
- Both rule files validated against `response-redaction.md` + `ai-to-db-guard.md` shape: frontmatter blockquote → Rule → When applies → Pattern → Existing enforcement → When NOT to apply → Escalation → Related
- All enforcer citations verified on disk (`eslint-rules/require-tiered-redactor.mjs`, `tests/api/tier-visibility-coverage.test.ts`, `lib/privacy/stamp-regulatory-expiry.ts` from PR #1939, `app/api/admin/retention/cleanup/route.ts`, `scripts/check-fk-consistency.ts`)

Closes #1920
Refs #1915 (epic), #1916 (S1 → PR #1938), #1917 (S5a → PR #1939), #1918 (S8a → PR #1941)
Pairs with: #1919 (ST Tallyseal tx)

Deploy command: `/vm-cp`