### PR TITLE
feat(wizard): P3g — resolve profileFieldsToCapture source-refs (#1850)

### DIFF
--- a/apps/admin/lib/wizard/__tests__/fixtures/course-reference-ielts-v2.3.md
+++ b/apps/admin/lib/wizard/__tests__/fixtures/course-reference-ielts-v2.3.md
@@ -191,7 +191,7 @@ settings:
     follow-up questions. About twenty minutes total.
   scheduledCues: []             # Baseline uses the warmer framing — no aloud cue countdown
   scaffoldPool: source:stall-scaffolds-monologue   # examiner-mode silence rules; Part 2 long-turn nudges only
-  profileFieldsToCapture: [reason, targetBand, timeline, selfLevel]
+  profileFieldsToCapture: source:ielts-speaking-profile-fields   # Source 14 — per-key {prompt, type} metadata
   prepSilenceSec: 60            # Part 2 prep phase inside Baseline
   incompleteThresholdSec: 600   # below 10 min = abandoned (50% of expected) — does not count
   scoringCriteria: [FC, LR, GRA, Pron]
@@ -1172,6 +1172,17 @@ Part 1 short Q&A reuses the discussion stall scaffolds — single-question stall
 - *format:* structured-md  
 - *moduleRef:* part1  
 - *settingRef:* moduleScaffoldPool  
+  
+### Source 14 — IELTS profile fields (Baseline)  
+  
+A short list of conversational profile fields the tutor weaves into the Baseline warm-up. Each field carries a verbatim tutor prompt + a coercion type (`text` / `number` / `band`). Extracted at end-of-session by `lib/pipeline/extract-profile-fields.ts` and written to `CallerAttribute` rows under the course-agnostic `profile:*` namespace. Replaces the v2.3-pre-P3g inline shortlist `[reason, targetBand, timeline, selfLevel]`, which the runtime filter silently dropped because each entry lacked `prompt` + `type`.  
+  
+- *location:* `docs/external/ielts/ielts-speaking/Upload Docs/ielts-speaking-profile-fields.md`  
+- *format:* structured-md  
+- *moduleRef:* baseline  
+- *settingRef:* moduleProfileFieldsToCapture  
+- *Outcomes served:* none directly — profile data drives downstream personalisation (`profile:reason` motivational hooks; `profile:targetBand` stretch threshold; `profile:timeline` urgency framing; `profile:selfLevel` calibration of first-question difficulty).  
+- *Ordering:* the tutor asks fields in source-file order during warm-up; no re-prompting mid-session.  
   
 ### Content preferences  
   

--- a/apps/admin/lib/wizard/__tests__/parse-source-content.test.ts
+++ b/apps/admin/lib/wizard/__tests__/parse-source-content.test.ts
@@ -7,7 +7,11 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { parseCueCardBank, parseStallScaffolds } from "../parse-source-content";
+import {
+  parseCueCardBank,
+  parseProfileFields,
+  parseStallScaffolds,
+} from "../parse-source-content";
 
 const REPO_ROOT = join(__dirname, "..", "..", "..", "..", "..");
 
@@ -104,5 +108,128 @@ describe("parseStallScaffolds — IELTS Part 2 + Part 3 scaffolds", () => {
 
   it("returns empty when no Scaffold pool section is present", () => {
     expect(parseStallScaffolds("# A doc without the section.\n")).toEqual([]);
+  });
+});
+
+describe("parseProfileFields — IELTS Baseline profile fields", () => {
+  const text = readFileSync(
+    join(
+      REPO_ROOT,
+      "docs",
+      "external",
+      "ielts",
+      "ielts-speaking",
+      "Upload Docs",
+      "ielts-speaking-profile-fields.md",
+    ),
+    "utf-8",
+  );
+
+  it("parses the four canonical fields in source order", () => {
+    const fields = parseProfileFields(text);
+    expect(fields).toHaveLength(4);
+    expect(fields[0].key).toBe("profile:reason");
+    expect(fields[1].key).toBe("profile:targetBand");
+    expect(fields[2].key).toBe("profile:timeline");
+    expect(fields[3].key).toBe("profile:selfLevel");
+  });
+
+  it("extracts the verbatim prompt + type for the band field", () => {
+    const fields = parseProfileFields(text);
+    const band = fields.find((f) => f.key === "profile:targetBand");
+    expect(band).toBeDefined();
+    expect(band!.type).toBe("band");
+    expect(band!.prompt).toBe("What band score are you aiming for?");
+  });
+
+  it("each field carries non-empty key + prompt + valid type", () => {
+    const fields = parseProfileFields(text);
+    for (const f of fields) {
+      expect(f.key.length).toBeGreaterThan(0);
+      expect(f.prompt.length).toBeGreaterThan(0);
+      expect(["text", "number", "band"]).toContain(f.type);
+    }
+  });
+
+  it("returns empty when no field headers are present", () => {
+    expect(parseProfileFields("# A doc with no fields\n\nSome prose.\n")).toEqual([]);
+  });
+
+  it("drops a field missing prompt", () => {
+    const partial = [
+      "### Field 1 — incomplete",
+      "",
+      "- **key:** `profile:x`",
+      "- **type:** text",
+      "",
+      "### Field 2 — complete",
+      "",
+      "- **key:** `profile:y`",
+      "- **type:** text",
+      "- **prompt:** What about Y?",
+      "",
+    ].join("\n");
+    const fields = parseProfileFields(partial);
+    expect(fields).toHaveLength(1);
+    expect(fields[0].key).toBe("profile:y");
+  });
+
+  it("drops a field with an invalid type", () => {
+    const bad = [
+      "### Field 1 — bad type",
+      "",
+      "- **key:** `profile:x`",
+      "- **type:** integer",
+      "- **prompt:** What is X?",
+      "",
+    ].join("\n");
+    expect(parseProfileFields(bad)).toEqual([]);
+  });
+
+  it("parses 'number' and 'text' types alongside 'band'", () => {
+    const mixed = [
+      "### Field 1 — text field",
+      "",
+      "- **key:** `profile:a`",
+      "- **type:** text",
+      "- **prompt:** A?",
+      "",
+      "### Field 2 — number field",
+      "",
+      "- **key:** `profile:b`",
+      "- **type:** number",
+      "- **prompt:** B?",
+      "",
+      "### Field 3 — band field",
+      "",
+      "- **key:** `profile:c`",
+      "- **type:** band",
+      "- **prompt:** C?",
+      "",
+    ].join("\n");
+    const fields = parseProfileFields(mixed);
+    expect(fields).toHaveLength(3);
+    expect(fields.map((f) => f.type)).toEqual(["text", "number", "band"]);
+  });
+
+  it("ignores prose outside Field blocks", () => {
+    const mixed = [
+      "# Header",
+      "",
+      "Some intro prose with `- **key:**` looking text in a code block.",
+      "",
+      "### Field 1 — real",
+      "",
+      "- **key:** `profile:real`",
+      "- **type:** text",
+      "- **prompt:** What is real?",
+      "",
+      "## Footer notes",
+      "",
+      "- **key:** `profile:ignored` (this is in a different ## section)",
+    ].join("\n");
+    const fields = parseProfileFields(mixed);
+    expect(fields).toHaveLength(1);
+    expect(fields[0].key).toBe("profile:real");
   });
 });

--- a/apps/admin/lib/wizard/__tests__/resolve-module-source-refs.test.ts
+++ b/apps/admin/lib/wizard/__tests__/resolve-module-source-refs.test.ts
@@ -104,18 +104,44 @@ describe("resolveModuleSourceRefs — IELTS v2.3 against real disk", () => {
     );
   });
 
+  it("inlines baseline.profileFieldsToCapture from Source 14 (P3g)", () => {
+    const byModuleId = new Map<string, Partial<AuthoredModuleSettings>>();
+    const out = resolveModuleSourceRefs(byModuleId, IELTS_V23, { repoRoot: REPO_ROOT });
+    const baseline = out.byModuleId.get("baseline");
+    expect(baseline).toBeDefined();
+    expect(Array.isArray(baseline!.profileFieldsToCapture)).toBe(true);
+    expect(baseline!.profileFieldsToCapture!).toHaveLength(4);
+    const reason = baseline!.profileFieldsToCapture!.find(
+      (f) => f.key === "profile:reason",
+    );
+    expect(reason).toBeDefined();
+    expect(reason!.type).toBe("text");
+    expect(reason!.prompt.length).toBeGreaterThan(0);
+    const targetBand = baseline!.profileFieldsToCapture!.find(
+      (f) => f.key === "profile:targetBand",
+    );
+    expect(targetBand!.type).toBe("band");
+  });
+
   it("returns a structured resolution log", () => {
     const byModuleId = new Map<string, Partial<AuthoredModuleSettings>>();
     const out = resolveModuleSourceRefs(byModuleId, IELTS_V23, { repoRoot: REPO_ROOT });
     const resolved = out.resolutions.filter((r) => r.status === "resolved");
-    // post-multi-route: 3 cueCardPool resolutions (part2 + mock + baseline)
-    // + 5 scaffoldPool resolutions (part2 + part3 + mock + baseline + part1) = 8
-    expect(resolved.length).toBeGreaterThanOrEqual(8);
+    // post-multi-route + P3g: 3 cueCardPool (part2 + mock + baseline) +
+    // 5 scaffoldPool (part2 + part3 + mock + baseline + part1) +
+    // 1 profileFieldsToCapture (baseline) = 9
+    expect(resolved.length).toBeGreaterThanOrEqual(9);
     const part2Cue = resolved.find(
       (r) => r.moduleId === "part2" && r.field === "cueCardPool",
     );
     expect(part2Cue).toBeDefined();
     expect(part2Cue!.itemCount).toBeGreaterThanOrEqual(80);
+    const baselineProfile = resolved.find(
+      (r) =>
+        r.moduleId === "baseline" && r.field === "profileFieldsToCapture",
+    );
+    expect(baselineProfile).toBeDefined();
+    expect(baselineProfile!.itemCount).toBe(4);
   });
 });
 

--- a/apps/admin/lib/wizard/parse-source-content.ts
+++ b/apps/admin/lib/wizard/parse-source-content.ts
@@ -11,12 +11,13 @@
  * Format dispatch (today):
  *   - `cueCardBank`   → Array<{ topic, bullets[] }>
  *   - `stallScaffold` → string[]
+ *   - `profileFields` → Array<{ key, prompt, type }>  (P3g, #1850)
  *
- * Both parsers are deterministic, dependency-free, and tolerant of the
+ * All parsers are deterministic, dependency-free, and tolerant of the
  * cosmetic variations in the HFF-authored fixtures (extra blank lines,
  * `> ` quoted bodies, leading `## ` separators).
  *
- * Issue #1850 P3f.
+ * Issue #1850 P3f + P3g.
  */
 
 // ── Cue card bank (Source 2 — Part 2 cue cards) ──────────────────────
@@ -159,6 +160,98 @@ export function parseStallScaffolds(text: string): string[] {
     if (m) {
       const txt = m[1].trim();
       if (txt) out.push(txt);
+    }
+  }
+  return out;
+}
+
+// ── Profile fields (Source N — Baseline profile fields) ──────────────
+//
+// Input format (mirrors cue-card / scaffold convention):
+//
+//   ### Field 1 — reason
+//
+//   - **key:** `profile:reason`
+//   - **type:** text
+//   - **prompt:** What's bringing you to IELTS Speaking? Work, study, …
+//
+// Output: [{
+//   key: "profile:reason",
+//   type: "text",
+//   prompt: "What's bringing you to IELTS Speaking? Work, study, …",
+// }, ...]
+//
+// Shape matches `ProfileFieldToCapture` in `lib/types/json-fields.ts`.
+// The runtime consumer (`lib/pipeline/extract-profile-fields.ts`)
+// filters out anything that doesn't have all three fields with valid
+// `type` (text | number | band) — the parser drops malformed entries
+// rather than emit them and rely on the runtime filter.
+
+/** A declared profile field — mirrors `ProfileFieldToCapture`. */
+export interface ProfileFieldEntry {
+  key: string;
+  prompt: string;
+  type: "text" | "number" | "band";
+}
+
+const FIELD_HEADER = /^###\s+Field\s+\d+\s*[—–-]\s+.+?\s*$/i;
+/** `- **key:** \`profile:reason\`` — key inside backticks or bare. */
+const KEY_LINE = /^\s*-\s*\*\*key:\*\*\s*`?([A-Za-z0-9_:.-]+)`?\s*$/i;
+/** `- **type:** text|number|band`. */
+const TYPE_LINE = /^\s*-\s*\*\*type:\*\*\s*(text|number|band)\s*$/i;
+/** `- **prompt:** <free text up to end-of-line>`. */
+const PROMPT_LINE = /^\s*-\s*\*\*prompt:\*\*\s*(.+?)\s*$/i;
+const VALID_TYPES: ReadonlySet<string> = new Set(["text", "number", "band"]);
+
+/**
+ * Parse a profile-fields markdown file. Returns an array of
+ * `{ key, prompt, type }` entries — one per `### Field N — …` heading.
+ * Order is preserved (the tutor asks fields in source order). Entries
+ * missing any of the three required attributes, or with an out-of-set
+ * `type`, are dropped — the resolver would otherwise emit shapes the
+ * runtime filter rejects.
+ */
+export function parseProfileFields(text: string): ProfileFieldEntry[] {
+  const lines = text.split(/\r?\n/);
+  const out: ProfileFieldEntry[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    if (!FIELD_HEADER.test(lines[i])) {
+      i++;
+      continue;
+    }
+    i++;
+    // Collect key / type / prompt within the field block — stop at the
+    // next `### ` heading or a top-level `## ` section.
+    let key: string | undefined;
+    let type: ProfileFieldEntry["type"] | undefined;
+    let prompt: string | undefined;
+    while (i < lines.length) {
+      const line = lines[i];
+      if (/^##\s/.test(line) || /^###\s/.test(line)) break;
+      const kMatch = line.match(KEY_LINE);
+      if (kMatch) {
+        key = kMatch[1].trim();
+        i++;
+        continue;
+      }
+      const tMatch = line.match(TYPE_LINE);
+      if (tMatch) {
+        const t = tMatch[1].toLowerCase();
+        if (VALID_TYPES.has(t)) type = t as ProfileFieldEntry["type"];
+        i++;
+        continue;
+      }
+      const pMatch = line.match(PROMPT_LINE);
+      if (pMatch) {
+        prompt = pMatch[1].trim();
+        i++;
+        continue;
+      }
+      i++;
+    }
+    if (key && type && prompt) {
+      out.push({ key, prompt, type });
     }
   }
   return out;

--- a/apps/admin/lib/wizard/resolve-module-source-refs.ts
+++ b/apps/admin/lib/wizard/resolve-module-source-refs.ts
@@ -1,5 +1,5 @@
 /**
- * resolve-module-source-refs.ts (#1850 P3f)
+ * resolve-module-source-refs.ts (#1850 P3f + P3g)
  *
  * @canonical-doc docs/CONTENT-PIPELINE.md §"Per-module YAML settings blocks"
  *
@@ -9,8 +9,10 @@
  * strings (`source:<id>`) instead of resolved structured values:
  *   - `cueCardPool`               (e.g. `source:cue-card-bank-v1`)
  *   - `scaffoldPool`              (e.g. `source:stall-scaffolds-monologue`)
- *   - `profileFieldsToCapture`    (e.g. `[reason, targetBand, …]` shortform —
- *      not a source-ref today; deferred to P3g, see below)
+ *   - `profileFieldsToCapture`    (e.g. `source:ielts-speaking-profile-fields`,
+ *      P3g — was an inline shortlist `[reason, targetBand, …]` pre-P3g
+ *      which the runtime filter at `extract-profile-fields.ts:362-378`
+ *      dropped silently because each entry lacked `prompt` + `type`.)
  *
  * This module IS the resolver stage. Given the per-module YAML output
  * (as it would appear pre-skip — the caller re-parses raw YAML and
@@ -33,14 +35,7 @@
  *
  * Pure (no Prisma, no network); injectable file reader for tests.
  *
- * The `profileFieldsToCapture` field is intentionally NOT resolved here
- * — the v2.3 fixture supplies it as an inline shortlist
- * (`[reason, targetBand, timeline, selfLevel]`) without per-key prompt
- * + type metadata, and the source file doesn't exist on disk yet. P3g
- * will introduce a profile-fields-source markdown convention and the
- * matching parser. The resolver leaves the field unset on this PR.
- *
- * Issue #1850 P3f.
+ * Issue #1850 P3f + P3g.
  */
 
 import { readFileSync, existsSync } from "node:fs";
@@ -55,6 +50,7 @@ import {
 } from "./parse-content-sources";
 import {
   parseCueCardBank,
+  parseProfileFields,
   parseStallScaffolds,
 } from "./parse-source-content";
 
@@ -159,6 +155,7 @@ export function extractSourceRefsFromYamlBlocks(
 const RESOLVABLE_FIELDS = new Set<keyof AuthoredModuleSettings>([
   "cueCardPool",
   "scaffoldPool",
+  "profileFieldsToCapture",
 ]);
 
 /** Injectable file reader so the resolver is unit-testable without disk. */
@@ -255,6 +252,19 @@ function parseByFormat(
     const items = parseStallScaffolds(fileText);
     if (items.length === 0) {
       return { ok: false, reason: "stall-scaffold parser produced 0 items" };
+    }
+    return { ok: true, value: items, itemCount: items.length };
+  }
+  if (field === "profileFieldsToCapture") {
+    if (normalisedFormat !== "structured-md") {
+      return {
+        ok: false,
+        reason: `unexpected format "${format}" for profileFieldsToCapture`,
+      };
+    }
+    const items = parseProfileFields(fileText);
+    if (items.length === 0) {
+      return { ok: false, reason: "profile-fields parser produced 0 items" };
     }
     return { ok: true, value: items, itemCount: items.length };
   }

--- a/docs/external/ielts/ielts-speaking/Upload Docs/ielts-speaking-profile-fields.md
+++ b/docs/external/ielts/ielts-speaking/Upload Docs/ielts-speaking-profile-fields.md
@@ -1,0 +1,52 @@
+# IELTS Speaking — Profile fields to capture (Baseline Assessment)
+
+**Source:** HF-authored (Paul Wander, 2026-06-18). Not derived from any external source. Operator content.
+**Module:** `baseline` (Baseline Assessment).
+**Setting:** `moduleProfileFieldsToCapture`.
+**Status:** Initial set — calibrate against real Baseline sessions.
+
+## Purpose
+
+During the Baseline Assessment, the tutor weaves four short conversational profile questions into the warm-up. The answers are extracted by `lib/pipeline/extract-profile-fields.ts` and written to `CallerAttribute` rows under the course-agnostic `profile:*` namespace. They drive downstream personalisation (`profile:reason` → motivational hooks; `profile:targetBand` → stretch-band threshold; `profile:timeline` → urgency framing; `profile:selfLevel` → calibration of the very first question's difficulty).
+
+**Constraints (per `## Profile capture` in the course reference):**
+
+- Each field MUST be asked verbatim in the warm-up before the first Part 1 question is delivered.
+- Each field has a single coercion type — `text`, `number`, or `band`. A `band` value must be a half-band between 1.0 and 9.0.
+- The tutor never re-prompts a field mid-session; if the learner doesn't answer, the field is silently dropped.
+
+## Fields
+
+### Field 1 — reason
+
+- **key:** `profile:reason`
+- **type:** text
+- **prompt:** What's bringing you to IELTS Speaking? Work, study, immigration, something else?
+
+### Field 2 — targetBand
+
+- **key:** `profile:targetBand`
+- **type:** band
+- **prompt:** What band score are you aiming for?
+
+### Field 3 — timeline
+
+- **key:** `profile:timeline`
+- **type:** text
+- **prompt:** When do you need this by? A rough month is fine.
+
+### Field 4 — selfLevel
+
+- **key:** `profile:selfLevel`
+- **type:** text
+- **prompt:** Where do you feel you are right now — beginner, intermediate, advanced?
+
+## Ordering
+
+The tutor asks the fields in the order they appear above. The order is deliberate: motivation first (anchors the rest of the conversation), then concrete targets, then timeline pressure, then self-assessment. The tutor does NOT lead with `selfLevel` — learners under-estimate themselves when asked cold.
+
+## Notes
+
+- Per-key prompt phrasing in this file is the canonical wording. The composed prompt template substitutes these into the tutor system prompt verbatim — do not paraphrase at projection time.
+- `profile:targetBand` is the only `band`-typed field today. The coercion validator rejects values outside 1.0–9.0 or non-half-bands (e.g. 6.3 → rejected). The tutor should re-ask if the learner gives a vague answer like "a high band".
+- Future fields should be added BELOW the current four — `Field N — <key>` ordering matters for the parser's order-preserving output.


### PR DESCRIPTION
## Summary

Closes the last G8 source-ref field in P3 of epic #1850. v2.3 supplied `profileFieldsToCapture` as an inline shortlist `[reason, targetBand, timeline, selfLevel]` — these silently dropped at runtime because the filter at `extract-profile-fields.ts:362-378` requires `key` + `prompt` + `type` per entry. P3g enriches the field via a source file with per-key `{key, prompt, type}` metadata + a new parser, matching the P3f pattern for `cueCardPool` + `scaffoldPool`.

## Reuse-finder findings

1. **Schema shape** (`apps/admin/lib/types/json-fields.ts:1062`): `profileFieldsToCapture?: ProfileFieldToCapture[]` where each entry is `{key: string, prompt: string, type: "text"|"number"|"band"}`. Already structured — no schema change needed.
2. **Runtime consumer** (`lib/pipeline/extract-profile-fields.ts:343-378`): `resolveProfileFieldsForCall` reads `Playbook.config.modules[].settings.profileFieldsToCapture`, filters entries lacking `key`+`prompt`+`type`. The inline shortlist had no consumer effect pre-P3g.
3. **Existing parser siblings** (`lib/wizard/parse-source-content.ts`): `parseCueCardBank` + `parseStallScaffolds` are deterministic, dependency-free, structured-md walkers. New `parseProfileFields` mirrors the shape.
4. **Wizard course-create path** (`lib/chat/wizard-tool-executor/tools/create_course.ts`): does NOT read `profileFieldsToCapture` — confirmed via grep across the dispatcher + all 109 lines of create_course.ts. Course-create API unaffected by this PR [verified by 18/18 wizard-tool-executor tests].
5. **Coverage rules** — `tests/lib/wizard/fixture-type-coverage.test.ts` walks YAML KEYS not values; the YAML key `profileFieldsToCapture` is unchanged, only its value form (inline list → `source:…`). `tests/lib/journey/registry-consumer-coverage.test.ts` classifies `scope: "module"` settings as `family-shortcut` so the G8 cohort entry remains compliant. No coverage-test updates needed.

## Decisions

**Decision 1: Keep `Array<{key, prompt, type}>` (existing schema).** The runtime consumer ALREADY requires the structured form; the inline shortlist was producer-only data the consumer rejected. Backwards-compatible — old playbooks with the inline form continue to load; the runtime filter drops the malformed entries silently as it did before. No schema migration. [verified at `lib/types/json-fields.ts:1015-1022`]

**Decision 2: Source file at `docs/external/ielts/ielts-speaking/Upload Docs/ielts-speaking-profile-fields.md`, format `structured-md`.** Mirrors cue-card / scaffold convention. Per-field block: `### Field N — <key>` + `- **key:** \`profile:<key>\`` + `- **type:** text|number|band` + `- **prompt:** <verbatim>`.

## Operator requirement verifications

- **A. Wizard projection works with v2.3** — verified by `lib/wizard/__tests__/resolve-module-source-refs.test.ts::"inlines baseline.profileFieldsToCapture from Source 14 (P3g)"` [verified, test green]. Asserts `baseline.profileFieldsToCapture` has 4 entries, each with key+prompt+type; `targetBand` typed `"band"`. Updated resolution-log assertion confirms ≥9 resolved (3 cue-card + 5 scaffold + 1 profile).
- **B. Course create API still works** — verified by `tests/lib/chat/wizard-tool-executor` (18/18 green) + grep-confirmed that `create_course.ts` never reads `profileFieldsToCapture`. The Inspector + journey-setting API still serialize `ProfileFieldToCapture[]` unchanged — `tests/components/modules-tab/ModuleInspectorPanel.test.tsx::"moduleProfileFieldsToCapture"` 8/8 green. [verified, tests green]
- **C. Backfill on hf-sandbox** — Operator runs on hf-dev VM (edit-only machine per CLAUDE.local.md): `cd ~/HF/apps/admin && npx tsx scripts/backfill-module-settings-from-course-ref.ts --course-ref lib/wizard/__tests__/fixtures/course-reference-ielts-v2.3.md --playbook-id 20b21160-0516-49c9-a8da-105772f41e64 --dry-run` then drop `--dry-run`. Only the Practice playbook (`20b21160…`) has a baseline module to receive resolved settings; V1.0 (`eb6bc79e…`) + PAW (`41d4dcfa…`) have no baseline module and will skip with `module overlap: 0` cleanly. Backfill script (`scripts/backfill-module-settings-from-course-ref.ts:32, 152`) already invokes `resolveModuleSourceRefs` — P3g plugs in automatically; no script changes needed. [unverified-on-this-machine — operator runs on VM per shared discipline; SQL audit: `SELECT config->'modules'->0->'settings'->'profileFieldsToCapture' FROM \"Playbook\" WHERE id='20b21160-0516-49c9-a8da-105772f41e64'`]

## Source file content

4 fields for IELTS Baseline Assessment warm-up: `profile:reason` (text), `profile:targetBand` (band), `profile:timeline` (text), `profile:selfLevel` (text). Each carries a verbatim tutor prompt; ordering deliberate (motivation → target → timeline → self-level). EXTRACT writes to `CallerAttribute` rows under `profile:*` namespace with scope `PROFILE` per the existing #1704 contract.

## Test counts

- New: 8 vitests for `parseProfileFields` + 1 integration test for baseline resolution + 1 updated resolution-log assertion.
- Sibling unaffected: 262 wizard, 385 wizard+journey, 18 wizard-tool-executor (create_course), 8 ModuleInspectorPanel — all green pre- and post-PR.

## Verified by

- `npx vitest run lib/wizard/__tests__/parse-source-content.test.ts` — 15/15 green (8 new + 7 existing)
- `npx vitest run lib/wizard/__tests__/resolve-module-source-refs.test.ts` — 11/11 green (1 new + 1 updated + 9 existing)
- `npx vitest run tests/lib/wizard tests/lib/journey lib/wizard/__tests__` — 385/386 green (1 pre-existing skip)
- `npx vitest run tests/lib/chat/wizard-tool-executor tests/lib/chat/wizard-tool-executor-dispatcher.test.ts` — 18/18 green
- `npx vitest run tests/components/modules-tab/ModuleInspectorPanel.test.tsx` — 8/8 green
- `npx tsc --noEmit` — 37 pre-existing errors unchanged, 0 from this PR (ratchet down 2)
- `npm run lint` — 0 errors, 4539 warnings (== pre-PR baseline; 0 from this PR)
- `npm run ratchet:check` — lint_errors == baseline; tsc_errors -2 under baseline

## Lattice survey

- **Surface:** `AuthoredModuleSettings.profileFieldsToCapture` (Playbook.config.modules[].settings)
- **Sibling writers/readers:** detect-module-settings (skip — known shape), resolve-module-source-refs (new write path via P3g), extract-profile-fields (read at runtime, CallerAttribute write), Inspector (UI read/write via useJourneySettingMutator), backfill script (read course-ref → write config), wizard-tool-executor.create_course (does NOT read or write).
- **Risk shapes checked:**
  - Sibling-writer drift: P3f resolver already handles `cueCardPool` + `scaffoldPool` via the same `RESOLVABLE_FIELDS` + `parseByFormat` pattern; P3g extends the dispatcher; no clobbering — the resolver merges into `byModuleId` via `(settings as Record).[field]=value`. Existing inline-list path becomes a no-op (skipped by `isSourceRefString` guard — not a `source:` string).
  - Default-deny gates: No ESLint guard on this surface. `HF_FLAG_IELTS_MODULE_SETTINGS` gates the runtime consumer; resolver runs at projection time independently.
  - Cascade respect: Field is module-scoped, not in `lib/cascade/effective-value.ts::FAMILIES` — no cascade family. Snapshot read is correct.
  - Convention conflict: None — `text|number|band` enum + `profile:*` key namespace per #1704.
- **Decision:** Extend existing resolver dispatcher; no new sibling writer; backwards-compatible runtime (the inline-list form continues to load but produces zero captured fields, same as pre-PR).

Issue #1850.

🤖 Generated with [Claude Code](https://claude.com/claude-code)