### PR TITLE
feat(privacy): Tallyseal tx-discipline forward-compat scaffold (ST, #1919)

### DIFF
--- a/apps/admin/app/api/intake/bootstrap/route.ts
+++ b/apps/admin/app/api/intake/bootstrap/route.ts
@@ -13,10 +13,8 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { resolveTenantCtx } from "@/lib/intake/hf-adapter/auth";
 import { loadDisclosureCopy } from "@/lib/intake/hf-adapter/disclosure-content";
-import {
-  getDisclosureStore,
-  deriveDisclosureId,
-} from "@/lib/intake/hf-adapter/disclosure-store";
+import { deriveDisclosureId } from "@/lib/intake/hf-adapter/disclosure-store";
+import { recordDisclosure } from "@/lib/intake/hf-adapter/record-disclosure-with-tx";
 import {
   openSession,
   appendEvent,
@@ -119,33 +117,25 @@ export async function POST(req: NextRequest) {
     // Q-CR9 write-path: populate tallyseal_disclosure alongside the
     // in-memory event. Best-effort — failure logs but doesn't block
     // intake (Q2 founder guidance; Q-BRIDGE-RECORDER-DURABILITY).
-    // Note: passing Date (not ISO string) because the underlying
-    // SQL column is `timestamptz` — the SDK's `Timestamp = Brand<string>`
-    // type contract is structurally satisfied by Date at runtime via
-    // Prisma's coercion; the cast bypasses the type-only mismatch.
-    try {
-      const store = await getDisclosureStore();
-      await store.record({
-        id: deriveDisclosureId(session.intentId, requirementId),
-        tenantId: session.tenant.id,
-        subject: subjectId,
-        requirementId,
-        content: copy.content,
-        contentHash: copy.contentHash,
-        deliveredAt,
-        // 'in-app' per the SDK CHECK constraint
-        // (delivery_method IN 'in-app','email','sms','mail','api').
-        // HF delivers via TallysealBanner — closest semantic match.
-        deliveryMethod: "in-app",
-        acknowledgedAt: null,
-        retractedAt: null,
-      } as never);
-    } catch (err) {
-      console.error(
-        "[intake/bootstrap] disclosureStore.record failed (continuing):",
-        err instanceof Error ? err.message : err,
-      );
-    }
+    //
+    // #1919 — routed through `recordDisclosure(...)` wrapper so the
+    // future Tallyseal Drop-1 tx-discipline upgrade is a one-line
+    // change in the wrapper rather than a refactor here. The wrapper
+    // accepts `tx?` for forward-compat (IGNORED today, used post-Drop-1).
+    // See `lib/intake/hf-adapter/record-disclosure-with-tx.ts` header.
+    await recordDisclosure({
+      id: deriveDisclosureId(session.intentId, requirementId),
+      tenantId: session.tenant.id,
+      subject: subjectId,
+      requirementId,
+      content: copy.content,
+      contentHash: copy.contentHash,
+      deliveredAt,
+      // 'in-app' per the SDK CHECK constraint
+      // (delivery_method IN 'in-app','email','sms','mail','api').
+      // HF delivers via TallysealBanner — closest semantic match.
+      deliveryMethod: "in-app",
+    });
   }
 
   // Resolve classroomToken (Option B routing): look up the cohort

--- a/apps/admin/app/api/intake/disclosure-acknowledge/route.ts
+++ b/apps/admin/app/api/intake/disclosure-acknowledge/route.ts
@@ -18,10 +18,8 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import {
-  getDisclosureStore,
-  deriveDisclosureId,
-} from "@/lib/intake/hf-adapter/disclosure-store";
+import { deriveDisclosureId } from "@/lib/intake/hf-adapter/disclosure-store";
+import { markDisclosureAcknowledged } from "@/lib/intake/hf-adapter/record-disclosure-with-tx";
 import {
   appendEvent,
   getSession,
@@ -115,19 +113,16 @@ export async function POST(req: NextRequest) {
   // Q-CR9 write-path: stamp tallyseal_disclosure.acknowledged_at
   // alongside the in-memory event. Best-effort — failure logs but
   // doesn't block the learner (Q2 founder guidance).
-  try {
-    const store = await getDisclosureStore();
-    await store.markAcknowledged(
-      session.tenant.id as never,
-      disclosureId as never,
-      acknowledgedAt as never,
-    );
-  } catch (err) {
-    console.error(
-      "[intake/disclosure-acknowledge] disclosureStore.markAcknowledged failed (continuing):",
-      err instanceof Error ? err.message : err,
-    );
-  }
+  //
+  // #1919 — routed through `markDisclosureAcknowledged(...)` wrapper
+  // so the future Tallyseal Drop-1 tx-discipline upgrade is a one-line
+  // change in the wrapper rather than a refactor here. The wrapper
+  // accepts `tx?` for forward-compat (IGNORED today, used post-Drop-1).
+  await markDisclosureAcknowledged({
+    tenantId: session.tenant.id,
+    disclosureId,
+    acknowledgedAt,
+  });
 
   return NextResponse.json({ ok: true });
 }

--- a/apps/admin/lib/intake/hf-adapter/record-disclosure-with-tx.ts
+++ b/apps/admin/lib/intake/hf-adapter/record-disclosure-with-tx.ts
@@ -140,3 +140,4 @@ export async function markDisclosureAcknowledged(
     );
   }
 }
+

--- a/apps/admin/lib/intake/hf-adapter/record-disclosure-with-tx.ts
+++ b/apps/admin/lib/intake/hf-adapter/record-disclosure-with-tx.ts
@@ -1,0 +1,142 @@
+/**
+ * record-disclosure-with-tx — forward-compat wrapper for Tallyseal Drop 1.
+ *
+ * Enforces CHAIN-CONTRACTS.md §6a I-PR1 (epic #1915 child #1919) —
+ * intake-path disclosure writes become atomic with intake-state mutation
+ * once both Tallyseal Drop 1 (Ask #2: `opts?: { tx?: PrismaTxLike }` on
+ * `*Store.record()` / `markAcknowledged()`) AND Drop 2 / Ask #4
+ * (`PrismaEventStore.writeEvent` adoption guidance) have landed.
+ *
+ * Today (pre-Drop-1):
+ *   - `record(...)` passes through to `store.record(...)` best-effort
+ *   - `markAcknowledged(...)` passes through to `store.markAcknowledged(...)` best-effort
+ *   - `tx` argument is accepted for type-shape forward-compat but IGNORED
+ *     until Tallyseal-side accepts it
+ *
+ * Post-Drop-1 (target 2026-06-25, drop-dead 2026-06-30):
+ *   - Replace `store.record(payload)` with `store.record(payload, { tx })`
+ *   - Replace `store.markAcknowledged(...)` with the tx-accepting variant
+ *   - Atomicity is now enforced when callers pass `tx`
+ *
+ * Post-Drop-2 + Phase 1.5 (Ask #4 (a) docs land — late June / early July):
+ *   - Bootstrap route wraps its intake-state mutation + this helper's
+ *     call in a single `prisma.$transaction`, passing the tx to both
+ *
+ * Until then the I-PR1 invariant is documented as PENDING in
+ * CHAIN-CONTRACTS.md §6a (PR #1938). The wrapper makes the future swap
+ * a one-line change at the call site rather than a refactor.
+ *
+ * The wrapper deliberately preserves the existing best-effort semantics
+ * — see `disclosure-store.ts` JSDoc + Q-BRIDGE-RECORDER-DURABILITY for
+ * the "Postgres hiccup must not block a learner mid-intake" rationale.
+ *
+ * @see github.com/.../issues/1919 (this scaffold)
+ * @see Tallyseal TKT-HF-DISCLOSURE-STORE-TX (Drop 1 ticket)
+ * @see Tallyseal TKT-HF-PHASE-1-5-PRISMA-EVENT-STORE (Drop 2 ticket)
+ */
+
+import type { PrismaClient } from "@prisma/client";
+import { getDisclosureStore } from "./disclosure-store";
+
+/**
+ * Prisma transaction client shape — matches the type yielded inside
+ * `prisma.$transaction(async (tx) => ...)`. Kept structural rather
+ * than importing the full `Prisma.TransactionClient` because the
+ * exact type-name varies across Prisma versions and we only need
+ * "something Prisma-tx-shaped" for forward-compat.
+ */
+export type PrismaTxLike = Omit<
+  PrismaClient,
+  "$connect" | "$disconnect" | "$on" | "$transaction" | "$use" | "$extends"
+>;
+
+export interface RecordDisclosureArgs {
+  /** Synthetic `DisclosureId` from `deriveDisclosureId(intentId, requirementId)`. */
+  id: string;
+  /** Tallyseal tenant identifier. */
+  tenantId: string;
+  /** Data subject identifier (`intake-subject-{chatSessionId}`). */
+  subject: string;
+  /** Regulatory citation, e.g. `gdpr.art13.privacy-notice`. */
+  requirementId: string;
+  /** Resolved disclosure content shape from `loadDisclosureCopy`. */
+  content: unknown;
+  /** SHA-256 content hash of the canonical-JSON disclosure body. */
+  contentHash: string;
+  /** Timestamp the notice was shown to the subject. */
+  deliveredAt: Date;
+  /** Delivery method enum: in-app / email / sms / mail / api. */
+  deliveryMethod: "in-app" | "email" | "sms" | "mail" | "api";
+  /** Forward-compat: Prisma transaction client. IGNORED pre-Drop-1. */
+  tx?: PrismaTxLike;
+}
+
+export interface MarkAcknowledgedArgs {
+  tenantId: string;
+  disclosureId: string;
+  acknowledgedAt: Date;
+  /** Forward-compat: Prisma transaction client. IGNORED pre-Drop-1. */
+  tx?: PrismaTxLike;
+}
+
+/**
+ * Record a disclosure delivery to `tallyseal_disclosure`.
+ *
+ * Best-effort by design: failure logs to console but does NOT throw.
+ * The intake-path callers ARE expected to catch any rethrow if a future
+ * Drop-1-aware caller chooses to escalate failures.
+ *
+ * The `tx` argument is accepted for forward-compat and IGNORED today.
+ * When Tallyseal Drop 1 ships, change the inner call to pass `, { tx }`
+ * — see file header.
+ */
+export async function recordDisclosure(args: RecordDisclosureArgs): Promise<void> {
+  try {
+    const store = await getDisclosureStore();
+    // FORWARD-COMPAT MARKER: when Tallyseal Drop 1 lands, change to
+    //   await store.record({ ... } as never, args.tx ? { tx: args.tx } : undefined);
+    await store.record({
+      id: args.id,
+      tenantId: args.tenantId,
+      subject: args.subject,
+      requirementId: args.requirementId,
+      content: args.content,
+      contentHash: args.contentHash,
+      deliveredAt: args.deliveredAt,
+      deliveryMethod: args.deliveryMethod,
+      acknowledgedAt: null,
+      retractedAt: null,
+    } as never);
+  } catch (err) {
+    console.error(
+      "[intake] recordDisclosure best-effort write failed (continuing):",
+      err instanceof Error ? err.message : err,
+    );
+  }
+}
+
+/**
+ * Stamp `tallyseal_disclosure.acknowledged_at` for the given disclosure.
+ *
+ * Best-effort by design (same rationale as `recordDisclosure`). The
+ * `tx` argument is accepted for forward-compat and IGNORED today.
+ */
+export async function markDisclosureAcknowledged(
+  args: MarkAcknowledgedArgs,
+): Promise<void> {
+  try {
+    const store = await getDisclosureStore();
+    // FORWARD-COMPAT MARKER: when Tallyseal Drop 1 lands, change to
+    //   await store.markAcknowledged(args.tenantId, args.disclosureId, args.acknowledgedAt, args.tx ? { tx: args.tx } : undefined);
+    await store.markAcknowledged(
+      args.tenantId as never,
+      args.disclosureId as never,
+      args.acknowledgedAt as never,
+    );
+  } catch (err) {
+    console.error(
+      "[intake] markDisclosureAcknowledged best-effort write failed (continuing):",
+      err instanceof Error ? err.message : err,
+    );
+  }
+}

--- a/apps/admin/lib/intake/hf-adapter/record-disclosure-with-tx.ts
+++ b/apps/admin/lib/intake/hf-adapter/record-disclosure-with-tx.ts
@@ -141,3 +141,5 @@ export async function markDisclosureAcknowledged(
   }
 }
 
+
+// retry CI

--- a/apps/admin/tests/intake/record-disclosure-with-tx.test.ts
+++ b/apps/admin/tests/intake/record-disclosure-with-tx.test.ts
@@ -1,0 +1,165 @@
+/**
+ * #1919 — pin the forward-compat shape of `recordDisclosure` /
+ * `markDisclosureAcknowledged` so the Tallyseal Drop 1 swap is a
+ * one-line change rather than a refactor.
+ *
+ * What we pin today:
+ *   - The wrapper functions exist + are exported
+ *   - They accept the documented arg shape (compile-time type test)
+ *   - They accept an optional `tx?` argument (forward-compat)
+ *   - Best-effort semantics preserved — internal failures don't throw
+ *
+ * What we DO NOT pin today:
+ *   - Whether `tx` is actually plumbed through to Tallyseal — that
+ *     requires Drop 1 to ship `opts?: { tx?: PrismaTxLike }` on the
+ *     SDK side. Pre-Drop-1 the wrapper accepts + ignores `tx`. A
+ *     post-Drop-1 follow-on PR will land the active plumbing + a
+ *     vitest that asserts the tx is honoured.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const recordMock = vi.fn().mockResolvedValue(undefined);
+const markAcknowledgedMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/lib/intake/hf-adapter/disclosure-store", () => ({
+  getDisclosureStore: vi.fn().mockResolvedValue({
+    record: recordMock,
+    markAcknowledged: markAcknowledgedMock,
+  }),
+  deriveDisclosureId: (intentId: string, requirementId: string) =>
+    `disc_${intentId}_${requirementId}`,
+}));
+
+import {
+  recordDisclosure,
+  markDisclosureAcknowledged,
+  type PrismaTxLike,
+} from "@/lib/intake/hf-adapter/record-disclosure-with-tx";
+
+describe("recordDisclosure (forward-compat wrapper, #1919)", () => {
+  beforeEach(() => {
+    recordMock.mockClear();
+    markAcknowledgedMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls the underlying store.record with the documented shape", async () => {
+    const deliveredAt = new Date("2026-06-18T12:00:00Z");
+    await recordDisclosure({
+      id: "disc_int_gdpr.art13.privacy-notice",
+      tenantId: "tenant_x",
+      subject: "intake-subject-abc",
+      requirementId: "gdpr.art13.privacy-notice",
+      content: { body: "redacted" },
+      contentHash: "deadbeef",
+      deliveredAt,
+      deliveryMethod: "in-app",
+    });
+    expect(recordMock).toHaveBeenCalledTimes(1);
+    const arg = recordMock.mock.calls[0][0];
+    expect(arg.id).toBe("disc_int_gdpr.art13.privacy-notice");
+    expect(arg.tenantId).toBe("tenant_x");
+    expect(arg.requirementId).toBe("gdpr.art13.privacy-notice");
+    expect(arg.deliveryMethod).toBe("in-app");
+    expect(arg.acknowledgedAt).toBeNull();
+    expect(arg.retractedAt).toBeNull();
+    expect(arg.deliveredAt).toBe(deliveredAt);
+  });
+
+  it("swallows store.record failures (best-effort)", async () => {
+    recordMock.mockRejectedValueOnce(new Error("postgres unreachable"));
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      recordDisclosure({
+        id: "disc_x_y",
+        tenantId: "t",
+        subject: "s",
+        requirementId: "r",
+        content: {},
+        contentHash: "h",
+        deliveredAt: new Date(),
+        deliveryMethod: "in-app",
+      }),
+    ).resolves.toBeUndefined();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[intake] recordDisclosure"),
+      expect.any(String),
+    );
+  });
+
+  it("accepts but does not propagate `tx` (pre-Drop-1 behaviour)", async () => {
+    const fakeTx = {} as PrismaTxLike;
+    await recordDisclosure({
+      id: "id",
+      tenantId: "t",
+      subject: "s",
+      requirementId: "r",
+      content: {},
+      contentHash: "h",
+      deliveredAt: new Date(),
+      deliveryMethod: "in-app",
+      tx: fakeTx,
+    });
+    expect(recordMock).toHaveBeenCalledTimes(1);
+    // Pre-Drop-1: store.record is called with exactly ONE argument
+    // (the payload). When Drop 1 lands, the wrapper passes a second
+    // `{ tx }` argument and this assertion flips.
+    expect(recordMock.mock.calls[0].length).toBe(1);
+  });
+});
+
+describe("markDisclosureAcknowledged (forward-compat wrapper, #1919)", () => {
+  beforeEach(() => {
+    recordMock.mockClear();
+    markAcknowledgedMock.mockClear();
+  });
+
+  it("calls the underlying store.markAcknowledged", async () => {
+    const acknowledgedAt = new Date("2026-06-18T13:00:00Z");
+    await markDisclosureAcknowledged({
+      tenantId: "tenant_x",
+      disclosureId: "disc_int_gdpr.art13.privacy-notice",
+      acknowledgedAt,
+    });
+    expect(markAcknowledgedMock).toHaveBeenCalledTimes(1);
+    expect(markAcknowledgedMock).toHaveBeenCalledWith(
+      "tenant_x",
+      "disc_int_gdpr.art13.privacy-notice",
+      acknowledgedAt,
+    );
+  });
+
+  it("swallows markAcknowledged failures (best-effort)", async () => {
+    markAcknowledgedMock.mockRejectedValueOnce(new Error("db error"));
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      markDisclosureAcknowledged({
+        tenantId: "t",
+        disclosureId: "d",
+        acknowledgedAt: new Date(),
+      }),
+    ).resolves.toBeUndefined();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[intake] markDisclosureAcknowledged"),
+      expect.any(String),
+    );
+  });
+
+  it("accepts but does not propagate `tx` (pre-Drop-1 behaviour)", async () => {
+    const fakeTx = {} as PrismaTxLike;
+    await markDisclosureAcknowledged({
+      tenantId: "t",
+      disclosureId: "d",
+      acknowledgedAt: new Date(),
+      tx: fakeTx,
+    });
+    expect(markAcknowledgedMock).toHaveBeenCalledTimes(1);
+    // Pre-Drop-1: 3 positional args (tenantId, disclosureId, acknowledgedAt).
+    // Post-Drop-1: 4th `{ tx }` argument added.
+    expect(markAcknowledgedMock.mock.calls[0].length).toBe(3);
+  });
+});

--- a/apps/admin/tests/intake/record-disclosure-with-tx.test.ts
+++ b/apps/admin/tests/intake/record-disclosure-with-tx.test.ts
@@ -19,8 +19,14 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-const recordMock = vi.fn().mockResolvedValue(undefined);
-const markAcknowledgedMock = vi.fn().mockResolvedValue(undefined);
+// vi.mock factories are hoisted above all imports — top-level `const`
+// declarations aren't yet in TDZ-bound scope when the factory runs.
+// Use vi.hoisted() to declare the mock fns BEFORE the factory references
+// them. Standard vitest pattern.
+const { recordMock, markAcknowledgedMock } = vi.hoisted(() => ({
+  recordMock: vi.fn().mockResolvedValue(undefined),
+  markAcknowledgedMock: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock("@/lib/intake/hf-adapter/disclosure-store", () => ({
   getDisclosureStore: vi.fn().mockResolvedValue({

--- a/apps/admin/tests/lib/voice/route-handlers-1345.test.ts
+++ b/apps/admin/tests/lib/voice/route-handlers-1345.test.ts
@@ -42,9 +42,10 @@ interface MockCallRow {
   createdAt: Date;
   playbookId: string | null;
   usedPromptId: string | null;
-  // #1917 — regulatory expiry column; nullable, populated by
-  // stampRegulatoryExpiry() at create-time via the fresh-arrival path.
-  regulatoryExpiresAt: Date | null;
+  // #1917 — regulatory expiry column; nullable + optional in this mock
+  // because some fixtures pre-date S5a and don't populate it. The create
+  // mock at line 113 defaults to null when omitted.
+  regulatoryExpiresAt?: Date | null;
 }
 
 const stores = vi.hoisted(() => ({

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-18T13:20:59.597Z",
+  "generatedAt": "2026-06-18T13:34:59.392Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1843,
-  "edgeCount": 4336,
+  "fileCount": 1844,
+  "edgeCount": 4339,
   "skippedEdges": 1,
   "edges": [
     {
@@ -4753,6 +4753,10 @@
     },
     {
       "from": "app/api/intake/bootstrap/route.ts",
+      "to": "lib/intake/hf-adapter/record-disclosure-with-tx.ts"
+    },
+    {
+      "from": "app/api/intake/bootstrap/route.ts",
       "to": "lib/intake/intake-session-cookie.ts"
     },
     {
@@ -4794,6 +4798,10 @@
     {
       "from": "app/api/intake/disclosure-acknowledge/route.ts",
       "to": "lib/intake/hf-adapter/disclosure-store.ts"
+    },
+    {
+      "from": "app/api/intake/disclosure-acknowledge/route.ts",
+      "to": "lib/intake/hf-adapter/record-disclosure-with-tx.ts"
     },
     {
       "from": "app/api/intake/disclosure-acknowledge/route.ts",
@@ -13760,6 +13768,10 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "lib/intake/hf-adapter/record-disclosure-with-tx.ts",
+      "to": "lib/intake/hf-adapter/disclosure-store.ts"
+    },
+    {
       "from": "lib/intake/prisma-event-store.ts",
       "to": "lib/intake/tallyseal/index.ts"
     },
@@ -18976,7 +18988,7 @@
     {
       "path": "app/api/intake/bootstrap/route.ts",
       "inDegree": 0,
-      "outDegree": 7
+      "outDegree": 8
     },
     {
       "path": "app/api/intake/chat/route.ts",
@@ -18986,7 +18998,7 @@
     {
       "path": "app/api/intake/disclosure-acknowledge/route.ts",
       "inDegree": 0,
-      "outDegree": 4
+      "outDegree": 5
     },
     {
       "path": "app/api/intake/disclosure-signal/route.ts",
@@ -24210,7 +24222,7 @@
     },
     {
       "path": "lib/intake/hf-adapter/disclosure-store.ts",
-      "inDegree": 3,
+      "inDegree": 4,
       "outDegree": 2
     },
     {
@@ -24222,6 +24234,11 @@
       "path": "lib/intake/hf-adapter/projection.ts",
       "inDegree": 1,
       "outDegree": 0
+    },
+    {
+      "path": "lib/intake/hf-adapter/record-disclosure-with-tx.ts",
+      "inDegree": 2,
+      "outDegree": 1
     },
     {
       "path": "lib/intake/intake-session-cookie.ts",

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-18T13:21:00.016Z",
+  "generatedAt": "2026-06-18T13:34:59.760Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-18T13:20:58.048Z",
+  "generatedAt": "2026-06-18T13:34:58.312Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-18T13:21:00.514Z",
+  "generatedAt": "2026-06-18T13:35:00.123Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,6 +1,6 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-18T13:20:58.714Z",
+  "generatedAt": "2026-06-18T13:34:58.731Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {


### PR DESCRIPTION
## Summary

Prepares CHAIN-CONTRACTS.md §6a I-PR1 (shipped in PR #1938) for the atomicity flip when Tallyseal Drop 1 (Ask #2) lands. Target 2026-06-25, drop-dead 2026-06-30 — before HF Sprint 1 close 2026-07-02.

- **New scaffold:** `lib/intake/hf-adapter/record-disclosure-with-tx.ts` with `recordDisclosure({...args, tx?})` and `markDisclosureAcknowledged({...args, tx?})` wrappers. `tx?` is accepted but ignored today; Drop-1 swap is a 1-line change inside two FORWARD-COMPAT MARKER comments.
- **Routes refactored:** bootstrap + disclosure-acknowledge now call the wrappers. Behaviour is byte-identical today (best-effort try/catch preserved inside the wrapper).
- **6 vitests:** wrapper shape + best-effort + tx-acceptance + arg-count assertions that will fail (intentionally) when Drop 1 ships — a canary for the swap.

## Why a scaffold, not the actual atomicity flip

Atomic disclosure write requires TWO upstreams:

1. **Tallyseal Drop 1** — ships `opts?: { tx }` on the store methods. Target 2026-06-25.
2. **Phase 1.5** (Tallyseal Drop 2 / Ask #4 (a)) — brings the intake event log into Prisma so the `prisma.$transaction` callback covers BOTH writes.

Today the intake event log is in-memory (`session-store`). Without Phase 1.5 we can't roll it back if the Prisma disclosure write fails — wrapping in `$transaction` alone wouldn't yield true atomicity. The scaffold makes the future swap structural (1-line change in wrapper + the bootstrap route calls a `tx`-aware variant) rather than a 2-file refactor.

Per CHAIN-CONTRACTS.md §6a I-PR1 the invariant remains **PENDING** until both upstreams land. The wrapper makes the enforcer ready to flip.

## Tallyseal coordination state

| Ask | Status | Drop |
|---|---|---|
| #1 `@@ignore` Prisma typegen | LOCKED → queued | Drop 2 |
| **#2 `opts?: { tx }` on store methods** | **LOCKED → queued-priority** | **Drop 1 (target 2026-06-25)** |
| #3 `bundleVersion` API | LOCKED → queued | Drop 2 |
| #4 (a) PrismaEventStore docs | LOCKED → gogogo, ~2h | Drop 2 |
| #5 admin bridge finish | LOCKED → queued, explicit DI for pdfRenderer | Drop 2 |
| #6 signal taxonomy | DECLINED → use ConsentGranted/ConsentRevoked instead | n/a |

Fallback documented: if Drop 1 slips past 2026-06-30, the local tx-wrapper in `lib/intake/hf-adapter/` is **already scaffolded by THIS PR**. Tallyseal recorded `Q-DISCLOSURE-STORE-TX-LOCAL-ADAPTER-DEBT` on their side.

## Carve-out

`disclosure-signal/route.ts` is NOT routed through the wrapper. Signal writes are explicitly OUTSIDE the disclosure-write atomicity contract per Q-CR9 SIGNAL-not-gate — they are observational evidence, not gates. Keeping them direct is intentional.

## Test plan

- [x] `tests/intake/record-disclosure-with-tx.test.ts` — 6 vitests authored:
  - `calls the underlying store.record with the documented shape`
  - `swallows store.record failures (best-effort)`
  - `accepts but does not propagate ` + "`" + `tx` + "`" + ` (pre-Drop-1 behaviour)`
  - `calls the underlying store.markAcknowledged`
  - `swallows markAcknowledged failures (best-effort)`
  - `accepts but does not propagate ` + "`" + `tx` + "`" + ` (pre-Drop-1 behaviour)`
- [x] Behaviour-preserving refactor — `bootstrap/route.ts:108-130` and `disclosure-acknowledge/route.ts:115-126` call counts and shapes unchanged
- [x] Signal route at `app/api/intake/disclosure-signal/route.ts` untouched (Q-CR9 SIGNAL-not-gate carve-out)
- [x] pre-push ESLint passes
- [ ] CI green
- [ ] Verify on hf-dev: intake-v2 still emits 3 disclosure rows (S8a + this); ack route still stamps acknowledged_at

## Verified by

- `grep -n "store.record\|store.markAcknowledged" apps/admin/app apps/admin/lib` — pre-PR returned 2 inline call sites in `bootstrap/route.ts:117` + `disclosure-acknowledge/route.ts:120`. Post-PR returns 0 inline calls — both intake-path call sites now route through `lib/intake/hf-adapter/record-disclosure-with-tx.ts:recordDisclosure` and `markDisclosureAcknowledged`. The only remaining direct calls are inside the wrapper itself.
- `app/api/intake/disclosure-signal/route.ts` left untouched — verified by `git diff origin/main -- 'app/api/intake/*'` returning only `bootstrap/route.ts` + `disclosure-acknowledge/route.ts` modifications
- `apps/admin/lib/intake/hf-adapter/record-disclosure-with-tx.ts:1-50` file header documents the Drop 1 / Drop 2 / Phase 1.5 swap plan inline (FORWARD-COMPAT MARKER comments at lines 92 + 119 mark the 1-line change locations)
- `tests/intake/record-disclosure-with-tx.test.ts` — 6 vitests cover wrapper shape, best-effort failure swallow, `tx?` forward-compat acceptance, and the arg-count pre-Drop-1 pin (`expect(recordMock.mock.calls[0].length).toBe(1)` — flips when Drop 1 ships)
- `disclosure-store.ts` JSDoc preserved verbatim; Q-CR9 SIGNAL-not-gate + Q-BRIDGE-RECORDER-DURABILITY semantics unchanged (best-effort write, no learner-blocking failure mode)
- pre-push hook output: `[pre-push] lint: no errors in changed files. [pre-push] Push checks passed.`

Closes #1919
Refs #1915 (epic), #1916 (S1 → PR #1938), #1917 (S5a → PR #1939), #1918 (S8a → PR #1941), #1920 (S10 → PR #1944)

Deploy command: `/vm-cp`