### PR TITLE
docs: reflect 2026-06-18 stable-DEV state + neutralise broken deploy.yml stub

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,21 @@
 name: Deploy
 
+# 2026-06-18: this workflow is a NON-FUNCTIONAL STUB from the original
+# skeleton — `STAGING_DATABASE_URL` is a placeholder secret name (real
+# one is `DATABASE_URL_STAGING`), the deploy step is commented-out
+# pseudo-code, and the smoke test points at `staging.yourapp.com`.
+# Every push to `main` triggered this and failed in CI noise.
+#
+# REAL fast-fix path to DEV today: `gh workflow run deploy-staging-quick.yml`
+# (~5-7 min, runner-only image, GHA cache). See docs/RELEASE-PROCESS.md §2.
+#
+# Disabled push-trigger; kept workflow_dispatch so the placeholder code
+# survives without firing on every commit. Repair tracked separately —
+# until then the lean workflow is the canonical fast path.
+
 on:
-  push:
-    branches: [main]
+  # push:
+  #   branches: [main]   # disabled — was failing on every push (see banner above)
   workflow_dispatch:
     inputs:
       environment:

--- a/docs/CLOUD-DEPLOYMENT.md
+++ b/docs/CLOUD-DEPLOYMENT.md
@@ -337,12 +337,12 @@ All envs live in the same GCP project (`hf-admin-prod`, region `europe-west2`). 
 | **pilot** | `pilot.humanfirstfoundation.com` | `hf-admin-pilot` | `DATABASE_URL_PILOT` | `hf_pilot` | `hf-seed-pilot` | `hf-migrate-pilot` |
 | **prod** | `app.humanfirstfoundation.com` | `hf-admin-prod` | `DATABASE_URL_PROD` | `hf_prod` | `hf-seed-prod` | `hf-migrate-prod` |
 
-### Current state (as of #726 Phase 1 complete)
+### Current state (as of 2026-06-18 — Phase 3 complete; Phase 4 partial)
 
 | Env | Status | Notes |
 |-----|--------|-------|
-| **sandbox** (VM) | ✅ alive | Still uses `hf_dev` DB until Phase 3 renames to `hf_sandbox` |
-| **staging** | 🟡 transitional | Cloud Run `hf-admin-dev` is alive at `dev.humanfirstfoundation.com`; renames to `hf-admin-staging` at `staging.humanfirstfoundation.com` in Phase 4 |
+| **sandbox** (VM) | ✅ alive | `hf-dev` VM uses `hf_sandbox` DB (Phase 3 done 2026-06-07) |
+| **staging** | 🟡 transitional | Cloud Run service is still named `hf-admin-dev`, public URL still `dev.humanfirstfoundation.com`. **DB binding:** historically bound to `DATABASE_URL_SANDBOX` (shared with the VM). **2026-06-18 stable-DEV rebuild:** clean `hf_staging` rebuilt with 7 PUBLISHED playbooks (IELTS Speaking, Big Five, Intro to Psychology, Spot the Spin, 3 CIO/CTO variants) + 4 institutions + 5 SUPERADMIN users + 0 callers. Pivot via `/db-route staging staging` re-binds Cloud Run to `DATABASE_URL_STAGING`. Service rename + DNS cut to `staging.humanfirstfoundation.com` remain Phase 4 work. |
 | **pilot** | ⏳ to be provisioned | Phase 5 — old `hf-admin-test` + `hf_test` DB killed in Phase 1 |
 | **prod** | ⏳ to be provisioned | Phase 6 — old `hf-admin` + `hf` DB + `lab.humanfirstfoundation.com` killed in Phase 1 (prod was broken/unused) |
 
@@ -353,7 +353,7 @@ All envs live in the same GCP project (`hf-admin-prod`, region `europe-west2`). 
 | **Cloud SQL** | `hf-db` — PostgreSQL 16, db-f1-micro, private IP only (172.23.0.3). Separate databases per env. **Automated daily backups enabled 2026-05-24** (14 retained, 7-day PITR, start time 02:00). |
 | **VPC Connector** | `hf-connector` — bridges Cloud Run → Cloud SQL |
 | **Artifact Registry** | `europe-west2-docker.pkg.dev/hf-admin-prod/hf-docker/` |
-| **Secrets Manager** | `DATABASE_URL_SANDBOX` (VM dev), `DATABASE_URL_STAGING` (hf-admin-dev Cloud Run, has A3 pool params), `AUTH_SECRET`, `HF_SUPERADMIN_TOKEN`, `ANTHROPIC_API_KEY`, `INTERNAL_API_SECRET`, `OPENAI_API_KEY`. (`DATABASE_URL_DEV` was deleted 2026-06-07 — renamed to `_STAGING` per the Phase 4 cutover.) |
+| **Secrets Manager** | `DATABASE_URL_SANDBOX` (VM + Cloud Run `hf-admin-dev` pre-pivot), `DATABASE_URL_STAGING` (Cloud Run `hf-admin-dev` post-pivot; A3 pool params), `AUTH_SECRET`, `HF_SUPERADMIN_TOKEN`, `ANTHROPIC_API_KEY`, `INTERNAL_API_SECRET`, `OPENAI_API_KEY`. (`DATABASE_URL_DEV` was deleted 2026-06-07.) Use `/db-route` to switch the Cloud Run binding atomically without rebuild. |
 | **Cloudflare Worker** | `still-cake-1d83` (canonical router) — see [CLOUDFLARE-WORKER-ROUTING.md](./CLOUDFLARE-WORKER-ROUTING.md) |
 | **Cloudflare Tunnel** | `00d2c2cc-...` on hf-dev VM — currently dead weight, may be decommissioned |
 

--- a/docs/RELEASE-PROCESS.md
+++ b/docs/RELEASE-PROCESS.md
@@ -10,7 +10,7 @@
 | Env | Cloud Run | Cloud SQL DB | Stability | Who writes |
 |---|---|---|---|---|
 | **SAND** | n/a (VM `hf-dev`) | `hf_sandbox` | Throwaway | Paul + Boaz (interactive) via `/vm-cp` / `/vm-cpp` |
-| **DEV** | `hf-admin-dev` (`dev.humanfirstfoundation.com`) | `hf_dev` | Semi-stable | CI only (auto-deploy on merge to `main`) |
+| **DEV** | `hf-admin-dev` (`dev.humanfirstfoundation.com`) | `hf_staging` (post-2026-06-18 pivot — pre-pivot was `hf_sandbox`) | Semi-stable | Manual `gh workflow run deploy-staging-quick.yml` (~5-7 min); auto-deploy on `main` push is a stub that fails every run (#1725 follow-on) |
 | **TEST** | `hf-admin-test` (`test.humanfirstfoundation.com`) | `hf_test` | Most stable | Release-tag promotion only |
 | **PROD** | `hf-admin` (`lab.humanfirstfoundation.com`) | `hf_prod` | Live | Release-tag promotion (post-TEST smoke) |
 
@@ -25,7 +25,7 @@ feature branch → PR → main → DEV (auto) → release/* branch → TEST → 
 ```
 
 - **Branches:** `feat/<#>-slug` / `fix/<#>-slug` / `chore/<slug>` — mandatory per CLAUDE.md.
-- **DEV is auto-deployed** from `main` on every merge (shipped in [#1725](https://github.com/WANDERCOLTD/HF/issues/1725)). `paths-ignore` skips docs-only commits.
+- **DEV is intended to auto-deploy** from `main` on every merge (target shipped in [#1725](https://github.com/WANDERCOLTD/HF/issues/1725)) — however the `deploy.yml` workflow is currently a non-functional stub (placeholder DB secret + placeholder URL; fails on every push to `main`). **Until repaired, ship to DEV via `gh workflow run deploy-staging-quick.yml`** (~5-7 min, lean runner-only image with GHA cache).
 - **TEST is promoted** by cutting a `release/<date>` branch. Same image source as DEV; rebuilt with `NEXT_PUBLIC_APP_ENV=TEST`.
 - **PROD is promoted** by merging the `release/*` branch + tagging. Same image SHA path; rebuilt with `NEXT_PUBLIC_APP_ENV=PROD`.
 
@@ -156,7 +156,7 @@ Alert channel: operator email on 2 consecutive uptime failures (Cloud Monitoring
 ## 11. Glossary
 
 - **SAND** — VM `hf-dev`, `hf_sandbox` DB. Operators iterate here.
-- **DEV** — Cloud Run `hf-admin-dev`, `hf_dev` DB. CI-only writes; auto-refreshes from `main`.
+- **DEV** — Cloud Run `hf-admin-dev` at `dev.humanfirstfoundation.com`, `hf_staging` DB (post-2026-06-18 pivot). Fast-fix path: `gh workflow run deploy-staging-quick.yml` (~5-7 min). Auto-deploy from `main` is a stub today (see §2).
 - **TEST** — Cloud Run `hf-admin-test`, `hf_test` DB. Release-promotion only.
 - **PROD** — Cloud Run `hf-admin`, `hf_prod` DB. Live.
 - **Promotion** — `release/<date>` branch cut from main + tag triggers TEST/PROD deploy of the same source SHA.


### PR DESCRIPTION
Three updates from tonight's stable-DEV staging build:

1. **docs/CLOUD-DEPLOYMENT.md** — Current-state table updated for Phase 3 complete + Phase 4 partial. Secrets Manager row reflects pre/post-pivot binding distinction.
2. **docs/RELEASE-PROCESS.md** — corrected the false 'DEV auto-deploys from main' claim. deploy.yml is a non-functional stub; real fast-fix path is `gh workflow run deploy-staging-quick.yml` (~5-7 min).
3. **.github/workflows/deploy.yml** — push-trigger commented out so the stub stops failing every main push. workflow_dispatch retained.

## Evidence

`gh run list --workflow=deploy.yml --limit 5` returned 5 consecutive `failure` runs on 2026-06-18 push events. `gh run list --workflow=deploy-staging-quick.yml` returned all `success` on manual dispatches.

## Verified by

Lattice survey (CI-docs-parity rule): `.github/workflows/deploy.yml` change paired with edits to both watched docs (`docs/CLOUD-DEPLOYMENT.md` + `docs/RELEASE-PROCESS.md`). No DB column mutation, no chain-stage boundary, no new guard; docs-correctness + dead-workflow neutralisation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)