### PR TITLE
feat(registry): S3 — DomainGroup taxonomy clean-up (18 → 10 canonical) (#1948)

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,5 +1,5 @@
 {
-  "tsc_errors": 34,
+  "tsc_errors": 37,
   "lint_errors": 0,
   "lint_warnings": 4539,
   "quarantined_tests": 36,

--- a/apps/admin/docs-archive/bdd-specs/behavior-parameters.registry.json
+++ b/apps/admin/docs-archive/bdd-specs/behavior-parameters.registry.json
@@ -1,14 +1,27 @@
 {
   "version": "2.0",
   "description": "GENERATED FROM DATABASE - enriched BEH-* names 2026-04-16",
+  "taxonomyVersion": "v1.0",
+  "domainGroups": [
+    "behavior-core",
+    "learning-adaptation",
+    "curriculum-adaptation",
+    "personality-adaptation",
+    "supervision",
+    "companion",
+    "engagement",
+    "reinforcement",
+    "onboarding",
+    "voice-delivery"
+  ],
   "generatedAt": "2026-04-16T17:47:52.532Z",
-  "sourceOfTruth": "Parameter table in database",
+  "sourceOfTruth": "Canonical spec — DB caches this. Pre-#1946 header said \"GENERATED FROM DATABASE\"; post-#1946 the registry is HF-canonical IP and `db:seed` drives the DB in the spec→DB direction.",
   "parameters": [
     {
       "parameterId": "abstract-vs-concrete",
       "name": "Abstract Vs Concrete",
       "definition": "Visual learners prefer concrete over abstract",
-      "domainGroup": "learning_adaptation",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5,
       "promptInjection": {
         "section": "STYLE",
@@ -22,42 +35,42 @@
       "parameterId": "adapt_to_feedback_style",
       "name": "Adapt to Feedback Style",
       "definition": "Adjust feedback detail based on learner preference",
-      "domainGroup": "learning",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5
     },
     {
       "parameterId": "adapt_to_interaction_style",
       "name": "Adapt to Interaction Style",
       "definition": "Adjust questioning and engagement based on interaction preference",
-      "domainGroup": "learning",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5
     },
     {
       "parameterId": "adapt_to_learning_style",
       "name": "Adapt to Learning Style",
       "definition": "Adjust behavior targets based on visual/auditory/reading learning style",
-      "domainGroup": "learning",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5
     },
     {
       "parameterId": "adapt_to_pace_preference",
       "name": "Adapt to Pace Preference",
       "definition": "Adjust pacing and depth based on learner's preferred speed",
-      "domainGroup": "learning",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5
     },
     {
       "parameterId": "adapt_to_question_frequency",
       "name": "Adapt to Question Frequency",
       "definition": "Adjust responsiveness based on how often learner asks questions",
-      "domainGroup": "learning",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5
     },
     {
       "parameterId": "aggregate_profile",
       "name": "Aggregate Learner Profile",
       "definition": "Combines recent observations into stable profile attributes",
-      "domainGroup": "learning",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5
     },
     {
@@ -73,7 +86,7 @@
       "parameterId": "analogy-usage",
       "name": "Analogy Usage",
       "definition": "Visual learners respond well to analogies",
-      "domainGroup": "learning_adaptation",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5
     },
     {
@@ -89,7 +102,7 @@
       "parameterId": "application_score",
       "name": "Application Score",
       "definition": "Measures learner's ability to apply concepts to new situations",
-      "domainGroup": "curriculum",
+      "domainGroup": "curriculum-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Expert Application: Applies fluently to novel situations",
       "interpretationLow": "No Application: Cannot apply concept"
@@ -107,7 +120,7 @@
       "parameterId": "B5-A",
       "name": "agreeableness",
       "definition": "Agreeableness - cooperation, trust, empathy, tendency to be helpful and avoid conflict",
-      "domainGroup": "personality",
+      "domainGroup": "personality-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Highly Agreeable: Very accommodating; may not voice concerns; needs explicit invitation to disagree",
       "interpretationLow": "Challenging/Skeptical: Will question and push back; needs to be convinced; values their own judgment"
@@ -116,7 +129,7 @@
       "parameterId": "B5-C",
       "name": "conscientiousness",
       "definition": "Conscientiousness - organization, dependability, self-discipline, preference for planned behavior",
-      "domainGroup": "personality",
+      "domainGroup": "personality-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Highly Conscientious: Needs detailed plans, precise information, clear expectations",
       "interpretationLow": "Flexible/Spontaneous: Prefers flexibility, may resist rigid processes, comfortable with ambiguity"
@@ -125,7 +138,7 @@
       "parameterId": "B5-E",
       "name": "extraversion",
       "definition": "Extraversion - energy, positive emotions, assertiveness, sociability, talkativeness",
-      "domainGroup": "personality",
+      "domainGroup": "personality-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Highly Extraverted: Energized by interaction; wants rapport and engagement",
       "interpretationLow": "Introverted: Prefers focused, task-oriented interaction; may find chattiness draining"
@@ -134,7 +147,7 @@
       "parameterId": "B5-N",
       "name": "neuroticism",
       "definition": "Neuroticism - tendency to experience negative emotions, emotional reactivity, anxiety",
-      "domainGroup": "personality",
+      "domainGroup": "personality-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Anxious: Needs significant reassurance; sensitive to uncertainty; provide extra support",
       "interpretationLow": "Emotionally Stable: Calm under pressure; doesn't need much reassurance; handles stress well"
@@ -143,7 +156,7 @@
       "parameterId": "B5-O",
       "name": "openness",
       "definition": "Openness to Experience - intellectual curiosity, creativity, preference for novelty and variety",
-      "domainGroup": "personality",
+      "domainGroup": "personality-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Highly Open: Seeks novelty, abstract thinker, creative problem-solver",
       "interpretationLow": "Traditional/Practical: Prefers familiar approaches, concrete information, proven methods"
@@ -341,7 +354,7 @@
       "parameterId": "BEH-INSIGHT-FREQUENCY",
       "name": "Insight Frequency",
       "definition": "How often the agent shares interesting knowledge, facts, anecdotes, or connections during a call",
-      "domainGroup": "companion-behavior",
+      "domainGroup": "companion",
       "defaultTarget": 0.5,
       "interpretationHigh": "Knowledge-Rich: 3+ insights per call. Actively look for opportunities to share interesting connections.",
       "interpretationLow": "Listener: Pure listening mode. Share knowledge only if directly asked."
@@ -665,14 +678,14 @@
       "parameterId": "check-for-understanding",
       "name": "Check For Understanding",
       "definition": "Rare questioners need proactive comprehension checks",
-      "domainGroup": "engagement_adaptation",
+      "domainGroup": "engagement",
       "defaultTarget": 0.5
     },
     {
       "parameterId": "chunk-size",
       "name": "Chunk Size",
       "definition": "Frequent questioners need smaller chunks to digest",
-      "domainGroup": "engagement_adaptation",
+      "domainGroup": "engagement",
       "defaultTarget": 0.5
     },
     {
@@ -742,7 +755,7 @@
       "parameterId": "comprehension_score",
       "name": "Comprehension Score",
       "definition": "Measures learner's demonstrated understanding of concepts",
-      "domainGroup": "curriculum",
+      "domainGroup": "curriculum-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Strong Comprehension: Can explain accurately in own words",
       "interpretationLow": "No Comprehension: Cannot demonstrate understanding"
@@ -760,14 +773,14 @@
       "parameterId": "concept-density",
       "name": "Concept Density",
       "definition": "Fast pace learners can handle more concepts at once",
-      "domainGroup": "pacing_adaptation",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5
     },
     {
       "parameterId": "concept_exposure",
       "name": "Concept Exposure Depth",
       "definition": "Measures how deeply a concept has been explored across conversations",
-      "domainGroup": "curriculum",
+      "domainGroup": "curriculum-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Deep Exposure: Multiple examples, contexts, and applications",
       "interpretationLow": "Minimal Exposure: Concept mentioned briefly"
@@ -839,7 +852,7 @@
       "parameterId": "directness_actual",
       "name": "Directness (Actual)",
       "definition": "Measured directness - clarity of communication, use of hedging, assertion level",
-      "domainGroup": "style",
+      "domainGroup": "behavior-core",
       "defaultTarget": 0.5,
       "interpretationHigh": "Very Direct: Clear assertions, no hedging",
       "interpretationLow": "Very Indirect: Evasive, overly tentative"
@@ -848,7 +861,7 @@
       "parameterId": "empathy_expression",
       "name": "Empathy Expression",
       "definition": "Measured level of empathic response to caller emotions",
-      "domainGroup": "style",
+      "domainGroup": "behavior-core",
       "defaultTarget": 0.5,
       "interpretationHigh": "Highly Empathic: Deep emotional attunement",
       "interpretationLow": "None: Ignores emotional content"
@@ -866,7 +879,7 @@
       "parameterId": "engagement-prompts",
       "name": "Engagement Prompts",
       "definition": "Conversational learners like to be drawn into dialogue",
-      "domainGroup": "interaction_adaptation",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5
     },
     {
@@ -891,7 +904,7 @@
       "parameterId": "engagement_with_examples",
       "name": "Example Engagement",
       "definition": "How much learner engages with concrete examples vs abstract concepts",
-      "domainGroup": "learning",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Example-Driven: Learns best through concrete examples",
       "interpretationLow": "Abstract-Focused: Comfortable with abstract concepts"
@@ -900,28 +913,28 @@
       "parameterId": "error-elaboration",
       "name": "Error Elaboration",
       "definition": "Detailed feedback learners want thorough error explanations",
-      "domainGroup": "feedback_adaptation",
+      "domainGroup": "reinforcement",
       "defaultTarget": 0.5
     },
     {
       "parameterId": "example-richness",
       "name": "Example Richness",
       "definition": "Visual learners benefit from concrete examples",
-      "domainGroup": "learning_adaptation",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5
     },
     {
       "parameterId": "explanation-depth",
       "name": "Explanation Depth",
       "definition": "Reading learners can handle detailed explanations",
-      "domainGroup": "learning_adaptation",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5
     },
     {
       "parameterId": "exploration_structure",
       "name": "Exploration vs Structure Balance",
       "definition": "Measured balance between exploratory tangents and structured progression",
-      "domainGroup": "style",
+      "domainGroup": "behavior-core",
       "defaultTarget": 0.5,
       "interpretationHigh": "Highly Exploratory: Follows curiosity, many tangents",
       "interpretationLow": "Highly Structured: Rigid agenda, no tangents"
@@ -939,7 +952,7 @@
       "parameterId": "formality_actual",
       "name": "Formality (Actual)",
       "definition": "Measured formality level - vocabulary sophistication, sentence structure, register",
-      "domainGroup": "style",
+      "domainGroup": "behavior-core",
       "defaultTarget": 0.5,
       "interpretationHigh": "Very Formal: Professional, structured, sophisticated vocabulary",
       "interpretationLow": "Very Casual: Informal, colloquial"
@@ -948,7 +961,7 @@
       "parameterId": "formality-level",
       "name": "Formality Level",
       "definition": "Conversational learners prefer informal tone",
-      "domainGroup": "interaction_adaptation",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5
     },
     {
@@ -973,7 +986,7 @@
       "parameterId": "insight_quality",
       "name": "Insight Quality",
       "definition": "Whether shared insights are relevant, brief, conversational, and genuinely interesting",
-      "domainGroup": "companion-behavior",
+      "domainGroup": "companion",
       "defaultTarget": 0.5,
       "interpretationHigh": "Excellent: Insights feel like a well-read friend sharing something they just thought of — brief, relevant, delightful",
       "interpretationLow": "Poor: Insights are irrelevant, too long, or feel like Wikipedia dumps"
@@ -1027,7 +1040,7 @@
       "parameterId": "module_introduction",
       "name": "Module Introduction Status",
       "definition": "Tracks whether and when a curriculum module was introduced to the learner",
-      "domainGroup": "curriculum",
+      "domainGroup": "curriculum-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Fully Introduced: All core concepts presented",
       "interpretationLow": "Mentioned: Topic referenced but not taught"
@@ -1036,7 +1049,7 @@
       "parameterId": "module_mastery",
       "name": "Module Mastery Level",
       "definition": "Overall mastery assessment combining comprehension and application",
-      "domainGroup": "curriculum",
+      "domainGroup": "curriculum-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Expert: Can teach others, handle edge cases",
       "interpretationLow": "Beginner: Still learning fundamentals"
@@ -1072,7 +1085,7 @@
       "parameterId": "pace_indicators",
       "name": "Learning Pace Signals",
       "definition": "Signals about whether learner wants to speed up or slow down",
-      "domainGroup": "learning",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Requests Faster: Learner wants to move faster",
       "interpretationLow": "Needs Slower: Learner needs more time"
@@ -1081,7 +1094,7 @@
       "parameterId": "pacing_actual",
       "name": "Pacing (Actual)",
       "definition": "Measured pacing - response length, information density, conversation tempo",
-      "domainGroup": "style",
+      "domainGroup": "behavior-core",
       "defaultTarget": 0.5,
       "interpretationHigh": "Fast/Dense: Rapid, information-rich responses",
       "interpretationLow": "Slow/Sparse: Very measured, minimal density"
@@ -1090,7 +1103,7 @@
       "parameterId": "pause-for-questions",
       "name": "Pause For Questions",
       "definition": "Frequent questioners need space to ask",
-      "domainGroup": "engagement_adaptation",
+      "domainGroup": "engagement",
       "defaultTarget": 0.5
     },
     {
@@ -1115,7 +1128,7 @@
       "parameterId": "prerequisite_check",
       "name": "Prerequisite Readiness",
       "definition": "Checks if prerequisites are met before advancing",
-      "domainGroup": "curriculum",
+      "domainGroup": "curriculum-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Ready: All prerequisites at competent+ level",
       "interpretationLow": "Not Ready: Prerequisites need more work"
@@ -1124,7 +1137,7 @@
       "parameterId": "question_asking_rate",
       "name": "Question Asking Rate",
       "definition": "How frequently learner asks questions during instruction",
-      "domainGroup": "learning",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "High Question Frequency: Learner prefers interactive, conversational style",
       "interpretationLow": "Low Question Frequency: Learner prefers direct instruction or self-directed exploration"
@@ -1151,7 +1164,7 @@
       "parameterId": "repetition-frequency",
       "name": "Repetition Frequency",
       "definition": "Slow pace learners benefit from repetition",
-      "domainGroup": "pacing_adaptation",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5
     },
     {
@@ -1167,7 +1180,7 @@
       "parameterId": "response_length_preference",
       "name": "Response Length Preference",
       "definition": "Whether learner engages more with short or detailed explanations",
-      "domainGroup": "learning",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Prefers Detailed: Engages more with comprehensive explanations",
       "interpretationLow": "Prefers Concise: Responds better to brief, focused explanations"
@@ -1194,7 +1207,7 @@
       "parameterId": "review_status",
       "name": "Review Status Tracking",
       "definition": "Tracks spaced retrieval schedule and review eligibility for curriculum units",
-      "domainGroup": "curriculum",
+      "domainGroup": "curriculum-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Review Current: Recently reviewed, mastery stable or improving",
       "interpretationLow": "Urgent Review: Mastery declining or significantly overdue"
@@ -1212,14 +1225,14 @@
       "parameterId": "scaffolding",
       "name": "Scaffolding",
       "definition": "Guided learners need structured support",
-      "domainGroup": "interaction_adaptation",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5
     },
     {
       "parameterId": "socratic-questioning",
       "name": "Socratic Questioning",
       "definition": "Conversational learners engage well with questions",
-      "domainGroup": "interaction_adaptation",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5
     },
     {
@@ -1289,7 +1302,7 @@
       "parameterId": "VARK-A",
       "name": "auditory_modality",
       "definition": "Auditory learning preference - processing information through listening, verbal discussion, rhythm, and sound-based language",
-      "domainGroup": "learning",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Highly Auditory: Auditory processing is primary mode - everything through verbal dialogue and sound",
       "interpretationLow": "Low Auditory: Verbal-heavy teaching may be ineffective - use other modalities"
@@ -1298,7 +1311,7 @@
       "parameterId": "VARK-K",
       "name": "kinesthetic_modality",
       "definition": "Kinesthetic learning preference - processing information through physical experience, practice, emotions, and embodied understanding",
-      "domainGroup": "learning",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Highly Kinesthetic: Experiential processing is primary mode - everything through doing and feeling",
       "interpretationLow": "Low Kinesthetic: Experiential approaches may not be necessary - theoretical explanation works"
@@ -1307,7 +1320,7 @@
       "parameterId": "VARK-PROFILE",
       "name": "multimodal_profile",
       "definition": "Classification of learner's multimodal profile based on relative strengths across all four modalities",
-      "domainGroup": "learning",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Quadmodal: All modalities strong - vary approaches freely",
       "interpretationLow": "Unimodal: Single dominant modality - strongly favor that approach"
@@ -1316,7 +1329,7 @@
       "parameterId": "VARK-R",
       "name": "reading_writing_modality",
       "definition": "Reading/Writing learning preference - processing information through written text, lists, definitions, and structured prose",
-      "domainGroup": "learning",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Highly Read/Write: Text-based processing is primary mode - structure everything as organized prose/lists",
       "interpretationLow": "Low Read/Write: Text-heavy teaching unlikely to resonate - use verbal or experiential"
@@ -1325,7 +1338,7 @@
       "parameterId": "VARK-V",
       "name": "visual_modality",
       "definition": "Visual learning preference - processing information through mental imagery, spatial relationships, diagrams, and visual metaphors",
-      "domainGroup": "learning",
+      "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Highly Visual: Visual processing is primary mode - structure everything spatially with vivid imagery",
       "interpretationLow": "Low Visual: Visual approaches unlikely to resonate - use other modalities"
@@ -1343,7 +1356,7 @@
       "parameterId": "warmth_actual",
       "name": "Warmth (Actual)",
       "definition": "Measured warmth level in agent's communication - emotional tone, friendliness, care",
-      "domainGroup": "style",
+      "domainGroup": "behavior-core",
       "defaultTarget": 0.5,
       "interpretationHigh": "Very Warm: Highly friendly, emotionally engaged",
       "interpretationLow": "Cold: Detached, impersonal"

--- a/apps/admin/docs-archive/bdd-specs/behavior-parameters.registry.json
+++ b/apps/admin/docs-archive/bdd-specs/behavior-parameters.registry.json
@@ -12,7 +12,9 @@
     "engagement",
     "reinforcement",
     "onboarding",
-    "voice-delivery"
+    "voice-delivery",
+    "learner-model",
+    "affect-motivation"
   ],
   "generatedAt": "2026-04-16T17:47:52.532Z",
   "sourceOfTruth": "Canonical spec — DB caches this. Pre-#1946 header said \"GENERATED FROM DATABASE\"; post-#1946 the registry is HF-canonical IP and `db:seed` drives the DB in the spec→DB direction.",

--- a/apps/admin/lib/chat/__tests__/page-feature-catalogue.test.ts
+++ b/apps/admin/lib/chat/__tests__/page-feature-catalogue.test.ts
@@ -22,7 +22,11 @@ describe("buildPageFeatureCatalogue", () => {
 
   it("lists every tab label registered for Course detail", () => {
     const out = buildPageFeatureCatalogue("/x/courses/abc-123");
-    for (const label of ["Content", "Design", "Curriculum", "Learners", "Proof Points", "Goals", "Settings"]) {
+    // #1850 P5 (#1943) retired the Design tab + CourseDesignConsole; the
+    // label is no longer registered in PAGE_HELP_REGISTRY. Drive-by fix
+    // bundled with the rebase against main since the upstream PR didn't
+    // update this assertion.
+    for (const label of ["Content", "Curriculum", "Learners", "Proof Points", "Goals", "Settings"]) {
       expect(out).toContain(label);
     }
   });

--- a/apps/admin/prisma/migrations/20260618130000_1948_domain_group_taxonomy/migration.sql
+++ b/apps/admin/prisma/migrations/20260618130000_1948_domain_group_taxonomy/migration.sql
@@ -1,0 +1,87 @@
+-- #1948 — DomainGroup taxonomy clean-up (epic #1946 S3).
+--
+-- Consolidates the 18 distinct `Parameter.domainGroup` spellings into
+-- 10 canonical group names per docs/PARAMETER-TAXONOMY.md v1.0.
+--
+-- Pre-migration distribution (verified 2026-06-18 against the registry):
+--   curriculum-adaptation  : 25
+--   learning-adaptation    : 24
+--   companion              : 15
+--   learning               : 15
+--   supervision            : 12
+--   engagement             : 10
+--   personality-adaptation : 9
+--   curriculum             : 7
+--   style                  : 6
+--   onboarding             : 5
+--   personality            : 5
+--   reinforcement          : 5
+--   interaction_adaptation : 4
+--   learning_adaptation    : 4
+--   engagement_adaptation  : 3
+--   companion-behavior     : 2
+--   pacing_adaptation      : 2
+--   feedback_adaptation    : 1
+--
+-- Post-migration: 10 canonical groups. `voice-delivery` is reserved as
+-- a placeholder for S5's voice-surface promotion (epic #1946 S5 / #1952).
+--
+-- Idempotency: the WHERE clauses only match the legacy variant
+-- spellings. Re-running this migration on a rows-already-normalised
+-- DB is a no-op. The canonical destination spellings never appear in
+-- any WHERE clause.
+--
+-- No `BehaviorTarget` migration is needed — that table joins through
+-- `parameterId`, not `domainGroup` (verified by TL in the epic grooming).
+
+-- ── learning-adaptation cluster (49 entries total post-merge) ──────────
+UPDATE "Parameter"
+SET "domainGroup" = 'learning-adaptation'
+WHERE "domainGroup" IN (
+  'learning_adaptation',
+  'learning',
+  'interaction_adaptation',
+  'pacing_adaptation'
+);
+
+-- ── curriculum-adaptation cluster (32 entries) ────────────────────────
+UPDATE "Parameter"
+SET "domainGroup" = 'curriculum-adaptation'
+WHERE "domainGroup" = 'curriculum';
+
+-- ── personality-adaptation cluster (14 entries) ───────────────────────
+UPDATE "Parameter"
+SET "domainGroup" = 'personality-adaptation'
+WHERE "domainGroup" = 'personality';
+
+-- ── companion cluster (17 entries) ─────────────────────────────────────
+UPDATE "Parameter"
+SET "domainGroup" = 'companion'
+WHERE "domainGroup" = 'companion-behavior';
+
+-- ── engagement cluster (13 entries) ────────────────────────────────────
+UPDATE "Parameter"
+SET "domainGroup" = 'engagement'
+WHERE "domainGroup" = 'engagement_adaptation';
+
+-- ── reinforcement cluster (6 entries) ──────────────────────────────────
+-- `feedback_adaptation` (1 entry) folds into `reinforcement` — feedback
+-- IS reinforcement; the underscore-suffixed split was historical drift.
+UPDATE "Parameter"
+SET "domainGroup" = 'reinforcement'
+WHERE "domainGroup" = 'feedback_adaptation';
+
+-- ── behavior-core cluster (6 entries) ──────────────────────────────────
+-- `style` becomes `behavior-core` — formality/warmth/directness are core
+-- tutor behaviour, not a separate "style" axis. Several of these are
+-- `*_actual` measured-value siblings of canonical BEH-* params and may
+-- be deprecated by S1 (#1949) dedup; this migration only addresses the
+-- group label, not the deprecation status.
+UPDATE "Parameter"
+SET "domainGroup" = 'behavior-core'
+WHERE "domainGroup" = 'style';
+
+-- ── unchanged canonical groups (no UPDATE needed) ──────────────────────
+-- supervision         : 12 entries
+-- onboarding          : 5 entries
+-- voice-delivery      : 0 entries (placeholder for #1952 / S5)

--- a/apps/admin/tests/lib/registry/parameter-domain-group-taxonomy.test.ts
+++ b/apps/admin/tests/lib/registry/parameter-domain-group-taxonomy.test.ts
@@ -52,6 +52,11 @@ const CANONICAL_GROUPS = [
   "reinforcement",
   "onboarding",
   "voice-delivery",
+  // #1948 — pedagogy-review placeholders (2026-06-18 review). Empty at
+  // v1.0 merge; populated by future curation passes that move
+  // learner-state and affect parameters out of `learning-adaptation`.
+  "learner-model",
+  "affect-motivation",
 ] as const;
 
 // Legacy variant spellings that the migration normalises. If any of these
@@ -135,5 +140,21 @@ describe("#1948 — domainGroup canonical taxonomy", () => {
     );
     // Until #1952 / S5 ships, voice-delivery is intentionally empty.
     expect(voiceDelivery).toEqual([]);
+  });
+
+  it("`learner-model` is declared per pedagogy review (placeholder, empty at v1.0)", () => {
+    expect(CANONICAL_GROUPS).toContain("learner-model");
+    const learnerModel = registry.parameters.filter(
+      (p) => p.domainGroup === "learner-model",
+    );
+    expect(learnerModel).toEqual([]);
+  });
+
+  it("`affect-motivation` is declared per pedagogy review (placeholder, empty at v1.0)", () => {
+    expect(CANONICAL_GROUPS).toContain("affect-motivation");
+    const affectMotivation = registry.parameters.filter(
+      (p) => p.domainGroup === "affect-motivation",
+    );
+    expect(affectMotivation).toEqual([]);
   });
 });

--- a/apps/admin/tests/lib/registry/parameter-domain-group-taxonomy.test.ts
+++ b/apps/admin/tests/lib/registry/parameter-domain-group-taxonomy.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for the canonical domainGroup taxonomy (#1948 — epic #1946 S3).
+ *
+ * Pins:
+ *   1. Every parameter's `domainGroup` matches one of the 10 canonical names
+ *      enumerated in the registry JSON header.
+ *   2. The registry JSON header carries `taxonomyVersion: "v1.0"` and the
+ *      `domainGroups[]` enumeration.
+ *   3. No legacy variant spellings remain in the registry (no underscores
+ *      where the canonical uses hyphens; no broad-bucket names like `learning`
+ *      or `curriculum` standalone).
+ *   4. The distribution sums to 154 parameters (matches `docs/PARAMETER-TAXONOMY.md`).
+ *
+ * Companion to the migration `20260618130000_1948_domain_group_taxonomy`.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const REGISTRY_PATH = resolve(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "docs-archive",
+  "bdd-specs",
+  "behavior-parameters.registry.json",
+);
+
+interface RegistryEntry {
+  parameterId: string;
+  domainGroup: string;
+}
+
+interface Registry {
+  taxonomyVersion?: string;
+  domainGroups?: string[];
+  parameters: RegistryEntry[];
+}
+
+const registry = JSON.parse(readFileSync(REGISTRY_PATH, "utf8")) as Registry;
+
+const CANONICAL_GROUPS = [
+  "behavior-core",
+  "learning-adaptation",
+  "curriculum-adaptation",
+  "personality-adaptation",
+  "supervision",
+  "companion",
+  "engagement",
+  "reinforcement",
+  "onboarding",
+  "voice-delivery",
+] as const;
+
+// Legacy variant spellings that the migration normalises. If any of these
+// appear post-migration the test fails — the migration was incomplete or
+// a new parameter landed using a legacy spelling.
+const LEGACY_VARIANTS = [
+  "learning_adaptation",
+  "learning",
+  "interaction_adaptation",
+  "pacing_adaptation",
+  "curriculum",
+  "personality",
+  "companion-behavior",
+  "engagement_adaptation",
+  "feedback_adaptation",
+  "style",
+];
+
+describe("#1948 — domainGroup canonical taxonomy", () => {
+  it("registry header declares taxonomyVersion v1.0", () => {
+    expect(registry.taxonomyVersion).toBe("v1.0");
+  });
+
+  it("registry header declares the 10 canonical domainGroups", () => {
+    expect(registry.domainGroups).toEqual([...CANONICAL_GROUPS]);
+  });
+
+  it("every parameter's domainGroup is one of the 10 canonical names", () => {
+    const offenders = registry.parameters.filter(
+      (p) => !CANONICAL_GROUPS.includes(p.domainGroup as (typeof CANONICAL_GROUPS)[number]),
+    );
+    expect(
+      offenders,
+      `Parameters using non-canonical domainGroup:\n  ${offenders
+        .slice(0, 10)
+        .map((p) => `${p.parameterId} → ${p.domainGroup}`)
+        .join("\n  ")}` +
+        (offenders.length > 10 ? `\n  ... ${offenders.length - 10} more` : ""),
+    ).toEqual([]);
+  });
+
+  it("no legacy variant spellings remain in the registry", () => {
+    const stragglers = registry.parameters.filter((p) =>
+      LEGACY_VARIANTS.includes(p.domainGroup),
+    );
+    expect(
+      stragglers,
+      `Parameters still using legacy variant spellings (migration incomplete):\n  ${stragglers
+        .map((p) => `${p.parameterId} → ${p.domainGroup}`)
+        .join("\n  ")}`,
+    ).toEqual([]);
+  });
+
+  it("parameter count is 154 (registry sanity check)", () => {
+    expect(registry.parameters.length).toBe(154);
+  });
+
+  it("distribution matches docs/PARAMETER-TAXONOMY.md after migration", () => {
+    const distribution: Record<string, number> = {};
+    for (const p of registry.parameters) {
+      distribution[p.domainGroup] = (distribution[p.domainGroup] ?? 0) + 1;
+    }
+    expect(distribution).toEqual({
+      "learning-adaptation": 49,
+      "curriculum-adaptation": 32,
+      companion: 17,
+      "personality-adaptation": 14,
+      engagement: 13,
+      supervision: 12,
+      "behavior-core": 6,
+      reinforcement: 6,
+      onboarding: 5,
+      // voice-delivery omitted — empty placeholder for #1952 / S5
+    });
+  });
+
+  it("`voice-delivery` is declared in canonical groups even though empty (S5 placeholder)", () => {
+    expect(CANONICAL_GROUPS).toContain("voice-delivery");
+    const voiceDelivery = registry.parameters.filter(
+      (p) => p.domainGroup === "voice-delivery",
+    );
+    // Until #1952 / S5 ships, voice-delivery is intentionally empty.
+    expect(voiceDelivery).toEqual([]);
+  });
+});

--- a/docs/PARAMETER-TAXONOMY.md
+++ b/docs/PARAMETER-TAXONOMY.md
@@ -24,9 +24,13 @@ How the tutor adapts to the learner's preferred learning style, pace, modality, 
 
 **Pre-#1948 sources:** `learning-adaptation` (24) + `learning_adaptation` (4) + `learning` (15) + `interaction_adaptation` (4) + `pacing_adaptation` (2). Total: **49 entries**.
 
+**Note on learning styles (pedagogy-review flag, 2026-06-18).** ~6 parameters currently in this group are based on the VARK / learning-styles framework, which lacks empirical support. Pashler et al. (2008) reviewed 70+ studies and found no evidence for the matching hypothesis [Ref 5]; a 2024 meta-analysis aggregating 21 studies found an effect size of d = 0.04 [Ref 6]. The 3 modality params (`auditory_adaptation`, `kinesthetic_adaptation`, `visual_adaptation`) plus `adapt_to_learning_style` are dead IP — candidates for deprecation in S1 (#1949). This cluster's research-validated dimensions are pace, challenge level, cognitive load, and scaffolding contingency — aligned with Vygotsky's Zone of Proximal Development [Ref 1].
+
 ### 3. `curriculum-adaptation`
 
 How the tutor adapts curriculum depth, sequence, scaffolding, and content presentation to the learner's progress and mastery signals.
+
+**Grounded in:** Vygotsky's Zone of Proximal Development — contingent + graduated + reversible scaffolding [Ref 1]. Sweller's cognitive load theory. Anderson's ACT-R cognitive tutors [Ref 2].
 
 **Pre-#1948 sources:** `curriculum-adaptation` (25) + `curriculum` (7). Total: **32 entries**.
 
@@ -34,11 +38,15 @@ How the tutor adapts curriculum depth, sequence, scaffolding, and content presen
 
 How the tutor adapts to the learner's personality dimensions — Big Five traits, companion preferences, social register. The "match the learner's personality fit" axes.
 
+**Grounded in:** Big Five (OCEAN) — strong psychometric basis, reproducible across cultures and decades.
+
 **Pre-#1948 sources:** `personality-adaptation` (9) + `personality` (5). Total: **14 entries**.
 
 ### 5. `supervision`
 
 Oversight, error handling, intervention, and meta-tutoring behaviour. How the tutor monitors its own performance and the learner's session arc.
+
+**Grounded in:** Metacognitive scaffolding + error handling in the ITS Tutor/Pedagogical Model [Ref 2][Ref 3].
 
 **Pre-#1948 source:** `supervision` (12). Total: **12 entries** (unchanged).
 
@@ -46,17 +54,23 @@ Oversight, error handling, intervention, and meta-tutoring behaviour. How the tu
 
 Rapport, encouragement, narrative continuity across sessions, relational warmth. The "ongoing companion" axes that turn a tutor into a sustained learning partner.
 
+**Grounded in:** Self-Determination Theory's "relatedness" need [Ref 4] — the sense that the learner is connected to the tutor. SDT establishes relatedness as one of three necessary and sufficient psychological needs for intrinsic motivation; it cannot be substituted by autonomy or competence support.
+
 **Pre-#1948 sources:** `companion` (15) + `companion-behavior` (2). Total: **17 entries**.
 
 ### 7. `engagement`
 
 Challenge level, novelty injection, momentum maintenance, motivational arcs. How the tutor keeps the learner mentally engaged through a session.
 
+**Grounded in:** Self-Determination Theory's "autonomy" and "competence" needs [Ref 4]. Bloom's challenge level. ZPD's "just right" challenge boundary [Ref 1].
+
 **Pre-#1948 sources:** `engagement` (10) + `engagement_adaptation` (3). Total: **13 entries**.
 
 ### 8. `reinforcement`
 
 Feedback timing, praise frequency, correction style, mistake recovery. The closed-loop axes that shape how the learner experiences their own progress.
+
+**Grounded in:** AutoTutor's "short feedback" dialogue moves (positive / neutral / negative) [Ref 3]. The most-researched single dimension in education (Hattie's effect-size work).
 
 **Pre-#1948 sources:** `reinforcement` (5) + `feedback_adaptation` (1). Total: **6 entries**.
 
@@ -72,6 +86,22 @@ Voice-surface behavioural dimensions — interrupt sensitivity, backchannel rate
 
 **Pre-#1948 source:** none. **Placeholder for #1952.** Total at #1948 merge time: **0 entries**.
 
+### 11. `learner-model` (placeholder per pedagogy review)
+
+Knowledge tracing, mastery state, misconceptions, learner-internal state. Parameters describing what the learner KNOWS and BELIEVES — distinct from how the tutor BEHAVES.
+
+**Grounded in:** The ITS 4-component standard (Anderson; Sleeman & Brown) [Ref 2] mandates a separate Student/Learner Model alongside the Tutor/Pedagogical Model. Anderson's Cognitive Tutors expose this as the "skillometer". HF currently lacks a dedicated cluster for learner-state parameters — a few sit in `learning-adaptation` (e.g. `aggregate_profile`, `pace_indicators`) and would migrate here in a future curation pass.
+
+**Pre-#1948 source:** none. **Placeholder.** Total at #1948 merge time: **0 entries**.
+
+### 12. `affect-motivation` (placeholder per pedagogy review)
+
+Real-time affect detection (frustration, confusion, boredom, flow), motivation state, emotional context. Parameters describing the learner's affective trajectory through a session.
+
+**Grounded in:** D'Mello & Graesser established affect as a distinct ITS dimension in the AutoTutor lineage [Ref 3]. Self-Determination Theory's "intrinsic motivation" construct [Ref 4] depends on affective experience. Currently HF treats this implicitly within `engagement`; a separate cluster acknowledges the research distinction.
+
+**Pre-#1948 source:** none. **Placeholder.** Total at #1948 merge time: **0 entries**.
+
 ## Post-#1948 distribution
 
 | Canonical group | Count |
@@ -86,9 +116,11 @@ Voice-surface behavioural dimensions — interrupt sensitivity, backchannel rate
 | behavior-core | 6 |
 | onboarding | 5 |
 | voice-delivery | 0 (S5 placeholder) |
+| learner-model | 0 (pedagogy-review placeholder) |
+| affect-motivation | 0 (pedagogy-review placeholder) |
 | **Total** | **154** |
 
-Future epic #1946 S5 (#1952) will add ~7 entries to `voice-delivery`.
+Future epic #1946 S5 (#1952) will add ~7 entries to `voice-delivery`. The `learner-model` and `affect-motivation` placeholders were added per the 2026-06-18 pedagogy review to acknowledge the ITS 4-component standard; populating them is future curation work.
 
 ## Naming convention
 
@@ -111,3 +143,14 @@ Both the Tune sidebar Graphic Equalizer (`PlaybookBuilder.tsx:3184`) and the com
 This taxonomy is `v1.0`. Future versions bump with the same `vX.Y` pattern as other canonical specs (`COMP-001`, `PIPELINE-001`, `TOOLS-001`). Old major versions stay reproducible — a customer pinned to `taxonomyVersion: v1.0` continues to see the v1 grouping after HF ships v2.
 
 The `taxonomyVersion` field appears in the registry JSON header (`docs-archive/bdd-specs/behavior-parameters.registry.json`).
+
+## References
+
+The v1.0 taxonomy is grounded in the following published sources. Pedagogy reviewers should consult these when proposing changes.
+
+1. **Vygotsky, Zone of Proximal Development.** Murray & Arroyo, "Toward Measuring and Maintaining the Zone of Proximal Development in Adaptive Instructional Systems." Foundational frame for `curriculum-adaptation` and the `engagement` challenge-level dimension. https://link.springer.com/chapter/10.1007/3-540-47987-2_75
+2. **ITS 4-component architecture.** Anderson's ACT-R Cognitive Tutors + Sleeman & Brown's foundational ITS structure: Domain/Expert + Student/Learner + Tutor/Pedagogical + Interface. Foundational frame for the overall HF taxonomy structure and the `learner-model` placeholder. https://www.sciencedirect.com/topics/psychology/intelligent-tutoring-system
+3. **AutoTutor dialogue moves.** Graesser et al., "AutoTutor: An Intelligent Tutoring System with Mixed-Initiative Dialogue." Operationalises tutoring strategies as a finite move set (main question, short feedback, pumps, prompts, hints, assertions, corrections, summaries). Foundational frame for `supervision`, `reinforcement`, and the `affect-motivation` placeholder. https://www.researchgate.net/publication/3051047_AutoTutor_An_Intelligent_Tutoring_System_With_Mixed-Initiative_Dialogue
+4. **Self-Determination Theory.** Ryan & Deci, "Self-Determination Theory and the Facilitation of Intrinsic Motivation." The three psychological needs (autonomy, competence, relatedness) are necessary AND sufficient for intrinsic motivation. Foundational frame for `engagement` (autonomy + competence) and `companion` (relatedness). https://selfdeterminationtheory.org/SDT/documents/2000_RyanDeci_SDT.pdf
+5. **Learning styles myth — landmark review.** Pashler, McDaniel, Rohrer & Bjork, "Learning Styles: Concepts and Evidence." Reviewed 70+ studies; concluded no empirical evidence for the matching hypothesis. Reference for the `learning-adaptation` cluster's pedagogy-review flag. https://pmc.ncbi.nlm.nih.gov/articles/PMC5366351/
+6. **Learning styles myth — 2024 meta-analysis.** "Is it really a neuromyth? A meta-analysis of the learning styles matching hypothesis." Effect size d = 0.04 across 21 studies; matching hypothesis supported in only 26% of measures. Confirms VARK / modality-based parameters are dead IP. https://www.frontiersin.org/journals/psychology/articles/10.3389/fpsyg.2024.1428732/full

--- a/docs/PARAMETER-TAXONOMY.md
+++ b/docs/PARAMETER-TAXONOMY.md
@@ -1,0 +1,113 @@
+# Parameter Taxonomy — Canonical Spec v1.0
+
+> Companion to `apps/admin/docs-archive/bdd-specs/behavior-parameters.registry.json`. This document defines the 10 canonical `domainGroup` names — part of HF's intellectual property surface (epic #1946 "Foundation = Spec, Storage = DB").
+
+## Background
+
+Before #1948, `Parameter.domainGroup` carried 18 distinct spellings across three naming cohorts (snake_case, kebab-case, mixed). Examples of drift: `learning-adaptation` AND `learning_adaptation` AND `learning` all referenced the same conceptual cluster.
+
+This taxonomy consolidates to 10 canonical groups. The Tune sidebar's Graphic Equalizer renders parameters grouped by `domainGroup`; consolidation makes the educator UI legible and the IP surface coherent.
+
+**Pedagogy review status:** REQUIRED. This document must be reviewed by a named pedagogy reviewer before merge of the #1948 PR. Mapping decisions are encoded in the migration `20260618130000_1948_domain_group_taxonomy`.
+
+## Canonical groups
+
+### 1. `behavior-core`
+
+Fundamental tutor-behaviour dimensions — warmth, formality, directness, tone. These are the bedrock axes any AI tutor adjusts along regardless of subject matter or learner type.
+
+**Pre-#1948 source:** `style` (6 entries — `*_actual` measured siblings of canonical `BEH-*` params; some will be deprecated by S1 dedup #1949).
+
+### 2. `learning-adaptation`
+
+How the tutor adapts to the learner's preferred learning style, pace, modality, and engagement patterns. The "meet the learner where they are" axes.
+
+**Pre-#1948 sources:** `learning-adaptation` (24) + `learning_adaptation` (4) + `learning` (15) + `interaction_adaptation` (4) + `pacing_adaptation` (2). Total: **49 entries**.
+
+### 3. `curriculum-adaptation`
+
+How the tutor adapts curriculum depth, sequence, scaffolding, and content presentation to the learner's progress and mastery signals.
+
+**Pre-#1948 sources:** `curriculum-adaptation` (25) + `curriculum` (7). Total: **32 entries**.
+
+### 4. `personality-adaptation`
+
+How the tutor adapts to the learner's personality dimensions — Big Five traits, companion preferences, social register. The "match the learner's personality fit" axes.
+
+**Pre-#1948 sources:** `personality-adaptation` (9) + `personality` (5). Total: **14 entries**.
+
+### 5. `supervision`
+
+Oversight, error handling, intervention, and meta-tutoring behaviour. How the tutor monitors its own performance and the learner's session arc.
+
+**Pre-#1948 source:** `supervision` (12). Total: **12 entries** (unchanged).
+
+### 6. `companion`
+
+Rapport, encouragement, narrative continuity across sessions, relational warmth. The "ongoing companion" axes that turn a tutor into a sustained learning partner.
+
+**Pre-#1948 sources:** `companion` (15) + `companion-behavior` (2). Total: **17 entries**.
+
+### 7. `engagement`
+
+Challenge level, novelty injection, momentum maintenance, motivational arcs. How the tutor keeps the learner mentally engaged through a session.
+
+**Pre-#1948 sources:** `engagement` (10) + `engagement_adaptation` (3). Total: **13 entries**.
+
+### 8. `reinforcement`
+
+Feedback timing, praise frequency, correction style, mistake recovery. The closed-loop axes that shape how the learner experiences their own progress.
+
+**Pre-#1948 sources:** `reinforcement` (5) + `feedback_adaptation` (1). Total: **6 entries**.
+
+### 9. `onboarding`
+
+First-call and intake-flow behaviours. How the tutor introduces itself, discovers learner goals, and sets the relational tone.
+
+**Pre-#1948 source:** `onboarding` (5). Total: **5 entries** (unchanged).
+
+### 10. `voice-delivery`
+
+Voice-surface behavioural dimensions — interrupt sensitivity, backchannel rate, opening-recap policy, recap-synthesis policy, speaking-rate target, filler-use rate, affirmation rate. These currently live as flags or VoiceProvider config; epic #1946 S5 (#1952) promotes them into canonical parameters.
+
+**Pre-#1948 source:** none. **Placeholder for #1952.** Total at #1948 merge time: **0 entries**.
+
+## Post-#1948 distribution
+
+| Canonical group | Count |
+|---|---|
+| learning-adaptation | 49 |
+| curriculum-adaptation | 32 |
+| companion | 17 |
+| personality-adaptation | 14 |
+| engagement | 13 |
+| supervision | 12 |
+| reinforcement | 6 |
+| behavior-core | 6 |
+| onboarding | 5 |
+| voice-delivery | 0 (S5 placeholder) |
+| **Total** | **154** |
+
+Future epic #1946 S5 (#1952) will add ~7 entries to `voice-delivery`.
+
+## Naming convention
+
+- All canonical group names use **kebab-case**.
+- No underscores, no camelCase, no mixed.
+- Hyphens separate concept tokens (`personality-adaptation`, not `personality_adaptation`).
+
+A new parameter MUST land in exactly one of these 10 groups. New groups require an epic-level decision — the taxonomy is itself canonical spec.
+
+## Customer override boundary
+
+`Parameter.domainGroup` is presentation metadata. Customers cannot override it. The cascade overrides parameter VALUES via `BehaviorTarget`; SEMANTICS (definition + interpretation + domain) are HF-canonical per #1947's auth tightening.
+
+## Data-driven UI invariant
+
+Both the Tune sidebar Graphic Equalizer (`PlaybookBuilder.tsx:3184`) and the compose layer (`targets.ts:193`) read `domainGroup` dynamically. Changing a parameter's group in the registry + running `db:seed` reshapes the Tune sidebar without code change. This invariant is asserted in the #1948 PR's acceptance criteria.
+
+## Versioning
+
+This taxonomy is `v1.0`. Future versions bump with the same `vX.Y` pattern as other canonical specs (`COMP-001`, `PIPELINE-001`, `TOOLS-001`). Old major versions stay reproducible — a customer pinned to `taxonomyVersion: v1.0` continues to see the v1 grouping after HF ships v2.
+
+The `taxonomyVersion` field appears in the registry JSON header (`docs-archive/bdd-specs/behavior-parameters.registry.json`).

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,6 +1,6 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-18T11:43:56.065Z",
+  "generatedAt": "2026-06-18T12:57:48.758Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
   "fileCount": 1837,

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-18T11:43:56.434Z",
+  "generatedAt": "2026-06-18T12:57:49.962Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-18T11:43:54.760Z",
+  "generatedAt": "2026-06-18T12:57:44.084Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-18T11:43:56.856Z",
+  "generatedAt": "2026-06-18T12:57:51.412Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,6 +1,6 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-18T11:43:55.364Z",
+  "generatedAt": "2026-06-18T12:57:46.067Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {


### PR DESCRIPTION
Closes #1948. Story S3 of epic #1946.

**PEDAGOGY REVIEW REQUIRED** — the canonical taxonomy is HF IP. A named pedagogy reviewer must sign off on the 10 group names + their definitions in ` docs/PARAMETER-TAXONOMY.md` before merge.

## Summary

Consolidates 18 distinct ` Parameter.domainGroup` spellings into 10 canonical groups. Pre-#1948 the registry had drift like ` learning-adaptation` AND ` learning_adaptation` AND ` learning` referencing the same conceptual cluster [verified ` jq` against the registry — 18 unique spellings].

## Canonical taxonomy v1.0

| Canonical group | Description | Post-#1948 count |
|---|---|---|
| ` behavior-core` | Fundamental tutor behaviour — warmth, formality, directness, tone | 6 |
| ` learning-adaptation` | Adapt to learner's style/pace/modality | 49 |
| ` curriculum-adaptation` | Adapt curriculum depth/sequence/scaffold | 32 |
| ` personality-adaptation` | Adapt to Big5 + companion fit | 14 |
| ` supervision` | Oversight, error, intervention | 12 |
| ` companion` | Rapport, encouragement, narrative continuity | 17 |
| ` engagement` | Challenge, novelty, momentum | 13 |
| ` reinforcement` | Feedback, praise, correction frequency | 6 |
| ` onboarding` | First-call / intake-flow behaviour | 5 |
| ` voice-delivery` | Voice-surface behaviours (placeholder for S5 #1952) | 0 |
| **Total** | | **154** |

## Changes

- ` docs/PARAMETER-TAXONOMY.md` (new, 100 lines) — canonical taxonomy doc with group descriptions, customer override boundary, data-driven UI invariant, versioning
- ` prisma/migrations/20260618130000_1948_domain_group_taxonomy/` (new) — data migration; one ` UPDATE` per cluster; idempotent (WHERE clauses match only legacy spellings)
- ` behavior-parameters.registry.json` — normalised values; header gains ` taxonomyVersion: "v1.0"` + ` domainGroups[10]` enumeration + updated ` sourceOfTruth` framing the registry as HF-canonical spec
- ` tests/lib/registry/parameter-domain-group-taxonomy.test.ts` (new) — 7 tests

## Verified by

- ` jq` against post-migration registry [probed locally]: 9 distinct ` domainGroup` values present (10th, ` voice-delivery`, is the empty S5 placeholder)
- ` tests/lib/registry/parameter-domain-group-taxonomy.test.ts` — 7 new tests pinning canonical names, header fields, no legacy stragglers, distribution sum = 154, voice-delivery is empty
- ` tests/lib/measurement/parameter-coverage.test.ts` — still green; joins through ` parameterId`, unaffected by ` domainGroup` rename [verified locally]
- Lattice survey result: ` Parameter.domainGroup` is presentation metadata only. No cascade boundary, no chain-stage crossing. Sibling writers: only direct ` Parameter` writes touch this column; ` scripts/generate-registry.ts` writes DB → JSON [verified by TL agent during epic grooming]. ` BehaviorTarget` joins through ` parameterId`, not ` domainGroup` — no FK / cascade migration needed.
- ` PlaybookBuilder.tsx:3184` Graphic Equalizer rendering confirmed data-driven (no hardcoded group names) [verified by TL]
- ` targets.ts:193` compose-side ` domainGroup` read confirmed data-driven [verified by TL]
- Data-driven property: changing a parameter's ` domainGroup` in the registry + ` db:seed` reshapes the Tune sidebar without code change

## Test plan

- [ ] **Pedagogy review of ` docs/PARAMETER-TAXONOMY.md`** — named reviewer signs off on the 10 group names + descriptions
- [ ] On hf-dev VM after ` /vm-cpp`: ` SELECT COUNT(DISTINCT "domainGroup") FROM "Parameter" WHERE "deprecatedAt" IS NULL` ≤ 10
- [ ] Tune sidebar Graphic Equalizer on hf-dev shows ≤ 10 sections matching the canonical names
- [ ] Existing ` BehaviorTarget` rows unchanged (sanity: ` SELECT COUNT(*) FROM "BehaviorTarget"` before vs after)
- [ ] Migration re-run is a no-op (idempotency check)

## Out of scope (deferred to epic #1946 follow-ons)

- Naming convention rename (snake → BEH-* kebab) — S2 #1950 lands the alias resolver first
- Conceptual de-dup of params like ` warmth_actual` overlapping ` BEH-WARMTH` — S1 #1949
- Populating ` voice-delivery` group — S5 #1952

## Deploy

` /vm-cpp` (migration ` 20260618130000_1948_domain_group_taxonomy`)