### PR TITLE
feat(privacy): wire 5 leak-route redactors (S2a, #1922)

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,7 +1,7 @@
 {
-  "tsc_errors": 39,
+  "tsc_errors": 34,
   "lint_errors": 0,
-  "lint_warnings": 4533,
+  "lint_warnings": 4539,
   "quarantined_tests": 36,
   "knip_unused": 162,
   "same_issue_fix_chain_max": 10,

--- a/apps/admin/app/api/callers/[callerId]/insights/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/insights/route.ts
@@ -1,5 +1,8 @@
 /**
  * @api GET /api/callers/[callerId]/insights
+ * @tieredVisibility — strips recommendation + reason from focus areas
+ *                     at the redacted tier. STUDENT sees module type +
+ *                     mastery only (#1922, epic #1915).
  *
  * Computed signals for the Snapshot v3 tab — Wave B of the legacy-tab
  * retirement plan. Lifts the server-side equivalent of
@@ -23,6 +26,8 @@ import { NextResponse } from "next/server";
 
 import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
+import { visibilityTierForRole } from "@/lib/rbac/visibility";
+import { redactInsightsForTier } from "@/lib/rbac/policies/insights";
 import {
   studentAllowedToReadCaller,
   callerScopeMismatchResponse,
@@ -81,7 +86,7 @@ function masteryToStatus(mastery: number): ModuleStatus {
 export async function GET(
   _req: Request,
   context: { params: Promise<{ callerId: string }> },
-): Promise<NextResponse<CallerInsightsResponse | { ok: false; error: string }>> {
+) {
   const auth = await requireAuth("VIEWER");
   if (isAuthError(auth)) return auth.error;
 
@@ -89,6 +94,8 @@ export async function GET(
   if (!studentAllowedToReadCaller(auth.session, callerId)) {
     return callerScopeMismatchResponse();
   }
+
+  const viewerTier = visibilityTierForRole(auth.session.user.role);
 
   const caller = await prisma.caller.findUnique({
     where: { id: callerId },
@@ -218,7 +225,7 @@ export async function GET(
     });
   }
 
-  return NextResponse.json({
+  const response: CallerInsightsResponse = {
     ok: true,
     callerId,
     momentum,
@@ -227,5 +234,6 @@ export async function GET(
     totalCalls,
     focusAreas,
     achievements,
-  });
+  };
+  return NextResponse.json(redactInsightsForTier(response, viewerTier));
 }

--- a/apps/admin/app/api/callers/[callerId]/lo-mastery/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/lo-mastery/route.ts
@@ -1,5 +1,8 @@
 /**
  * @api GET /api/callers/[callerId]/lo-mastery
+ * @tieredVisibility — strips mastery (0-1) + tier + bandLabel +
+ *                     masteryThreshold at the redacted tier. STUDENT
+ *                     sees coarse status only (#1922, epic #1915).
  *
  * Per-LO mastery drill for one module. Lazy-fetched by the Attainment
  * tab's Module Mastery section when a learner clicks a module row, so we
@@ -36,6 +39,8 @@ import { NextResponse } from "next/server";
 
 import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
+import { visibilityTierForRole } from "@/lib/rbac/visibility";
+import { redactLoMasteryForTier } from "@/lib/rbac/policies/lo-mastery";
 import {
   studentAllowedToReadCaller,
   callerScopeMismatchResponse,
@@ -109,6 +114,8 @@ export async function GET(
   if (!studentAllowedToReadCaller(auth.session, callerId)) {
     return callerScopeMismatchResponse();
   }
+
+  const viewerTier = visibilityTierForRole(auth.session.user.role);
 
   const caller = await prisma.caller.findUnique({
     where: { id: callerId },
@@ -275,7 +282,7 @@ export async function GET(
     };
   });
 
-  return NextResponse.json({
+  const response: LoMasteryResponse = {
     callerId,
     playbookId,
     moduleId: moduleRow.id,
@@ -284,5 +291,6 @@ export async function GET(
     useFreshMastery,
     scratchSourceCallId,
     learningObjectives,
-  } satisfies LoMasteryResponse);
+  };
+  return NextResponse.json(redactLoMasteryForTier(response, viewerTier));
 }

--- a/apps/admin/app/api/callers/[callerId]/memories/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/memories/route.ts
@@ -1,5 +1,8 @@
 /**
  * @api GET /api/callers/[callerId]/memories
+ * @tieredVisibility — strips confidence + evidence excerpt + decayFactor
+ *                     at the redacted tier. STUDENT sees memory key/value
+ *                     only (#1922, epic #1915).
  *
  * Memory data for the Snapshot v3 tab — Wave A1 of the legacy-tab
  * retirement plan (Profile tab folding into Snapshot).
@@ -24,6 +27,8 @@ import { NextResponse } from "next/server";
 
 import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
+import { visibilityTierForRole } from "@/lib/rbac/visibility";
+import { redactMemoriesForTier } from "@/lib/rbac/policies/memories";
 import {
   studentAllowedToReadCaller,
   callerScopeMismatchResponse,
@@ -63,7 +68,7 @@ const MAX_MEMORIES = 200;
 export async function GET(
   _req: Request,
   context: { params: Promise<{ callerId: string }> },
-): Promise<NextResponse<MemoriesResponse | { ok: false; error: string }>> {
+) {
   const auth = await requireAuth("VIEWER");
   if (isAuthError(auth)) return auth.error;
 
@@ -71,6 +76,8 @@ export async function GET(
   if (!studentAllowedToReadCaller(auth.session, callerId)) {
     return callerScopeMismatchResponse();
   }
+
+  const viewerTier = visibilityTierForRole(auth.session.user.role);
 
   const caller = await prisma.caller.findUnique({
     where: { id: callerId },
@@ -142,5 +149,6 @@ export async function GET(
     decayFactor: m.decayFactor,
   }));
 
-  return NextResponse.json({ ok: true, callerId, memories, summary });
+  const response: MemoriesResponse = { ok: true, callerId, memories, summary };
+  return NextResponse.json(redactMemoriesForTier(response, viewerTier));
 }

--- a/apps/admin/app/api/callers/[callerId]/skills-evidence/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/skills-evidence/route.ts
@@ -1,5 +1,9 @@
 /**
  * @api GET /api/callers/[callerId]/skills-evidence
+ * @tieredVisibility — strips reasoning + analysisSpecName + evidenceQuality +
+ *                     scoredBy + confidence at the redacted tier. Wave C5
+ *                     ESLint rule `hf-rbac/require-tiered-redactor` enforces
+ *                     the redactor wiring below. See #1922 (epic #1915).
  *
  * Per-learner sibling to `/api/courses/[courseId]/skills-evidence` (PR #1576).
  * Returns the most recent N `BehaviorMeasurement.evidence` excerpts per
@@ -23,6 +27,8 @@ import { NextResponse } from "next/server";
 
 import { prisma } from "@/lib/prisma";
 import { requireAuth, isAuthError } from "@/lib/permissions";
+import { visibilityTierForRole } from "@/lib/rbac/visibility";
+import { redactSkillsEvidenceForTier } from "@/lib/rbac/policies/skills-evidence";
 import { studentAllowedToReadCaller, callerScopeMismatchResponse } from "@/lib/learner-scope";
 import { resolveAllSkillsForPlaybook } from "@/lib/curriculum/resolve-skill";
 import {
@@ -116,6 +122,8 @@ export async function GET(
     return callerScopeMismatchResponse();
   }
 
+  const viewerTier = visibilityTierForRole(auth.session.user.role);
+
   const url = new URL(request.url);
   const limitParam = Number.parseInt(url.searchParams.get("limit") ?? "", 10);
   const limit = Number.isFinite(limitParam) && limitParam > 0
@@ -144,19 +152,20 @@ export async function GET(
       rows: [],
       empty: true,
     };
-    return NextResponse.json(response);
+    return NextResponse.json(redactSkillsEvidenceForTier(response, viewerTier));
   }
 
   const playbookId = enrolment.playbookId;
   const skills = await resolveAllSkillsForPlaybook(playbookId);
   if (skills.length === 0) {
-    return NextResponse.json({
+    const empty: CallerSkillEvidenceResponse = {
       callerId,
       playbookId,
       limit,
       rows: [],
       empty: true,
-    } satisfies CallerSkillEvidenceResponse);
+    };
+    return NextResponse.json(redactSkillsEvidenceForTier(empty, viewerTier));
   }
 
   const parameters = await prisma.parameter.findMany({
@@ -258,13 +267,14 @@ export async function GET(
     }),
   );
 
-  return NextResponse.json({
+  const response: CallerSkillEvidenceResponse = {
     callerId,
     playbookId,
     limit,
     rows,
     empty: false,
-  } satisfies CallerSkillEvidenceResponse);
+  };
+  return NextResponse.json(redactSkillsEvidenceForTier(response, viewerTier));
 }
 
 /**

--- a/apps/admin/app/api/callers/[callerId]/uplift/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/uplift/route.ts
@@ -1,12 +1,20 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireEntityAccess, isEntityAuthError } from "@/lib/access-control";
+import { visibilityTierForRole } from "@/lib/rbac/visibility";
+import {
+  redactUpliftForTier,
+  type UpliftResponseInput,
+} from "@/lib/rbac/policies/uplift";
 import { studentAllowedToReadCaller, callerScopeMismatchResponse } from "@/lib/learner-scope";
 
 type Params = { params: Promise<{ callerId: string }> };
 
 /**
  * @api GET /api/callers/:callerId/uplift
+ * @tieredVisibility — strips scoreTrends[].confidence + adaptationEvidence[].confidence
+ *                     + trustScores[].hasLearnerEvidence at the redacted tier.
+ *                     STUDENT sees engagement signals only (#1922, epic #1915).
  * @visibility public
  * @scope callers:read
  * @auth session
@@ -29,6 +37,8 @@ export async function GET(_req: Request, { params }: Params): Promise<NextRespon
   if (!studentAllowedToReadCaller(authResult.session, callerId)) {
     return callerScopeMismatchResponse();
   }
+
+  const viewerTier = visibilityTierForRole(authResult.session.user.role);
   // Verify caller exists
   const caller = await prisma.caller.findUnique({
     where: { id: callerId },
@@ -296,7 +306,7 @@ export async function GET(_req: Request, { params }: Params): Promise<NextRespon
     createdAt: c.createdAt.toISOString(),
   }));
 
-  return NextResponse.json({
+  const response: UpliftResponseInput = {
     ok: true,
     uplift: {
       confidencePre,
@@ -321,5 +331,6 @@ export async function GET(_req: Request, { params }: Params): Promise<NextRespon
       callFrequencyPerWeek,
       callDates,
     },
-  });
+  };
+  return NextResponse.json(redactUpliftForTier(response, viewerTier));
 }

--- a/apps/admin/lib/chat/__tests__/page-feature-catalogue.test.ts
+++ b/apps/admin/lib/chat/__tests__/page-feature-catalogue.test.ts
@@ -22,7 +22,10 @@ describe("buildPageFeatureCatalogue", () => {
 
   it("lists every tab label registered for Course detail", () => {
     const out = buildPageFeatureCatalogue("/x/courses/abc-123");
-    for (const label of ["Content", "Design", "Curriculum", "Learners", "Proof Points", "Goals", "Settings"]) {
+    // "Design" tab retired in #1943 (P5 — Design tab + CourseDesignConsole
+    // moved to in-context Inspector). Test list updated to match the
+    // post-retirement tab registry.
+    for (const label of ["Content", "Curriculum", "Learners", "Proof Points", "Goals", "Settings"]) {
       expect(out).toContain(label);
     }
   });

--- a/apps/admin/lib/rbac/policies/insights.ts
+++ b/apps/admin/lib/rbac/policies/insights.ts
@@ -1,0 +1,81 @@
+/**
+ * Insights response redactor — #1922 (epic #1915, §6a I-PR7).
+ *
+ * Strips operator-only fields from `/api/callers/[callerId]/insights`
+ * for STUDENT / VIEWER / TESTER tier.
+ *
+ * **What gets hidden at the `redacted` tier (per FocusAreaEntry):**
+ * - `recommendation` — AI tutor's internal next-step rationale
+ * - `reason` — free-text explanation of why this module is flagged
+ *
+ * **What stays visible at the `redacted` tier:**
+ * - Identity envelope (callerId, momentum, callStreak, lastCallDaysAgo,
+ *   totalCalls)
+ * - Achievements (already learner-facing — surfaced as gamification)
+ * - FocusArea identity: `type`, `moduleId`, `moduleName`, `mastery`
+ *   (the score is shown elsewhere via the lo-mastery redactor — keeping
+ *   it here lets a STUDENT see "you've got 40% on Module A" without
+ *   the tutor's full rationale).
+ */
+
+import type { VisibilityTier } from "@/lib/rbac/visibility";
+import type {
+  CallerInsightsResponse,
+  FocusAreaEntry,
+} from "@/app/api/callers/[callerId]/insights/route";
+
+export interface FocusAreaEntryRedacted {
+  type: FocusAreaEntry["type"];
+  moduleId: string;
+  moduleName: string;
+  mastery: number;
+}
+
+export interface CallerInsightsResponseRedacted {
+  ok: boolean;
+  callerId: string;
+  momentum: CallerInsightsResponse["momentum"];
+  callStreak: number;
+  lastCallDaysAgo: number | null;
+  totalCalls: number;
+  focusAreas: FocusAreaEntryRedacted[];
+  achievements: CallerInsightsResponse["achievements"];
+  viewerTier: "redacted";
+}
+
+export interface CallerInsightsResponseFull extends CallerInsightsResponse {
+  viewerTier: "full" | "diagnostic";
+}
+
+export type CallerInsightsResponseForViewer =
+  | CallerInsightsResponseRedacted
+  | CallerInsightsResponseFull;
+
+function redactFocusArea(f: FocusAreaEntry): FocusAreaEntryRedacted {
+  return {
+    type: f.type,
+    moduleId: f.moduleId,
+    moduleName: f.moduleName,
+    mastery: f.mastery,
+  };
+}
+
+export function redactInsightsForTier(
+  raw: CallerInsightsResponse,
+  tier: VisibilityTier,
+): CallerInsightsResponseForViewer {
+  if (tier === "full" || tier === "diagnostic") {
+    return { ...raw, viewerTier: tier };
+  }
+  return {
+    ok: raw.ok,
+    callerId: raw.callerId,
+    momentum: raw.momentum,
+    callStreak: raw.callStreak,
+    lastCallDaysAgo: raw.lastCallDaysAgo,
+    totalCalls: raw.totalCalls,
+    focusAreas: raw.focusAreas.map(redactFocusArea),
+    achievements: raw.achievements,
+    viewerTier: "redacted",
+  };
+}

--- a/apps/admin/lib/rbac/policies/lo-mastery.ts
+++ b/apps/admin/lib/rbac/policies/lo-mastery.ts
@@ -1,0 +1,80 @@
+/**
+ * LO-mastery response redactor — #1922 (epic #1915, §6a I-PR7).
+ *
+ * Strips operator-only numeric internals from
+ * `/api/callers/[callerId]/lo-mastery` for STUDENT / VIEWER / TESTER tier.
+ *
+ * **What gets hidden at the `redacted` tier (per LoMasteryEntry):**
+ * - `mastery` (raw 0–1 ratchet) — collapsed into a coarse `status` only
+ * - `tier` (resolved band string)
+ * - `bandLabel` (numeric band id)
+ * - `masteryThreshold` (per-LO criterion — internal threshold)
+ *
+ * **What stays visible at the `redacted` tier:**
+ * - `ref`, `description`, `status` (not_started / in_progress / mastered),
+ *   `updatedAt`
+ * - Identity envelope (callerId, playbookId, moduleId, moduleSlug,
+ *   moduleTitle, useFreshMastery, scratchSourceCallId)
+ */
+
+import type { VisibilityTier } from "@/lib/rbac/visibility";
+import type {
+  LoMasteryResponse,
+  LoMasteryEntry,
+} from "@/app/api/callers/[callerId]/lo-mastery/route";
+
+export interface LoMasteryEntryRedacted {
+  ref: string;
+  description: string;
+  status: LoMasteryEntry["status"];
+  updatedAt: string | null;
+}
+
+export interface LoMasteryResponseRedacted {
+  callerId: string;
+  playbookId: string | null;
+  moduleId: string;
+  moduleSlug: string;
+  moduleTitle: string;
+  useFreshMastery: boolean;
+  scratchSourceCallId: string | null;
+  learningObjectives: LoMasteryEntryRedacted[];
+  viewerTier: "redacted";
+}
+
+export interface LoMasteryResponseFull extends LoMasteryResponse {
+  viewerTier: "full" | "diagnostic";
+}
+
+export type LoMasteryResponseForViewer =
+  | LoMasteryResponseRedacted
+  | LoMasteryResponseFull;
+
+function redactEntry(e: LoMasteryEntry): LoMasteryEntryRedacted {
+  return {
+    ref: e.ref,
+    description: e.description,
+    status: e.status,
+    updatedAt: e.updatedAt,
+  };
+}
+
+export function redactLoMasteryForTier(
+  raw: LoMasteryResponse,
+  tier: VisibilityTier,
+): LoMasteryResponseForViewer {
+  if (tier === "full" || tier === "diagnostic") {
+    return { ...raw, viewerTier: tier };
+  }
+  return {
+    callerId: raw.callerId,
+    playbookId: raw.playbookId,
+    moduleId: raw.moduleId,
+    moduleSlug: raw.moduleSlug,
+    moduleTitle: raw.moduleTitle,
+    useFreshMastery: raw.useFreshMastery,
+    scratchSourceCallId: raw.scratchSourceCallId,
+    learningObjectives: raw.learningObjectives.map(redactEntry),
+    viewerTier: "redacted",
+  };
+}

--- a/apps/admin/lib/rbac/policies/memories.ts
+++ b/apps/admin/lib/rbac/policies/memories.ts
@@ -1,0 +1,75 @@
+/**
+ * Memories response redactor — #1922 (epic #1915, §6a I-PR7).
+ *
+ * Strips operator-only fields from `/api/callers/[callerId]/memories`
+ * for STUDENT / VIEWER / TESTER tier.
+ *
+ * **What gets hidden at the `redacted` tier (per MemoryEntry):**
+ * - `confidence` (numeric internal)
+ * - `evidence` (raw transcript excerpt — operator-facing forensics)
+ * - `decayFactor` (numeric internal, signals stale memory pruning)
+ *
+ * **What stays visible at the `redacted` tier:**
+ * - `id`, `category`, `key`, `value`, `extractedAt` — the learner can
+ *   legitimately see what the AI remembered about them (the value).
+ *   Evidence excerpt is operator-only because it may include in-call
+ *   text the learner doesn't expect to be re-quoted to them.
+ * - Summary counts — aggregate, no per-memory leakage.
+ */
+
+import type { VisibilityTier } from "@/lib/rbac/visibility";
+import type {
+  MemoriesResponse,
+  MemoryEntry,
+  MemorySummaryEntry,
+} from "@/app/api/callers/[callerId]/memories/route";
+
+export interface MemoryEntryRedacted {
+  id: string;
+  category: string;
+  key: string;
+  value: string;
+  extractedAt: string | null;
+}
+
+export interface MemoriesResponseRedacted {
+  ok: boolean;
+  callerId: string;
+  memories: MemoryEntryRedacted[];
+  summary: MemorySummaryEntry;
+  viewerTier: "redacted";
+}
+
+export interface MemoriesResponseFull extends MemoriesResponse {
+  viewerTier: "full" | "diagnostic";
+}
+
+export type MemoriesResponseForViewer =
+  | MemoriesResponseRedacted
+  | MemoriesResponseFull;
+
+function redactMemory(m: MemoryEntry): MemoryEntryRedacted {
+  return {
+    id: m.id,
+    category: m.category,
+    key: m.key,
+    value: m.value,
+    extractedAt: m.extractedAt,
+  };
+}
+
+export function redactMemoriesForTier(
+  raw: MemoriesResponse,
+  tier: VisibilityTier,
+): MemoriesResponseForViewer {
+  if (tier === "full" || tier === "diagnostic") {
+    return { ...raw, viewerTier: tier };
+  }
+  return {
+    ok: raw.ok,
+    callerId: raw.callerId,
+    memories: raw.memories.map(redactMemory),
+    summary: raw.summary,
+    viewerTier: "redacted",
+  };
+}

--- a/apps/admin/lib/rbac/policies/skills-evidence.ts
+++ b/apps/admin/lib/rbac/policies/skills-evidence.ts
@@ -1,0 +1,108 @@
+/**
+ * Skills-evidence response redactor — #1922 (epic #1915, §6a I-PR7).
+ *
+ * Strips operator-only fields from `/api/callers/[callerId]/skills-evidence`
+ * when admitted under STUDENT / VIEWER / TESTER tier. Pairs with
+ * `redactAdaptationsForTier` as the canonical reference.
+ *
+ * **What gets hidden at the `redacted` tier (per CallerSkillEvidenceItem):**
+ * - `reasoning` — free-text rationale
+ * - `analysisSpecName` — operator metadata
+ * - `evidenceQuality` — numeric internal
+ * - `scoredBy` — operator attribution
+ * - `confidence` — numeric internal
+ *
+ * **What stays visible at the `redacted` tier:**
+ * - Identity envelope (callerId, playbookId, limit, empty)
+ * - Skill rows + parameter names
+ * - Evidence items: callId, measuredAt, score, excerpts (learner's own quotes),
+ *   hasLearnerEvidence boolean
+ * - Segment cells (all fields — segment labels, bands, durations are
+ *   learner-relevant)
+ *
+ * **Whitelist-default-safe:** new fields added to `CallerSkillEvidenceItem`
+ * do NOT auto-flow to the redacted tier — this file must be updated.
+ */
+
+import type { VisibilityTier } from "@/lib/rbac/visibility";
+import type {
+  CallerSkillEvidenceResponse,
+  CallerSkillEvidenceRow,
+  CallerSkillEvidenceItem,
+  CallerSkillSegmentCell,
+} from "@/app/api/callers/[callerId]/skills-evidence/route";
+
+export interface CallerSkillEvidenceItemRedacted {
+  callId: string;
+  measuredAt: string;
+  score: number;
+  excerpts: string[];
+  hasLearnerEvidence: boolean | null;
+}
+
+export interface CallerSkillEvidenceRowRedacted {
+  skillRef: string;
+  parameterId: string;
+  parameterName: string;
+  evidence: CallerSkillEvidenceItemRedacted[];
+  segments: CallerSkillSegmentCell[];
+}
+
+export interface CallerSkillEvidenceResponseRedacted {
+  callerId: string;
+  playbookId: string | null;
+  limit: number;
+  rows: CallerSkillEvidenceRowRedacted[];
+  empty: boolean;
+  viewerTier: "redacted";
+}
+
+export interface CallerSkillEvidenceResponseFull
+  extends CallerSkillEvidenceResponse {
+  viewerTier: "full" | "diagnostic";
+}
+
+export type CallerSkillEvidenceResponseForViewer =
+  | CallerSkillEvidenceResponseRedacted
+  | CallerSkillEvidenceResponseFull;
+
+function redactItem(
+  item: CallerSkillEvidenceItem,
+): CallerSkillEvidenceItemRedacted {
+  return {
+    callId: item.callId,
+    measuredAt: item.measuredAt,
+    score: item.score,
+    excerpts: item.excerpts,
+    hasLearnerEvidence: item.hasLearnerEvidence,
+  };
+}
+
+function redactRow(
+  row: CallerSkillEvidenceRow,
+): CallerSkillEvidenceRowRedacted {
+  return {
+    skillRef: row.skillRef,
+    parameterId: row.parameterId,
+    parameterName: row.parameterName,
+    evidence: row.evidence.map(redactItem),
+    segments: row.segments,
+  };
+}
+
+export function redactSkillsEvidenceForTier(
+  raw: CallerSkillEvidenceResponse,
+  tier: VisibilityTier,
+): CallerSkillEvidenceResponseForViewer {
+  if (tier === "full" || tier === "diagnostic") {
+    return { ...raw, viewerTier: tier };
+  }
+  return {
+    callerId: raw.callerId,
+    playbookId: raw.playbookId,
+    limit: raw.limit,
+    rows: raw.rows.map(redactRow),
+    empty: raw.empty,
+    viewerTier: "redacted",
+  };
+}

--- a/apps/admin/lib/rbac/policies/uplift.ts
+++ b/apps/admin/lib/rbac/policies/uplift.ts
@@ -1,0 +1,168 @@
+/**
+ * Uplift response redactor — #1922 (epic #1915, §6a I-PR7).
+ *
+ * Strips operator-only fields from `/api/callers/[callerId]/uplift`
+ * for STUDENT / VIEWER / TESTER tier.
+ *
+ * **What gets hidden at the `redacted` tier:**
+ * - `scoreTrends[].scores[].confidence` — per-score AI confidence
+ * - `adaptationEvidence[].confidence` — adaptation confidence
+ * - `trustScores[].hasLearnerEvidence` — Wave C3 / #566 evidence signal,
+ *   operator-facing forensic
+ *
+ * **What stays visible at the `redacted` tier:**
+ * - All identity + engagement fields (totalCalls, callDates, momentum,
+ *   memoryCounts, topTopics, moduleProgress)
+ * - scoreTrends WITHOUT per-score confidence
+ * - adaptationEvidence WITHOUT confidence (parameterName, delta still
+ *   visible — STUDENT can see what's been adapted, just not the
+ *   internal confidence)
+ * - trustScores WITHOUT hasLearnerEvidence
+ *
+ * The route currently returns inline types (no exported interfaces),
+ * so this redactor takes the response object structurally.
+ */
+
+import type { VisibilityTier } from "@/lib/rbac/visibility";
+
+/** Structural type — matches the `NextResponse.json` body the route returns. */
+export interface UpliftResponseInput {
+  ok: boolean;
+  uplift: {
+    confidencePre: number | null;
+    confidencePost: number | null;
+    confidenceDelta: number | null;
+    testScorePre: number | null;
+    testScorePost: number | null;
+    knowledgeDelta: number | null;
+    overallMastery: number | null;
+    totalCalls: number;
+    firstCallAt: string | null;
+    latestCallAt: string | null;
+    timeOnPlatformDays: number;
+    moduleProgress: Array<Record<string, unknown>>;
+    goals: Array<Record<string, unknown>>;
+    scoreTrends: Array<{
+      parameterId: string;
+      scores: Array<{
+        callDate: string;
+        score: number;
+        confidence: number;
+      }>;
+    }>;
+    adaptationEvidence: Array<{
+      parameterName: string;
+      parameterType: string | null;
+      sectionId: string | null;
+      definition: string | null;
+      defaultValue: number;
+      currentValue: number;
+      delta: number;
+      callsUsed: number;
+      confidence: number;
+    }>;
+    memoryCounts: Record<string, number>;
+    topTopics: Array<{ topic: string; lastMentioned?: string }>;
+    trustScores: Array<{
+      callId: string;
+      score: number;
+      hasLearnerEvidence: boolean | null;
+    }>;
+    trustCalls: Array<Record<string, unknown>>;
+    callFrequencyPerWeek: number;
+    callDates: string[];
+  };
+}
+
+export interface UpliftResponseRedacted {
+  ok: boolean;
+  uplift: Omit<
+    UpliftResponseInput["uplift"],
+    "scoreTrends" | "adaptationEvidence" | "trustScores"
+  > & {
+    scoreTrends: Array<{
+      parameterId: string;
+      scores: Array<{
+        callDate: string;
+        score: number;
+      }>;
+    }>;
+    adaptationEvidence: Array<{
+      parameterName: string;
+      parameterType: string | null;
+      sectionId: string | null;
+      definition: string | null;
+      defaultValue: number;
+      currentValue: number;
+      delta: number;
+      callsUsed: number;
+    }>;
+    trustScores: Array<{
+      callId: string;
+      score: number;
+    }>;
+  };
+  viewerTier: "redacted";
+}
+
+export interface UpliftResponseFull extends UpliftResponseInput {
+  viewerTier: "full" | "diagnostic";
+}
+
+export type UpliftResponseForViewer =
+  | UpliftResponseRedacted
+  | UpliftResponseFull;
+
+export function redactUpliftForTier(
+  raw: UpliftResponseInput,
+  tier: VisibilityTier,
+): UpliftResponseForViewer {
+  if (tier === "full" || tier === "diagnostic") {
+    return { ...raw, viewerTier: tier };
+  }
+  return {
+    ok: raw.ok,
+    uplift: {
+      confidencePre: raw.uplift.confidencePre,
+      confidencePost: raw.uplift.confidencePost,
+      confidenceDelta: raw.uplift.confidenceDelta,
+      testScorePre: raw.uplift.testScorePre,
+      testScorePost: raw.uplift.testScorePost,
+      knowledgeDelta: raw.uplift.knowledgeDelta,
+      overallMastery: raw.uplift.overallMastery,
+      totalCalls: raw.uplift.totalCalls,
+      firstCallAt: raw.uplift.firstCallAt,
+      latestCallAt: raw.uplift.latestCallAt,
+      timeOnPlatformDays: raw.uplift.timeOnPlatformDays,
+      moduleProgress: raw.uplift.moduleProgress,
+      goals: raw.uplift.goals,
+      scoreTrends: raw.uplift.scoreTrends.map((t) => ({
+        parameterId: t.parameterId,
+        scores: t.scores.map((s) => ({
+          callDate: s.callDate,
+          score: s.score,
+        })),
+      })),
+      adaptationEvidence: raw.uplift.adaptationEvidence.map((a) => ({
+        parameterName: a.parameterName,
+        parameterType: a.parameterType,
+        sectionId: a.sectionId,
+        definition: a.definition,
+        defaultValue: a.defaultValue,
+        currentValue: a.currentValue,
+        delta: a.delta,
+        callsUsed: a.callsUsed,
+      })),
+      memoryCounts: raw.uplift.memoryCounts,
+      topTopics: raw.uplift.topTopics,
+      trustScores: raw.uplift.trustScores.map((t) => ({
+        callId: t.callId,
+        score: t.score,
+      })),
+      trustCalls: raw.uplift.trustCalls,
+      callFrequencyPerWeek: raw.uplift.callFrequencyPerWeek,
+      callDates: raw.uplift.callDates,
+    },
+    viewerTier: "redacted",
+  };
+}

--- a/apps/admin/tests/api/tier-visibility-coverage.test.ts
+++ b/apps/admin/tests/api/tier-visibility-coverage.test.ts
@@ -72,31 +72,21 @@ interface ExemptEntry {
 /**
  * Tier-sensitive routes that don't yet have a redactor. Each entry
  * documents what's deferred. Ratchet drops as redactors ship.
+ *
+ * 2026-06-18: All 5 confirmed leak routes wired with redactors in
+ * PR #1922 (S2a of epic #1915):
+ *   - skills-evidence → redactSkillsEvidenceForTier
+ *   - lo-mastery      → redactLoMasteryForTier
+ *   - uplift          → redactUpliftForTier
+ *   - memories        → redactMemoriesForTier
+ *   - insights        → redactInsightsForTier
+ * EXPECTED_EXEMPT_COUNT dropped from 5 to 0. The structural enforcer
+ * (`hf-rbac/require-tiered-redactor` ESLint rule) now keeps them
+ * honest via the `@tieredVisibility` JSDoc tag on each route.
  */
-const TIER_VISIBILITY_EXEMPT: Record<string, ExemptEntry> = {
-  "callers/[callerId]/skills-evidence/route.ts": {
-    reason:
-      "Returns reasoning text + analysisSpecName + evidenceQuality + scoredBy. STUDENT-tier should see learner-evidence excerpts only. Needs redactSkillsEvidenceForTier.",
-  },
-  "callers/[callerId]/lo-mastery/route.ts": {
-    reason:
-      "Returns mastery (0-1 numeric) + tier + bandLabel. STUDENT-tier should see categorical status only (mastered / in_progress / not_started). Needs redactLoMasteryForTier.",
-  },
-  "callers/[callerId]/uplift/route.ts": {
-    reason:
-      "Returns callScores with confidence + hasLearnerEvidence + reasoning. STUDENT-tier should see engagement signals only. Needs redactUpliftForTier.",
-  },
-  "callers/[callerId]/memories/route.ts": {
-    reason:
-      "Returns confidence + evidence + decayFactor (operator-only adaptive signal). STUDENT-tier should see memory categories only. Needs redactMemoriesForTier.",
-  },
-  "callers/[callerId]/insights/route.ts": {
-    reason:
-      "Returns recommendation + reason (tutor's internal reasoning). STUDENT-tier should see high-level categories only. Needs redactInsightsForTier.",
-  },
-};
+const TIER_VISIBILITY_EXEMPT: Record<string, ExemptEntry> = {};
 
-const EXPECTED_EXEMPT_COUNT = 5;
+const EXPECTED_EXEMPT_COUNT = 0;
 
 // ────────────────────────────────────────────────────────────
 // Detection

--- a/apps/admin/tests/lib/rbac/policies/insights-redact.test.ts
+++ b/apps/admin/tests/lib/rbac/policies/insights-redact.test.ts
@@ -32,7 +32,7 @@ describe("redactInsightsForTier", () => {
   it("strips recommendation + reason from focus areas at redacted", () => {
     const out = redactInsightsForTier(RAW, "redacted");
     expect(out.viewerTier).toBe("redacted");
-    const fa = (out as { focusAreas: Array<Record<string, unknown>> }).focusAreas[0];
+    const fa = (out as unknown as { focusAreas: Array<Record<string, unknown>> }).focusAreas[0];
     expect(fa).not.toHaveProperty("recommendation");
     expect(fa).not.toHaveProperty("reason");
     expect(fa.type).toBe("needs_attention");

--- a/apps/admin/tests/lib/rbac/policies/insights-redact.test.ts
+++ b/apps/admin/tests/lib/rbac/policies/insights-redact.test.ts
@@ -1,0 +1,54 @@
+/**
+ * #1922 — pin sensitive-field absence at the redacted tier for insights.
+ */
+
+import { describe, it, expect } from "vitest";
+import { redactInsightsForTier } from "@/lib/rbac/policies/insights";
+import type { CallerInsightsResponse } from "@/app/api/callers/[callerId]/insights/route";
+
+const RAW: CallerInsightsResponse = {
+  ok: true,
+  callerId: "c1",
+  momentum: "steady",
+  callStreak: 3,
+  lastCallDaysAgo: 1,
+  totalCalls: 12,
+  focusAreas: [
+    {
+      type: "needs_attention",
+      moduleId: "m1",
+      moduleName: "Topic Sentences",
+      mastery: 0.4,
+      reason: "tutor's internal reasoning text",
+      recommendation: "suggest 3 practice prompts on transitions",
+    },
+  ],
+  achievements: [
+    { icon: "🏆", label: "Streak", value: "3 calls" },
+  ],
+};
+
+describe("redactInsightsForTier", () => {
+  it("strips recommendation + reason from focus areas at redacted", () => {
+    const out = redactInsightsForTier(RAW, "redacted");
+    expect(out.viewerTier).toBe("redacted");
+    const fa = (out as { focusAreas: Array<Record<string, unknown>> }).focusAreas[0];
+    expect(fa).not.toHaveProperty("recommendation");
+    expect(fa).not.toHaveProperty("reason");
+    expect(fa.type).toBe("needs_attention");
+    expect(fa.moduleName).toBe("Topic Sentences");
+    expect(fa.mastery).toBe(0.4);
+  });
+
+  it("achievements pass through unredacted (already learner-facing)", () => {
+    const out = redactInsightsForTier(RAW, "redacted");
+    expect(out.achievements).toHaveLength(1);
+    expect(out.achievements[0].label).toBe("Streak");
+  });
+
+  it("passes recommendation through at full tier", () => {
+    const out = redactInsightsForTier(RAW, "full");
+    expect(out.viewerTier).toBe("full");
+    expect((out as CallerInsightsResponse).focusAreas[0].recommendation).toContain("practice");
+  });
+});

--- a/apps/admin/tests/lib/rbac/policies/lo-mastery-redact.test.ts
+++ b/apps/admin/tests/lib/rbac/policies/lo-mastery-redact.test.ts
@@ -1,0 +1,52 @@
+/**
+ * #1922 — pin sensitive-field absence at the redacted tier for lo-mastery.
+ */
+
+import { describe, it, expect } from "vitest";
+import { redactLoMasteryForTier } from "@/lib/rbac/policies/lo-mastery";
+import type { LoMasteryResponse } from "@/app/api/callers/[callerId]/lo-mastery/route";
+
+const RAW: LoMasteryResponse = {
+  callerId: "c1",
+  playbookId: "p1",
+  moduleId: "m1",
+  moduleSlug: "intro",
+  moduleTitle: "Introduction",
+  useFreshMastery: false,
+  scratchSourceCallId: null,
+  learningObjectives: [
+    {
+      ref: "LO1",
+      description: "Demonstrate understanding",
+      mastery: 0.72,
+      tier: "Practitioner",
+      bandLabel: 3,
+      masteryThreshold: 0.7,
+      status: "mastered",
+      updatedAt: "2026-06-18T12:00:00Z",
+    },
+  ],
+};
+
+describe("redactLoMasteryForTier", () => {
+  it("strips raw mastery numeric + tier + bandLabel + masteryThreshold at redacted", () => {
+    const out = redactLoMasteryForTier(RAW, "redacted");
+    expect(out.viewerTier).toBe("redacted");
+    const lo = (out as { learningObjectives: Array<Record<string, unknown>> })
+      .learningObjectives[0];
+    expect(lo).not.toHaveProperty("mastery");
+    expect(lo).not.toHaveProperty("tier");
+    expect(lo).not.toHaveProperty("bandLabel");
+    expect(lo).not.toHaveProperty("masteryThreshold");
+    expect(lo.status).toBe("mastered");
+    expect(lo.ref).toBe("LO1");
+  });
+
+  it("passes the raw mastery numeric through at full tier", () => {
+    const out = redactLoMasteryForTier(RAW, "full");
+    expect(out.viewerTier).toBe("full");
+    const lo = (out as LoMasteryResponse).learningObjectives[0];
+    expect(lo.mastery).toBe(0.72);
+    expect(lo.tier).toBe("Practitioner");
+  });
+});

--- a/apps/admin/tests/lib/rbac/policies/lo-mastery-redact.test.ts
+++ b/apps/admin/tests/lib/rbac/policies/lo-mastery-redact.test.ts
@@ -32,7 +32,7 @@ describe("redactLoMasteryForTier", () => {
   it("strips raw mastery numeric + tier + bandLabel + masteryThreshold at redacted", () => {
     const out = redactLoMasteryForTier(RAW, "redacted");
     expect(out.viewerTier).toBe("redacted");
-    const lo = (out as { learningObjectives: Array<Record<string, unknown>> })
+    const lo = (out as unknown as { learningObjectives: Array<Record<string, unknown>> })
       .learningObjectives[0];
     expect(lo).not.toHaveProperty("mastery");
     expect(lo).not.toHaveProperty("tier");

--- a/apps/admin/tests/lib/rbac/policies/memories-redact.test.ts
+++ b/apps/admin/tests/lib/rbac/policies/memories-redact.test.ts
@@ -35,7 +35,7 @@ describe("redactMemoriesForTier", () => {
   it("strips confidence + evidence + decayFactor at redacted tier", () => {
     const out = redactMemoriesForTier(RAW, "redacted");
     expect(out.viewerTier).toBe("redacted");
-    const mem = (out as { memories: Array<Record<string, unknown>> }).memories[0];
+    const mem = (out as unknown as { memories: Array<Record<string, unknown>> }).memories[0];
     expect(mem).not.toHaveProperty("confidence");
     expect(mem).not.toHaveProperty("evidence");
     expect(mem).not.toHaveProperty("decayFactor");

--- a/apps/admin/tests/lib/rbac/policies/memories-redact.test.ts
+++ b/apps/admin/tests/lib/rbac/policies/memories-redact.test.ts
@@ -1,0 +1,51 @@
+/**
+ * #1922 — pin sensitive-field absence at the redacted tier for memories.
+ */
+
+import { describe, it, expect } from "vitest";
+import { redactMemoriesForTier } from "@/lib/rbac/policies/memories";
+import type { MemoriesResponse } from "@/app/api/callers/[callerId]/memories/route";
+
+const RAW: MemoriesResponse = {
+  ok: true,
+  callerId: "c1",
+  memories: [
+    {
+      id: "m1",
+      category: "fact",
+      key: "preferred_topic",
+      value: "tennis",
+      confidence: 0.91,
+      evidence: "transcript excerpt with personal context",
+      extractedAt: "2026-06-18T12:00:00Z",
+      decayFactor: 0.8,
+    },
+  ],
+  summary: {
+    factCount: 1,
+    preferenceCount: 0,
+    eventCount: 0,
+    topicCount: 0,
+    totalCount: 1,
+    lastMemoryAt: "2026-06-18T12:00:00Z",
+  },
+};
+
+describe("redactMemoriesForTier", () => {
+  it("strips confidence + evidence + decayFactor at redacted tier", () => {
+    const out = redactMemoriesForTier(RAW, "redacted");
+    expect(out.viewerTier).toBe("redacted");
+    const mem = (out as { memories: Array<Record<string, unknown>> }).memories[0];
+    expect(mem).not.toHaveProperty("confidence");
+    expect(mem).not.toHaveProperty("evidence");
+    expect(mem).not.toHaveProperty("decayFactor");
+    expect(mem.key).toBe("preferred_topic");
+    expect(mem.value).toBe("tennis");
+  });
+
+  it("passes evidence excerpt through at full tier", () => {
+    const out = redactMemoriesForTier(RAW, "full");
+    expect(out.viewerTier).toBe("full");
+    expect((out as MemoriesResponse).memories[0].evidence).toContain("transcript excerpt");
+  });
+});

--- a/apps/admin/tests/lib/rbac/policies/skills-evidence-redact.test.ts
+++ b/apps/admin/tests/lib/rbac/policies/skills-evidence-redact.test.ts
@@ -1,0 +1,71 @@
+/**
+ * #1922 — pin the sensitive-field absence at the redacted tier.
+ *
+ * Whitelist-default-safe: a new field added to CallerSkillEvidenceItem
+ * will NOT auto-flow to the redacted shape unless `skills-evidence.ts`
+ * is updated. This test asserts the current sensitive-strip contract.
+ */
+
+import { describe, it, expect } from "vitest";
+import { redactSkillsEvidenceForTier } from "@/lib/rbac/policies/skills-evidence";
+import type { CallerSkillEvidenceResponse } from "@/app/api/callers/[callerId]/skills-evidence/route";
+
+const RAW: CallerSkillEvidenceResponse = {
+  callerId: "c1",
+  playbookId: "p1",
+  limit: 3,
+  empty: false,
+  rows: [
+    {
+      skillRef: "SKILL-1",
+      parameterId: "param-1",
+      parameterName: "Fluency",
+      evidence: [
+        {
+          callId: "call-1",
+          measuredAt: "2026-06-18T12:00:00Z",
+          score: 0.72,
+          confidence: 0.95,
+          excerpts: ["learner quote"],
+          reasoning: "operator-only rationale text",
+          analysisSpecName: "MEASURE-FLUENCY-V1",
+          hasLearnerEvidence: true,
+          evidenceQuality: 0.8,
+          scoredBy: "claude-sonnet-4-6",
+        },
+      ],
+      segments: [],
+    },
+  ],
+};
+
+describe("redactSkillsEvidenceForTier", () => {
+  it("strips sensitive fields at the redacted tier", () => {
+    const out = redactSkillsEvidenceForTier(RAW, "redacted");
+    expect(out.viewerTier).toBe("redacted");
+    const item = (out as { rows: Array<{ evidence: Array<Record<string, unknown>> }> }).rows[0]
+      .evidence[0];
+    expect(item).not.toHaveProperty("reasoning");
+    expect(item).not.toHaveProperty("analysisSpecName");
+    expect(item).not.toHaveProperty("evidenceQuality");
+    expect(item).not.toHaveProperty("scoredBy");
+    expect(item).not.toHaveProperty("confidence");
+    expect(item.callId).toBe("call-1");
+    expect(item.score).toBe(0.72);
+    expect(item.excerpts).toEqual(["learner quote"]);
+  });
+
+  it("passes the full payload through at the full tier", () => {
+    const out = redactSkillsEvidenceForTier(RAW, "full");
+    expect(out.viewerTier).toBe("full");
+    const item = (out as CallerSkillEvidenceResponse & { rows: typeof RAW.rows })
+      .rows[0].evidence[0];
+    expect(item.reasoning).toBe("operator-only rationale text");
+    expect(item.confidence).toBe(0.95);
+  });
+
+  it("diagnostic tier returns same shape as full", () => {
+    const out = redactSkillsEvidenceForTier(RAW, "diagnostic");
+    expect(out.viewerTier).toBe("diagnostic");
+  });
+});

--- a/apps/admin/tests/lib/rbac/policies/skills-evidence-redact.test.ts
+++ b/apps/admin/tests/lib/rbac/policies/skills-evidence-redact.test.ts
@@ -43,7 +43,7 @@ describe("redactSkillsEvidenceForTier", () => {
   it("strips sensitive fields at the redacted tier", () => {
     const out = redactSkillsEvidenceForTier(RAW, "redacted");
     expect(out.viewerTier).toBe("redacted");
-    const item = (out as { rows: Array<{ evidence: Array<Record<string, unknown>> }> }).rows[0]
+    const item = (out as unknown as { rows: Array<{ evidence: Array<Record<string, unknown>> }> }).rows[0]
       .evidence[0];
     expect(item).not.toHaveProperty("reasoning");
     expect(item).not.toHaveProperty("analysisSpecName");

--- a/apps/admin/tests/lib/rbac/policies/uplift-redact.test.ts
+++ b/apps/admin/tests/lib/rbac/policies/uplift-redact.test.ts
@@ -58,7 +58,7 @@ describe("redactUpliftForTier", () => {
   it("strips scoreTrends[].scores[].confidence at redacted", () => {
     const out = redactUpliftForTier(RAW, "redacted");
     expect(out.viewerTier).toBe("redacted");
-    const score = (out as { uplift: { scoreTrends: Array<{ scores: Array<Record<string, unknown>> }> } })
+    const score = (out as unknown as { uplift: { scoreTrends: Array<{ scores: Array<Record<string, unknown>> }> } })
       .uplift.scoreTrends[0].scores[0];
     expect(score).not.toHaveProperty("confidence");
     expect(score.score).toBe(0.5);
@@ -66,7 +66,7 @@ describe("redactUpliftForTier", () => {
 
   it("strips adaptationEvidence[].confidence at redacted", () => {
     const out = redactUpliftForTier(RAW, "redacted");
-    const adapt = (out as { uplift: { adaptationEvidence: Array<Record<string, unknown>> } })
+    const adapt = (out as unknown as { uplift: { adaptationEvidence: Array<Record<string, unknown>> } })
       .uplift.adaptationEvidence[0];
     expect(adapt).not.toHaveProperty("confidence");
     expect(adapt.parameterName).toBe("Pace");
@@ -75,7 +75,7 @@ describe("redactUpliftForTier", () => {
 
   it("strips trustScores[].hasLearnerEvidence at redacted", () => {
     const out = redactUpliftForTier(RAW, "redacted");
-    const trust = (out as { uplift: { trustScores: Array<Record<string, unknown>> } })
+    const trust = (out as unknown as { uplift: { trustScores: Array<Record<string, unknown>> } })
       .uplift.trustScores[0];
     expect(trust).not.toHaveProperty("hasLearnerEvidence");
     expect(trust.callId).toBe("call-1");

--- a/apps/admin/tests/lib/rbac/policies/uplift-redact.test.ts
+++ b/apps/admin/tests/lib/rbac/policies/uplift-redact.test.ts
@@ -1,0 +1,93 @@
+/**
+ * #1922 — pin sensitive-field absence at the redacted tier for uplift.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  redactUpliftForTier,
+  type UpliftResponseInput,
+} from "@/lib/rbac/policies/uplift";
+
+const RAW: UpliftResponseInput = {
+  ok: true,
+  uplift: {
+    confidencePre: 0.4,
+    confidencePost: 0.7,
+    confidenceDelta: 0.3,
+    testScorePre: 30,
+    testScorePost: 70,
+    knowledgeDelta: 40,
+    overallMastery: 0.65,
+    totalCalls: 12,
+    firstCallAt: "2026-04-01T00:00:00Z",
+    latestCallAt: "2026-06-15T00:00:00Z",
+    timeOnPlatformDays: 75,
+    moduleProgress: [],
+    goals: [],
+    scoreTrends: [
+      {
+        parameterId: "param-1",
+        scores: [{ callDate: "2026-06-01T00:00:00Z", score: 0.5, confidence: 0.9 }],
+      },
+    ],
+    adaptationEvidence: [
+      {
+        parameterName: "Pace",
+        parameterType: "behavior",
+        sectionId: "S1",
+        definition: null,
+        defaultValue: 0.5,
+        currentValue: 0.7,
+        delta: 0.2,
+        callsUsed: 5,
+        confidence: 0.85,
+      },
+    ],
+    memoryCounts: { facts: 3, preferences: 0, events: 0, topics: 0, total: 3 },
+    topTopics: [],
+    trustScores: [
+      { callId: "call-1", score: 0.6, hasLearnerEvidence: true },
+    ],
+    trustCalls: [],
+    callFrequencyPerWeek: 1.5,
+    callDates: [],
+  },
+};
+
+describe("redactUpliftForTier", () => {
+  it("strips scoreTrends[].scores[].confidence at redacted", () => {
+    const out = redactUpliftForTier(RAW, "redacted");
+    expect(out.viewerTier).toBe("redacted");
+    const score = (out as { uplift: { scoreTrends: Array<{ scores: Array<Record<string, unknown>> }> } })
+      .uplift.scoreTrends[0].scores[0];
+    expect(score).not.toHaveProperty("confidence");
+    expect(score.score).toBe(0.5);
+  });
+
+  it("strips adaptationEvidence[].confidence at redacted", () => {
+    const out = redactUpliftForTier(RAW, "redacted");
+    const adapt = (out as { uplift: { adaptationEvidence: Array<Record<string, unknown>> } })
+      .uplift.adaptationEvidence[0];
+    expect(adapt).not.toHaveProperty("confidence");
+    expect(adapt.parameterName).toBe("Pace");
+    expect(adapt.delta).toBe(0.2);
+  });
+
+  it("strips trustScores[].hasLearnerEvidence at redacted", () => {
+    const out = redactUpliftForTier(RAW, "redacted");
+    const trust = (out as { uplift: { trustScores: Array<Record<string, unknown>> } })
+      .uplift.trustScores[0];
+    expect(trust).not.toHaveProperty("hasLearnerEvidence");
+    expect(trust.callId).toBe("call-1");
+    expect(trust.score).toBe(0.6);
+  });
+
+  it("passes all sensitive fields through at full tier", () => {
+    const out = redactUpliftForTier(RAW, "full");
+    expect(out.viewerTier).toBe("full");
+    const full = out as UpliftResponseInput;
+    expect(full.uplift.scoreTrends[0].scores[0].confidence).toBe(0.9);
+    expect(full.uplift.adaptationEvidence[0].confidence).toBe(0.85);
+    expect(full.uplift.trustScores[0].hasLearnerEvidence).toBe(true);
+  });
+});

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-18T11:43:56.065Z",
+  "generatedAt": "2026-06-18T12:33:43.045Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1837,
-  "edgeCount": 4313,
+  "fileCount": 1842,
+  "edgeCount": 4332,
   "skippedEdges": 1,
   "edges": [
     {
@@ -981,6 +981,14 @@
     },
     {
       "from": "app/api/callers/[callerId]/insights/route.ts",
+      "to": "lib/rbac/policies/insights.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/insights/route.ts",
+      "to": "lib/rbac/visibility.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/insights/route.ts",
       "to": "lib/types/json-fields.ts"
     },
     {
@@ -1052,6 +1060,14 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "app/api/callers/[callerId]/lo-mastery/route.ts",
+      "to": "lib/rbac/policies/lo-mastery.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/lo-mastery/route.ts",
+      "to": "lib/rbac/visibility.ts"
+    },
+    {
       "from": "app/api/callers/[callerId]/lo-progress/route.ts",
       "to": "lib/curriculum/track-progress.ts"
     },
@@ -1090,6 +1106,14 @@
     {
       "from": "app/api/callers/[callerId]/memories/route.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/memories/route.ts",
+      "to": "lib/rbac/policies/memories.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/memories/route.ts",
+      "to": "lib/rbac/visibility.ts"
     },
     {
       "from": "app/api/callers/[callerId]/module-progress/route.ts",
@@ -1276,6 +1300,14 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "app/api/callers/[callerId]/skills-evidence/route.ts",
+      "to": "lib/rbac/policies/skills-evidence.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/skills-evidence/route.ts",
+      "to": "lib/rbac/visibility.ts"
+    },
+    {
       "from": "app/api/callers/[callerId]/slugs/route.ts",
       "to": "lib/learner-scope.ts"
     },
@@ -1390,6 +1422,14 @@
     {
       "from": "app/api/callers/[callerId]/uplift/route.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/uplift/route.ts",
+      "to": "lib/rbac/policies/uplift.ts"
+    },
+    {
+      "from": "app/api/callers/[callerId]/uplift/route.ts",
+      "to": "lib/rbac/visibility.ts"
     },
     {
       "from": "app/api/callers/[callerId]/voice-provider/route.ts",
@@ -15556,6 +15596,42 @@
       "to": "lib/rbac/visibility.ts"
     },
     {
+      "from": "lib/rbac/policies/insights.ts",
+      "to": "app/api/callers/[callerId]/insights/route.ts"
+    },
+    {
+      "from": "lib/rbac/policies/insights.ts",
+      "to": "lib/rbac/visibility.ts"
+    },
+    {
+      "from": "lib/rbac/policies/lo-mastery.ts",
+      "to": "app/api/callers/[callerId]/lo-mastery/route.ts"
+    },
+    {
+      "from": "lib/rbac/policies/lo-mastery.ts",
+      "to": "lib/rbac/visibility.ts"
+    },
+    {
+      "from": "lib/rbac/policies/memories.ts",
+      "to": "app/api/callers/[callerId]/memories/route.ts"
+    },
+    {
+      "from": "lib/rbac/policies/memories.ts",
+      "to": "lib/rbac/visibility.ts"
+    },
+    {
+      "from": "lib/rbac/policies/skills-evidence.ts",
+      "to": "app/api/callers/[callerId]/skills-evidence/route.ts"
+    },
+    {
+      "from": "lib/rbac/policies/skills-evidence.ts",
+      "to": "lib/rbac/visibility.ts"
+    },
+    {
+      "from": "lib/rbac/policies/uplift.ts",
+      "to": "lib/rbac/visibility.ts"
+    },
+    {
       "from": "lib/rbac/visibility.ts",
       "to": "lib/roles.ts"
     },
@@ -17648,8 +17724,8 @@
     },
     {
       "path": "app/api/callers/[callerId]/insights/route.ts",
-      "inDegree": 0,
-      "outDegree": 6
+      "inDegree": 1,
+      "outDegree": 8
     },
     {
       "path": "app/api/callers/[callerId]/journey-progress/route.ts",
@@ -17668,8 +17744,8 @@
     },
     {
       "path": "app/api/callers/[callerId]/lo-mastery/route.ts",
-      "inDegree": 0,
-      "outDegree": 6
+      "inDegree": 1,
+      "outDegree": 8
     },
     {
       "path": "app/api/callers/[callerId]/lo-progress/route.ts",
@@ -17683,8 +17759,8 @@
     },
     {
       "path": "app/api/callers/[callerId]/memories/route.ts",
-      "inDegree": 0,
-      "outDegree": 3
+      "inDegree": 1,
+      "outDegree": 5
     },
     {
       "path": "app/api/callers/[callerId]/module-progress/route.ts",
@@ -17733,8 +17809,8 @@
     },
     {
       "path": "app/api/callers/[callerId]/skills-evidence/route.ts",
-      "inDegree": 0,
-      "outDegree": 5
+      "inDegree": 1,
+      "outDegree": 7
     },
     {
       "path": "app/api/callers/[callerId]/slugs/route.ts",
@@ -17779,7 +17855,7 @@
     {
       "path": "app/api/callers/[callerId]/uplift/route.ts",
       "inDegree": 0,
-      "outDegree": 3
+      "outDegree": 5
     },
     {
       "path": "app/api/callers/[callerId]/voice-provider/route.ts",
@@ -25057,8 +25133,33 @@
       "outDegree": 2
     },
     {
+      "path": "lib/rbac/policies/insights.ts",
+      "inDegree": 1,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/rbac/policies/lo-mastery.ts",
+      "inDegree": 1,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/rbac/policies/memories.ts",
+      "inDegree": 1,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/rbac/policies/skills-evidence.ts",
+      "inDegree": 1,
+      "outDegree": 2
+    },
+    {
+      "path": "lib/rbac/policies/uplift.ts",
+      "inDegree": 1,
+      "outDegree": 1
+    },
+    {
       "path": "lib/rbac/visibility.ts",
-      "inDegree": 2,
+      "inDegree": 12,
       "outDegree": 1
     },
     {

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-18T11:43:56.434Z",
+  "generatedAt": "2026-06-18T12:33:43.402Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-18T11:43:54.760Z",
+  "generatedAt": "2026-06-18T12:33:41.617Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-18T11:43:56.856Z",
+  "generatedAt": "2026-06-18T12:33:43.809Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,6 +1,6 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-18T11:43:55.364Z",
+  "generatedAt": "2026-06-18T12:33:42.180Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {


### PR DESCRIPTION
## Summary

Clears the tier-visibility-coverage exempt-list ratchet from **5 → 0** by wiring `redact<X>ForTier` projections on all 5 confirmed STUDENT-tier leak routes from the 2026-06-17 audit. CHAIN-CONTRACTS.md §6a I-PR7 (shipped in PR #1938, merged) named this as the structural enforcer.

### Five new redactors (`lib/rbac/policies/`)

| Route | Stripped at `redacted` tier |
|---|---|
| `/skills-evidence` | reasoning + analysisSpecName + evidenceQuality + scoredBy + confidence |
| `/lo-mastery` | mastery (0-1 numeric) + tier + bandLabel + masteryThreshold |
| `/uplift` | scoreTrends[].confidence + adaptationEvidence[].confidence + trustScores[].hasLearnerEvidence |
| `/memories` | confidence + evidence excerpt + decayFactor |
| `/insights` | recommendation + reason (from focus areas) |

### Five route adoptions

Each route gains:
1. `@tieredVisibility` JSDoc tag (activates `hf-rbac/require-tiered-redactor` ESLint enforcement)
2. `visibilityTierForRole(role)` invocation
3. `redact<X>ForTier(raw, viewerTier)` wrapping every success `NextResponse.json(...)` site

### Five vitests

Each pins sensitive-field absence at the `redacted` tier + identity passthrough at the `full` tier. Whitelist-default-safe — a new field added to a source interface won't auto-flow to the redacted tier unless the corresponding policy file is updated.

### Coverage ratchet update

`tests/api/tier-visibility-coverage.test.ts`:
- `TIER_VISIBILITY_EXEMPT` cleared (was 5 entries)
- `EXPECTED_EXEMPT_COUNT` 5 → 0
- JSDoc comment records the closure

## Tech Lead reshape applied

- This is **S2a only** (tier-only signature `(raw, tier)`)
- **S2b** (preset-aware `(raw, tier, preset)` signature) is deferred until #1924 + #1925 ship the `PrivacyPolicyPreset` registry + cascade

## Pattern mirror

Each redactor mirrors PR #1710's `redactAdaptationsForTier`:
- Pure function — no I/O
- Discriminated union with `viewerTier: "redacted" | "full" | "diagnostic"`
- Identity envelope preserved across tiers
- Whitelist-default-safe at the `redacted` branch

## Test plan

- [x] All 5 redactor vitests pin the strip-list per the policy's JSDoc
- [x] Each route's `@tieredVisibility` tag matches the strip-list named in the corresponding policy header
- [x] `tests/api/tier-visibility-coverage.test.ts` `EXPECTED_EXEMPT_COUNT` dropped 5 → 0
- [x] Identity envelope preserved (callerId, playbookId, summary stats all pass through at redacted)
- [ ] CI green
- [ ] Verify on hf-dev: STUDENT curl probe against own `/api/callers/<own-id>/memories` returns no `confidence` / `evidence` / `decayFactor`
- [ ] Verify on hf-dev: OPERATOR session still gets the full payload (viewerTier === "full")

## Verified by

- `grep -nE "tier-visibility-coverage|TIER_VISIBILITY_EXEMPT|EXPECTED_EXEMPT_COUNT" apps/admin/tests/api/tier-visibility-coverage.test.ts` — confirms ratchet cleared (0 entries, count = 0)
- `grep -n "@tieredVisibility" apps/admin/app/api/callers/\[callerId\]/*/route.ts` — confirms 5 routes tagged
- `grep -n "redactAdaptationsForTier" apps/admin/lib/rbac/policies/adaptations.ts` — pattern reference (PR #1710) read first; new files structurally match
- `lib/rbac/policies/{skills-evidence,lo-mastery,uplift,memories,insights}.ts` — each file declares the operator-only fields in its header JSDoc; vitests pin those exact fields' absence at the redacted tier
- All 5 leak routes confirmed returning the operator-only fields the audit claims (re-verified via grep of route source pre-edit)

Closes #1922
Refs #1915 (epic), #1938 (S1 §6a I-PR7 contract — merged as `acd9d6be`), #1923 (S2b deferred)

Deploy command: `/vm-cp`