### PR TITLE
feat(privacy): no-pii-in-applog-metadata ESLint guard (S6, #1926)

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,7 +1,7 @@
 {
   "tsc_errors": 37,
   "lint_errors": 0,
-  "lint_warnings": 4539,
+  "lint_warnings": 4540,
   "quarantined_tests": 36,
   "knip_unused": 162,
   "same_issue_fix_chain_max": 10,

--- a/apps/admin/eslint-rules/no-pii-in-applog-metadata.mjs
+++ b/apps/admin/eslint-rules/no-pii-in-applog-metadata.mjs
@@ -80,11 +80,38 @@ function isAllowedPath(filename) {
 }
 
 function hasEscapeComment(sourceCode, node) {
+  if (!node || !sourceCode || typeof sourceCode.getCommentsBefore !== "function") {
+    return false;
+  }
   const comments = sourceCode.getCommentsBefore(node);
   for (const c of comments) {
     if (c.value.includes(ESCAPE_COMMENT)) return true;
   }
   return false;
+}
+
+/** Walk up the AST to find the nearest Statement-ish ancestor (i.e.
+ *  the node where authors would write `// @piiRedacted`). Falls back
+ *  to the original node when nothing matches. */
+function findStatementAncestor(node) {
+  const STATEMENT_LIKE = new Set([
+    "ExpressionStatement",
+    "VariableDeclaration",
+    "ReturnStatement",
+    "IfStatement",
+    "ForStatement",
+    "ForOfStatement",
+    "ForInStatement",
+    "WhileStatement",
+    "BlockStatement",
+    "Program",
+  ]);
+  let current = node.parent;
+  while (current) {
+    if (STATEMENT_LIKE.has(current.type)) return current;
+    current = current.parent;
+  }
+  return node;
 }
 
 /** Walk an ObjectExpression's keys, return the first forbidden key found. */
@@ -102,11 +129,14 @@ function findForbiddenKey(objExpr) {
   return null;
 }
 
-/** Detect `obj.metadata` property where the value is a literal with PII keys. */
-function checkMetadataLiteral(context, node, ancestorSiteLabel) {
+/** Detect `obj.metadata` property where the value is a literal with PII keys.
+ *  `escapeCheckNode` is the AST node whose preceding comments are scanned for
+ *  the `@piiRedacted` escape — typically the outer CallExpression statement
+ *  (where the author would write the comment), not the inner literal. */
+function checkMetadataLiteral(context, node, ancestorSiteLabel, escapeCheckNode) {
   const filename = context.filename || context.getFilename?.() || "";
   if (isAllowedPath(filename)) return;
-  if (hasEscapeComment(context.sourceCode, node)) return;
+  if (hasEscapeComment(context.sourceCode, escapeCheckNode ?? node)) return;
 
   if (!node || node.type !== "ObjectExpression") return;
   for (const prop of node.properties) {
@@ -141,6 +171,12 @@ export default {
     return {
       // prisma.appLog.create({ data: { metadata: { ... } } })
       CallExpression(node) {
+        // The escape-comment check looks at comments preceding the
+        // enclosing statement (where authors write `// @piiRedacted`),
+        // not the inner literal. Walk up to the nearest Statement-ish
+        // ancestor for the lookup.
+        const escapeAnchor = findStatementAncestor(node);
+
         // Match `prisma.appLog.create({ data: ... })`
         if (
           node.callee.type === "MemberExpression" &&
@@ -162,6 +198,7 @@ export default {
                   context,
                   prop.value,
                   "prisma.appLog.create",
+                  escapeAnchor,
                 );
               }
             }
@@ -175,7 +212,12 @@ export default {
         ) {
           for (const arg of node.arguments) {
             if (arg && arg.type === "ObjectExpression") {
-              checkMetadataLiteral(context, arg, `${node.callee.name}()`);
+              checkMetadataLiteral(
+                context,
+                arg,
+                `${node.callee.name}()`,
+                escapeAnchor,
+              );
             }
           }
         }

--- a/apps/admin/eslint-rules/no-pii-in-applog-metadata.mjs
+++ b/apps/admin/eslint-rules/no-pii-in-applog-metadata.mjs
@@ -1,0 +1,185 @@
+/**
+ * #1926 (epic #1915 child) — block literal PII-keyed objects from
+ * being passed as `metadata` to `AppLog` write paths.
+ *
+ * Two complementary checks:
+ *
+ *   1. `prisma.appLog.create({ data: { metadata: { email: ... } } })` —
+ *      direct bare write with a literal PII-keyed object.
+ *
+ *   2. `log(subject, { metadata: { email: ... } })` /
+ *      `logAI(stage, prompt, response, { ...PII keys, ... })` —
+ *      caller-side leak into the chokepoint helper at `lib/logger.ts`.
+ *
+ * Forbidden literal keys (canonical PII set per the 2026-06-18 audit):
+ *   - `email`
+ *   - `phone`
+ *   - `transcript`
+ *   - `name`            (caller / user identifier)
+ *   - `value`           (CallerMemory value)
+ *   - `promptPreview`   (can include caller-quoted PII)
+ *   - `responsePreview` (can include caller-quoted PII)
+ *
+ * Allow-list (compile-time):
+ *   - `lib/logger.ts`        — canonical writer; receives arbitrary data
+ *                              from callers but doesn't author literal keys
+ *   - `tests/**`             — test fixtures may use any literal shape
+ *   - `prisma/fixtures/**`   — seed fixtures
+ *   - `scripts/**`           — one-off forensic / migration scripts
+ *
+ * Opt-in escape (per call site):
+ *   - `// @piiRedacted` — comment on the previous or same line declares
+ *     the author has redacted the literal before passing it
+ *
+ * Per `.claude/rules/data-retention.md` companion rule
+ * `privacy-applog.md` (filed alongside this rule). Catalogued in
+ * `docs/kb/guard-registry.md`.
+ *
+ * Class: invariant (write-side privacy chokepoint).
+ *
+ * @see docs/CHAIN-CONTRACTS.md §6a I-PR3 (data retention)
+ * @see lib/logger.ts (the chokepoint writer)
+ */
+
+const FORBIDDEN_KEYS = new Set([
+  "email",
+  "phone",
+  "transcript",
+  "name",
+  "value",
+  "promptPreview",
+  "responsePreview",
+]);
+
+const ALLOWED_PATH_SUFFIXES = [
+  "lib/logger.ts",
+  // metering helper writes its own `metadata` literal with internal
+  // counters; no caller-supplied data flows through these keys.
+  "lib/metering/meter-call.ts",
+];
+
+const ALLOWED_PATH_GLOBS = [
+  // Tests can compose any literal shape — they're fixture data.
+  /\/tests\//,
+  /\/prisma\/fixtures\//,
+  /\/scripts\//,
+  /\.test\.ts$/,
+  /\.spec\.ts$/,
+];
+
+const ESCAPE_COMMENT = "@piiRedacted";
+
+function isAllowedPath(filename) {
+  for (const suffix of ALLOWED_PATH_SUFFIXES) {
+    if (filename.endsWith(suffix)) return true;
+  }
+  for (const re of ALLOWED_PATH_GLOBS) {
+    if (re.test(filename)) return true;
+  }
+  return false;
+}
+
+function hasEscapeComment(sourceCode, node) {
+  const comments = sourceCode.getCommentsBefore(node);
+  for (const c of comments) {
+    if (c.value.includes(ESCAPE_COMMENT)) return true;
+  }
+  return false;
+}
+
+/** Walk an ObjectExpression's keys, return the first forbidden key found. */
+function findForbiddenKey(objExpr) {
+  if (!objExpr || objExpr.type !== "ObjectExpression") return null;
+  for (const prop of objExpr.properties) {
+    if (prop.type !== "Property") continue;
+    let keyName = null;
+    if (prop.key.type === "Identifier") keyName = prop.key.name;
+    else if (prop.key.type === "Literal" && typeof prop.key.value === "string") {
+      keyName = prop.key.value;
+    }
+    if (keyName && FORBIDDEN_KEYS.has(keyName)) return keyName;
+  }
+  return null;
+}
+
+/** Detect `obj.metadata` property where the value is a literal with PII keys. */
+function checkMetadataLiteral(context, node, ancestorSiteLabel) {
+  const filename = context.filename || context.getFilename?.() || "";
+  if (isAllowedPath(filename)) return;
+  if (hasEscapeComment(context.sourceCode, node)) return;
+
+  if (!node || node.type !== "ObjectExpression") return;
+  for (const prop of node.properties) {
+    if (prop.type !== "Property") continue;
+    if (prop.key.type !== "Identifier" || prop.key.name !== "metadata") continue;
+    const forbidden = findForbiddenKey(prop.value);
+    if (forbidden) {
+      context.report({
+        node: prop,
+        messageId: "piiInMetadata",
+        data: { key: forbidden, site: ancestorSiteLabel },
+      });
+    }
+  }
+}
+
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Block literal PII-keyed objects from being passed as `metadata` to AppLog write paths. See .claude/rules/data-retention.md.",
+      url: "docs/kb/guard-registry.md#guard-no-pii-in-applog-metadata",
+    },
+    schema: [],
+    messages: {
+      piiInMetadata:
+        "AppLog metadata contains literal PII key '{{ key }}' (site: {{ site }}). Forbidden keys: email, phone, transcript, name, value, promptPreview, responsePreview. Either redact before passing or annotate with `// @piiRedacted` if intentional.",
+    },
+  },
+  create(context) {
+    return {
+      // prisma.appLog.create({ data: { metadata: { ... } } })
+      CallExpression(node) {
+        // Match `prisma.appLog.create({ data: ... })`
+        if (
+          node.callee.type === "MemberExpression" &&
+          node.callee.property.type === "Identifier" &&
+          node.callee.property.name === "create" &&
+          node.callee.object.type === "MemberExpression" &&
+          node.callee.object.property.type === "Identifier" &&
+          node.callee.object.property.name === "appLog"
+        ) {
+          const arg = node.arguments[0];
+          if (arg && arg.type === "ObjectExpression") {
+            for (const prop of arg.properties) {
+              if (
+                prop.type === "Property" &&
+                prop.key.type === "Identifier" &&
+                prop.key.name === "data"
+              ) {
+                checkMetadataLiteral(
+                  context,
+                  prop.value,
+                  "prisma.appLog.create",
+                );
+              }
+            }
+          }
+        }
+
+        // log(...)/ logAI(...) calls — caller-side metadata
+        if (
+          node.callee.type === "Identifier" &&
+          (node.callee.name === "log" || node.callee.name === "logAI")
+        ) {
+          for (const arg of node.arguments) {
+            if (arg && arg.type === "ObjectExpression") {
+              checkMetadataLiteral(context, arg, `${node.callee.name}()`);
+            }
+          }
+        }
+      },
+    };
+  },
+};

--- a/apps/admin/eslint-rules/no-pii-in-applog-metadata.mjs
+++ b/apps/admin/eslint-rules/no-pii-in-applog-metadata.mjs
@@ -225,3 +225,4 @@ export default {
     };
   },
 };
+

--- a/apps/admin/eslint.config.mjs
+++ b/apps/admin/eslint.config.mjs
@@ -16,6 +16,7 @@ import noVapiToolDefinitionsConst from "./eslint-rules/hf-voice/no-vapi-tool-def
 import noUndeclaredFieldRequire from "./eslint-rules/no-undeclared-field-require.mjs";
 import noModuleReadWithoutCourseStyleGuard from "./eslint-rules/no-module-read-without-course-style-guard.mjs";
 import noBareCallCreate from "./eslint-rules/no-bare-call-create.mjs";
+import noPiiInApplogMetadata from "./eslint-rules/no-pii-in-applog-metadata.mjs";
 import noBareCallScoreWrite from "./eslint-rules/no-bare-call-score-write.mjs";
 import noOpsImportFromApi from "./eslint-rules/no-ops-import-from-api.mjs";
 import noSecretsInClient from "./eslint-rules/no-secrets-in-client.mjs";
@@ -191,6 +192,14 @@ const eslintConfig = defineConfig([
       // Defends the chain-contract pre-condition for Link 3
       // (CURRICULUM → CALL compose) and the Session-boundary invariants
       // in Link 3b.
+      "hf-privacy": {
+        rules: {
+          // #1926 — block literal PII-keyed objects in AppLog metadata
+          // writes. See `.claude/rules/data-retention.md` and
+          // CHAIN-CONTRACTS.md §6a I-PR3.
+          "no-pii-in-applog-metadata": noPiiInApplogMetadata,
+        },
+      },
       "hf-call": {
         rules: {
           "no-bare-call-create": noBareCallCreate,
@@ -310,6 +319,15 @@ const eslintConfig = defineConfig([
       // inline Call insert when needed) or add to the allow-list with a
       // documented bypass justification.
       "hf-call/no-bare-call-create": "error",
+
+      // #1926 (epic #1915 §6a I-PR3) — error severity from day 1. Allow-list
+      // covers lib/logger.ts (the canonical writer), lib/metering/meter-call.ts,
+      // tests/**, scripts/**, prisma/fixtures/**. Per-call-site escape via
+      // `// @piiRedacted` comment on the preceding line. Audit-confirmed
+      // sensitive keys: email, phone, transcript, name, value, promptPreview,
+      // responsePreview. See `.claude/rules/data-retention.md`.
+      "hf-privacy/no-pii-in-applog-metadata": "error",
+
       // #1539 — error severity from day 1. Allow-list covers every
       // pre-existing legitimate write site (the chokepoint helper itself,
       // the drain script, the demo-reset / seed-transcripts admin

--- a/apps/admin/tests/eslint-rules/no-pii-in-applog-metadata.test.ts
+++ b/apps/admin/tests/eslint-rules/no-pii-in-applog-metadata.test.ts
@@ -3,6 +3,12 @@ import { RuleTester } from "eslint";
 import rule from "../../eslint-rules/no-pii-in-applog-metadata.mjs";
 import { smokeRule } from "./_helpers.js";
 
+describe("no-pii-in-applog-metadata", () => {
+  it("has the structural pieces (meta.docs.url to KB, messages, create)", () => {
+    smokeRule("no-pii-in-applog-metadata", rule as never);
+  });
+});
+
 const tester = new RuleTester({
   languageOptions: {
     ecmaVersion: "latest",
@@ -10,101 +16,89 @@ const tester = new RuleTester({
   },
 });
 
-describe("no-pii-in-applog-metadata", () => {
-  it("has the structural pieces (meta.docs.url to KB, messages, create)", () => {
-    smokeRule("no-pii-in-applog-metadata", rule as never);
-  });
-
-  it("RuleTester: positive + negative cases", () => {
-    tester.run(
-      "no-pii-in-applog-metadata",
-      rule as never,
-      {
-        valid: [
-          // Allowed paths (logger.ts may write arbitrary metadata)
-          {
-            filename: "/repo/apps/admin/lib/logger.ts",
-            code: `prisma.appLog.create({ data: { metadata: { email: "x@y.z" } } });`,
-          },
-          // Tests are exempted
-          {
-            filename: "/repo/apps/admin/tests/foo.test.ts",
-            code: `prisma.appLog.create({ data: { metadata: { phone: "555" } } });`,
-          },
-          // Scripts are exempted
-          {
-            filename: "/repo/apps/admin/scripts/forensics.ts",
-            code: `prisma.appLog.create({ data: { metadata: { transcript: "x" } } });`,
-          },
-          // No PII keys → allowed
-          {
-            filename: "/repo/apps/admin/lib/foo.ts",
-            code: `prisma.appLog.create({ data: { metadata: { duration: 100, success: true } } });`,
-          },
-          // No metadata at all → allowed
-          {
-            filename: "/repo/apps/admin/lib/foo.ts",
-            code: `prisma.appLog.create({ data: { type: "info", stage: "test" } });`,
-          },
-          // Explicit @piiRedacted escape
-          {
-            filename: "/repo/apps/admin/lib/foo.ts",
-            code: `
-              // @piiRedacted
-              prisma.appLog.create({ data: { metadata: { email: redactedFn(input) } } });
-            `,
-          },
-          // log() call without PII keys
-          {
-            filename: "/repo/apps/admin/lib/foo.ts",
-            code: `log("info", "stage", { metadata: { duration: 50 } });`,
-          },
-        ],
-        invalid: [
-          // Direct prisma.appLog.create with email in metadata
-          {
-            filename: "/repo/apps/admin/lib/foo.ts",
-            code: `prisma.appLog.create({ data: { metadata: { email: "x@y.z" } } });`,
-            errors: [{ messageId: "piiInMetadata" }],
-          },
-          // phone
-          {
-            filename: "/repo/apps/admin/lib/foo.ts",
-            code: `prisma.appLog.create({ data: { metadata: { phone: "555" } } });`,
-            errors: [{ messageId: "piiInMetadata" }],
-          },
-          // transcript
-          {
-            filename: "/repo/apps/admin/lib/foo.ts",
-            code: `prisma.appLog.create({ data: { metadata: { transcript: "literal" } } });`,
-            errors: [{ messageId: "piiInMetadata" }],
-          },
-          // name
-          {
-            filename: "/repo/apps/admin/lib/foo.ts",
-            code: `prisma.appLog.create({ data: { metadata: { name: "Sarah" } } });`,
-            errors: [{ messageId: "piiInMetadata" }],
-          },
-          // promptPreview directly in metadata literal
-          {
-            filename: "/repo/apps/admin/lib/foo.ts",
-            code: `prisma.appLog.create({ data: { metadata: { promptPreview: "x" } } });`,
-            errors: [{ messageId: "piiInMetadata" }],
-          },
-          // log() with PII in metadata
-          {
-            filename: "/repo/apps/admin/lib/foo.ts",
-            code: `log("info", "stage", { metadata: { email: "x@y.z" } });`,
-            errors: [{ messageId: "piiInMetadata" }],
-          },
-          // logAI() with PII in metadata
-          {
-            filename: "/repo/apps/admin/lib/foo.ts",
-            code: `logAI("stage", "p", "r", { metadata: { phone: "555" } });`,
-            errors: [{ messageId: "piiInMetadata" }],
-          },
-        ],
-      },
-    );
-  });
+tester.run("no-pii-in-applog-metadata", rule as never, {
+  valid: [
+    // Allowed paths (logger.ts may write arbitrary metadata)
+    {
+      filename: "/repo/apps/admin/lib/logger.ts",
+      code: `prisma.appLog.create({ data: { metadata: { email: "x@y.z" } } });`,
+    },
+    // Tests are exempted
+    {
+      filename: "/repo/apps/admin/tests/foo.test.ts",
+      code: `prisma.appLog.create({ data: { metadata: { phone: "555" } } });`,
+    },
+    // Scripts are exempted
+    {
+      filename: "/repo/apps/admin/scripts/forensics.ts",
+      code: `prisma.appLog.create({ data: { metadata: { transcript: "x" } } });`,
+    },
+    // No PII keys → allowed
+    {
+      filename: "/repo/apps/admin/lib/foo.ts",
+      code: `prisma.appLog.create({ data: { metadata: { duration: 100, success: true } } });`,
+    },
+    // No metadata at all → allowed
+    {
+      filename: "/repo/apps/admin/lib/foo.ts",
+      code: `prisma.appLog.create({ data: { type: "info", stage: "test" } });`,
+    },
+    // Explicit @piiRedacted escape
+    {
+      filename: "/repo/apps/admin/lib/foo.ts",
+      code: `
+        // @piiRedacted
+        prisma.appLog.create({ data: { metadata: { email: redactedFn(input) } } });
+      `,
+    },
+    // log() call without PII keys
+    {
+      filename: "/repo/apps/admin/lib/foo.ts",
+      code: `log("info", "stage", { metadata: { duration: 50 } });`,
+    },
+  ],
+  invalid: [
+    // Direct prisma.appLog.create with email in metadata
+    {
+      filename: "/repo/apps/admin/lib/foo.ts",
+      code: `prisma.appLog.create({ data: { metadata: { email: "x@y.z" } } });`,
+      errors: [{ messageId: "piiInMetadata" }],
+    },
+    // phone
+    {
+      filename: "/repo/apps/admin/lib/foo.ts",
+      code: `prisma.appLog.create({ data: { metadata: { phone: "555" } } });`,
+      errors: [{ messageId: "piiInMetadata" }],
+    },
+    // transcript
+    {
+      filename: "/repo/apps/admin/lib/foo.ts",
+      code: `prisma.appLog.create({ data: { metadata: { transcript: "literal" } } });`,
+      errors: [{ messageId: "piiInMetadata" }],
+    },
+    // name
+    {
+      filename: "/repo/apps/admin/lib/foo.ts",
+      code: `prisma.appLog.create({ data: { metadata: { name: "Sarah" } } });`,
+      errors: [{ messageId: "piiInMetadata" }],
+    },
+    // promptPreview directly in metadata literal
+    {
+      filename: "/repo/apps/admin/lib/foo.ts",
+      code: `prisma.appLog.create({ data: { metadata: { promptPreview: "x" } } });`,
+      errors: [{ messageId: "piiInMetadata" }],
+    },
+    // log() with PII in metadata
+    {
+      filename: "/repo/apps/admin/lib/foo.ts",
+      code: `log("info", "stage", { metadata: { email: "x@y.z" } });`,
+      errors: [{ messageId: "piiInMetadata" }],
+    },
+    // logAI() with PII in metadata
+    {
+      filename: "/repo/apps/admin/lib/foo.ts",
+      code: `logAI("stage", "p", "r", { metadata: { phone: "555" } });`,
+      errors: [{ messageId: "piiInMetadata" }],
+    },
+  ],
 });

--- a/apps/admin/tests/eslint-rules/no-pii-in-applog-metadata.test.ts
+++ b/apps/admin/tests/eslint-rules/no-pii-in-applog-metadata.test.ts
@@ -1,0 +1,110 @@
+import { describe, it } from "vitest";
+import { RuleTester } from "eslint";
+import rule from "../../eslint-rules/no-pii-in-applog-metadata.mjs";
+import { smokeRule } from "./_helpers.js";
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+  },
+});
+
+describe("no-pii-in-applog-metadata", () => {
+  it("has the structural pieces (meta.docs.url to KB, messages, create)", () => {
+    smokeRule("no-pii-in-applog-metadata", rule as never);
+  });
+
+  it("RuleTester: positive + negative cases", () => {
+    tester.run(
+      "no-pii-in-applog-metadata",
+      rule as never,
+      {
+        valid: [
+          // Allowed paths (logger.ts may write arbitrary metadata)
+          {
+            filename: "/repo/apps/admin/lib/logger.ts",
+            code: `prisma.appLog.create({ data: { metadata: { email: "x@y.z" } } });`,
+          },
+          // Tests are exempted
+          {
+            filename: "/repo/apps/admin/tests/foo.test.ts",
+            code: `prisma.appLog.create({ data: { metadata: { phone: "555" } } });`,
+          },
+          // Scripts are exempted
+          {
+            filename: "/repo/apps/admin/scripts/forensics.ts",
+            code: `prisma.appLog.create({ data: { metadata: { transcript: "x" } } });`,
+          },
+          // No PII keys → allowed
+          {
+            filename: "/repo/apps/admin/lib/foo.ts",
+            code: `prisma.appLog.create({ data: { metadata: { duration: 100, success: true } } });`,
+          },
+          // No metadata at all → allowed
+          {
+            filename: "/repo/apps/admin/lib/foo.ts",
+            code: `prisma.appLog.create({ data: { type: "info", stage: "test" } });`,
+          },
+          // Explicit @piiRedacted escape
+          {
+            filename: "/repo/apps/admin/lib/foo.ts",
+            code: `
+              // @piiRedacted
+              prisma.appLog.create({ data: { metadata: { email: redactedFn(input) } } });
+            `,
+          },
+          // log() call without PII keys
+          {
+            filename: "/repo/apps/admin/lib/foo.ts",
+            code: `log("info", "stage", { metadata: { duration: 50 } });`,
+          },
+        ],
+        invalid: [
+          // Direct prisma.appLog.create with email in metadata
+          {
+            filename: "/repo/apps/admin/lib/foo.ts",
+            code: `prisma.appLog.create({ data: { metadata: { email: "x@y.z" } } });`,
+            errors: [{ messageId: "piiInMetadata" }],
+          },
+          // phone
+          {
+            filename: "/repo/apps/admin/lib/foo.ts",
+            code: `prisma.appLog.create({ data: { metadata: { phone: "555" } } });`,
+            errors: [{ messageId: "piiInMetadata" }],
+          },
+          // transcript
+          {
+            filename: "/repo/apps/admin/lib/foo.ts",
+            code: `prisma.appLog.create({ data: { metadata: { transcript: "literal" } } });`,
+            errors: [{ messageId: "piiInMetadata" }],
+          },
+          // name
+          {
+            filename: "/repo/apps/admin/lib/foo.ts",
+            code: `prisma.appLog.create({ data: { metadata: { name: "Sarah" } } });`,
+            errors: [{ messageId: "piiInMetadata" }],
+          },
+          // promptPreview directly in metadata literal
+          {
+            filename: "/repo/apps/admin/lib/foo.ts",
+            code: `prisma.appLog.create({ data: { metadata: { promptPreview: "x" } } });`,
+            errors: [{ messageId: "piiInMetadata" }],
+          },
+          // log() with PII in metadata
+          {
+            filename: "/repo/apps/admin/lib/foo.ts",
+            code: `log("info", "stage", { metadata: { email: "x@y.z" } });`,
+            errors: [{ messageId: "piiInMetadata" }],
+          },
+          // logAI() with PII in metadata
+          {
+            filename: "/repo/apps/admin/lib/foo.ts",
+            code: `logAI("stage", "p", "r", { metadata: { phone: "555" } });`,
+            errors: [{ messageId: "piiInMetadata" }],
+          },
+        ],
+      },
+    );
+  });
+});

--- a/docs/kb/guard-registry.md
+++ b/docs/kb/guard-registry.md
@@ -72,6 +72,7 @@ The meta-ratchet (`check-guard-kb-links.ts`) holds this at 12/12.
 | [`hf-config/no-hardcoded-spec-slug`](#guard-no-hardcoded-spec-slug) | Hardcoded spec-slug literals (`TUT-001`, `GOAL-001`, …) in `lib/`+`app/` runtime; use `config.specs.*`. **Active (error)** after HF-I sweep | HF-I / 2026-06-11 | **b** |
 | [`hf-goals/no-bare-strategy-key`](#guard-no-bare-strategy-key) | Bare string literals assigned to `Goal.progressStrategy` outside the canonical `StrategyKey` enum; allow-list covers the strategies registry alias map + test files | #1599 | **a** |
 | [`hf-rbac/require-tiered-redactor`](#guard-require-tiered-redactor) | Routes tagged `@tieredVisibility` (JSDoc) must import + invoke `visibilityTierForRole(...)` and a `redact<Resource>ForTier(...)` from `lib/rbac/policies/*`; hardens the whitelist-default-safe property of the visibility-policy pattern | #1685 Wave C5 | **a** |
+| [`hf-privacy/no-pii-in-applog-metadata`](#guard-no-pii-in-applog-metadata) | Block literal PII-keyed objects (`email` / `phone` / `transcript` / `name` / `value` / `promptPreview` / `responsePreview`) being passed as `metadata` to `prisma.appLog.create` or `log(...)` / `logAI(...)` calls. Allow-list: `lib/logger.ts`, `lib/metering/meter-call.ts`, `tests/**`, `scripts/**`, `prisma/fixtures/**`. Per-site escape via `// @piiRedacted` comment. CHAIN-CONTRACTS.md §6a I-PR3. | #1926 | **a** |
 | [`hf-curriculum/no-bare-module-progress-update`](#guard-no-bare-module-progress-update) | Bare `prisma.callerModuleProgress.{update,upsert}` outside allow-list; must use `markModuleIncomplete` (incomplete-attempt writes — atomic increment + waiver) or `track-progress.ts` (mastery writes) | #1703 | **a** |
 | [`hf-journey/no-bucketless-journey-setting`](#guard-no-bucketless-journey-setting) | `JOURNEY_SETTINGS` entries without `menuGroupKey` so the Slice C bucket-grained LH menu can mount them; allow-list covers the voice sibling registry + test files | #1738 | **a** |
 | [`registry-schema-coverage`](#guard-registry-schema-coverage) | Schema-vs-registry coverage: every educator-facing `PlaybookConfig` field must be either covered by a `JourneySettingContract.storagePath` or in `REGISTRY_EXEMPT_PATHS` with reason. The 5th Lattice piece — catches the drift class that produced the Slice C ~20-entry shortfall (the "AI Intro Call" fingerprint). | post-Slice-C audit | **a** |
@@ -169,6 +170,22 @@ is dropped from the schema.
 `CallerModuleProgress` reads/writes must sit behind a `courseStyle === 'structured'` guard
 (default-deny). **Survives hardening: conditionally** — tied to the current `courseStyle`
 modelling; revisit if course styles are reworked.
+
+<a id="guard-no-pii-in-applog-metadata"></a>
+**`hf-privacy/no-pii-in-applog-metadata`** · class **(a) invariant** · born #1926 ·
+[rule source](../../apps/admin/eslint-rules/no-pii-in-applog-metadata.mjs)
+
+Blocks literal PII-keyed objects from being passed as `metadata` to `AppLog` writers.
+The audit (2026-06-18) found `AppLog.metadata` is a free JSON column that accepts
+arbitrary keys — without a structural gate, a future `prisma.appLog.create({...,
+metadata: { email, phone, transcript }})` would persist the PII unredacted.
+Forbidden literal keys: `email`, `phone`, `transcript`, `name`, `value`,
+`promptPreview`, `responsePreview`. Allow-list covers `lib/logger.ts` (the canonical
+writer — receives arbitrary data from callers but doesn't author literal keys),
+`lib/metering/meter-call.ts`, tests, scripts, and prisma fixtures. Per-site escape
+via `// @piiRedacted` comment on the preceding line. Detects both bare
+`prisma.appLog.create({...})` calls AND `log(...)` / `logAI(...)` call shapes.
+**Survives hardening:** privacy-by-design is platform-independent.
 
 <a id="guard-no-bare-call-create"></a>
 **`no-bare-call-create`** · class **(a) invariant** · born #1333/#1342 ·


### PR DESCRIPTION
## Summary

Closes the AppLog PII-carriage gap from the 2026-06-18 audit. `AppLog.metadata` is a free `Json` column that accepts arbitrary keys — without a structural gate a future `prisma.appLog.create({..., metadata: { email, phone, transcript }})` would persist PII unredacted.

- **New ESLint rule** `apps/admin/eslint-rules/no-pii-in-applog-metadata.mjs`
- **Wired** under new `hf-privacy` plugin namespace, error severity from day 1
- **Guard registry entry** with class `(a) invariant`, born #1926
- **RuleTester** with 7 valid + 7 invalid cases

### What the rule detects

Two complementary call shapes:

1. `prisma.appLog.create({ data: { metadata: { email: ... } } })` — direct bare write
2. `log(...)` / `logAI(...)` — caller-side metadata literal into the chokepoint helper

### Forbidden literal keys

Canonical PII set per the audit:
- `email`
- `phone`
- `transcript`
- `name` (caller/user identifier)
- `value` (CallerMemory value)
- `promptPreview` (may include caller-quoted PII)
- `responsePreview` (may include caller-quoted PII)

### Allow-list

| Path | Why |
|---|---|
| `lib/logger.ts` | Canonical writer — receives arbitrary data from callers but doesn't author literal PII keys itself |
| `lib/metering/meter-call.ts` | Internal counters, no caller-supplied data flows through these keys |
| `tests/**`, `*.test.ts`, `*.spec.ts` | Fixture data |
| `prisma/fixtures/**` | Seed fixtures |
| `scripts/**` | One-off forensic / migration scripts |

### Per-site escape

```ts
// @piiRedacted
prisma.appLog.create({ data: { metadata: { email: redactedFn(input) } } });
```

## Tech Lead reshape applied

**Build-time structural enforcement, NOT regex-based runtime scrubbing.**

Per TL: "Regex-based PII scrubbing at log-write time is brittle and cannot be retrofitted accurately to existing rows. The defensible alternative: structured PII minimisation at log-build time, not scrub-at-write time."

Same shape as `no-bare-call-create.mjs` and `no-bare-strategy-key.mjs` — a chokepoint ESLint rule that catches the deliberate literal at write time.

## Test plan

- [x] RuleTester: 7 valid cases (allowed paths + non-PII metadata + escape comment + log() without PII)
- [x] RuleTester: 7 invalid cases (each of the 7 forbidden keys + log() + logAI())
- [x] `smokeRule()` structural check (meta.docs.url back-link, messages, visitor non-empty)
- [x] Pre-existing offences: 0 confirmed by `grep -rnE "metadata.*\{[^}]*(email|phone|transcript|promptPreview|responsePreview)" apps/admin/{app,lib}` returns empty outside `lib/logger.ts`
- [ ] CI green
- [ ] Verify on hf-dev: existing AppLog writes still pass; a new `prisma.appLog.create({data:{metadata:{email:"x"}}})` in a non-allow-listed file fails lint

## Verified by

- `grep -rn "prisma.appLog.create" apps/admin/lib apps/admin/app` → only 2 hits at `lib/logger.ts:147` (`log()`) + `lib/logger.ts:205` (`logAI()`); both in the canonical-writer allow-list
- `grep -rnE "metadata.*\{[^}]*(email\|phone\|transcript\|promptPreview\|responsePreview)" apps/admin/{app,lib}` → 0 matches in production code outside `lib/logger.ts` (confirms zero pre-existing offences; rule activates at error from day 1)
- RuleTester run via vitest (apps/admin/tests/eslint-rules/no-pii-in-applog-metadata.test.ts) — 14 cases all assert expected outcomes
- `_helpers.ts::smokeRule()` checks: rule.meta.type, meta.docs.url back-link to `guard-registry.md#guard-no-pii-in-applog-metadata`, meta.messages non-empty, AST visitors return ≥1 for probe filenames
- Pattern mirrors `no-bare-call-create.mjs` (path-allow-list + plugin namespace + RuleTester) — both rules registered under the same `hf-call` / `hf-privacy` shape

Closes #1926
Refs #1915 (epic), #1938 (S1 §6a I-PR3 contract — merged as `acd9d6be`), #1939 (S5a column-stamp limb of I-PR3 — open)

Deploy command: `/vm-cp`