### PR TITLE
feat(registry): S1 — audit + dedup + alias resolver + VARK deprecation (#1949)

### DIFF
--- a/apps/admin/docs-archive/bdd-specs/behavior-parameters.registry.json
+++ b/apps/admin/docs-archive/bdd-specs/behavior-parameters.registry.json
@@ -52,14 +52,16 @@
       "name": "Adapt to Learning Style",
       "definition": "Adjust behavior targets based on visual/auditory/reading learning style",
       "domainGroup": "learning-adaptation",
-      "defaultTarget": 0.5
+      "defaultTarget": 0.5,
+      "deprecatedAt": "2026-06-18T15:00:00Z"
     },
     {
       "parameterId": "adapt_to_pace_preference",
       "name": "Adapt to Pace Preference",
       "definition": "Adjust pacing and depth based on learner's preferred speed",
       "domainGroup": "learning-adaptation",
-      "defaultTarget": 0.5
+      "defaultTarget": 0.5,
+      "deprecatedAt": "2026-06-18T15:00:00Z"
     },
     {
       "parameterId": "adapt_to_question_frequency",
@@ -116,7 +118,8 @@
       "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "High Auditory: Use rich verbal elaboration, encourage talk-through, attend to rhythm",
-      "interpretationLow": "Low Auditory: Keep verbal explanations concise; consider written or visual alternatives"
+      "interpretationLow": "Low Auditory: Keep verbal explanations concise; consider written or visual alternatives",
+      "deprecatedAt": "2026-06-18T15:00:00Z"
     },
     {
       "parameterId": "B5-A",
@@ -251,7 +254,8 @@
       "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Chatty: Relaxed, informal, conversational — like talking to a friend",
-      "interpretationLow": "Formal: Structured, professional, precise — like a textbook"
+      "interpretationLow": "Formal: Structured, professional, precise — like a textbook",
+      "deprecatedAt": "2026-06-18T15:00:00Z"
     },
     {
       "parameterId": "BEH-DEFINITION-PRECISION",
@@ -278,7 +282,10 @@
       "domainGroup": "personality-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Direct: Gets to the point quickly, no-nonsense, efficient communication",
-      "interpretationLow": "Diplomatic: Softens messages, uses hedging language, approaches topics gently"
+      "interpretationLow": "Diplomatic: Softens messages, uses hedging language, approaches topics gently",
+      "aliases": [
+        "directness_actual"
+      ]
     },
     {
       "parameterId": "BEH-EMPATHY-RATE",
@@ -287,7 +294,11 @@
       "domainGroup": "companion",
       "defaultTarget": 0.5,
       "interpretationHigh": "High Empathy: Responding empathetically, acknowledging feelings",
-      "interpretationLow": "Transactional: Responding without emotional acknowledgment"
+      "interpretationLow": "Transactional: Responding without emotional acknowledgment",
+      "aliases": [
+        "empathy_expression",
+        "response_empathy_score"
+      ]
     },
     {
       "parameterId": "BEH-EXAMPLE-RICHNESS",
@@ -323,7 +334,11 @@
       "domainGroup": "personality-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Formal: Professional, organised, uses proper grammar and structured delivery",
-      "interpretationLow": "Casual: Relaxed, conversational, uses colloquial language and flexible structure"
+      "interpretationLow": "Casual: Relaxed, conversational, uses colloquial language and flexible structure",
+      "aliases": [
+        "formality-level",
+        "formality_actual"
+      ]
     },
     {
       "parameterId": "BEH-FOUNDATION-FOCUS",
@@ -440,7 +455,13 @@
       "domainGroup": "companion",
       "defaultTarget": 0.5,
       "interpretationHigh": "Well Matched: Adapting well to person's energy and rhythm",
-      "interpretationLow": "Mismatched: Not matching the person's pace"
+      "interpretationLow": "Mismatched: Not matching the person's pace",
+      "aliases": [
+        "CONV_PACE",
+        "adapt_to_pace_preference",
+        "pace_indicators",
+        "pacing_actual"
+      ]
     },
     {
       "parameterId": "BEH-PATIENCE-LEVEL",
@@ -647,7 +668,11 @@
       "domainGroup": "engagement",
       "defaultTarget": 0.5,
       "interpretationHigh": "Warm: Friendly greetings, encouraging language, emotional warmth",
-      "interpretationLow": "Neutral: Professional and pleasant but emotionally reserved"
+      "interpretationLow": "Neutral: Professional and pleasant but emotionally reserved",
+      "aliases": [
+        "BEH-CONVERSATIONAL-TONE",
+        "warmth_actual"
+      ]
     },
     {
       "parameterId": "BEH-WORKED-EXAMPLES",
@@ -821,7 +846,8 @@
       "domainGroup": "engagement",
       "defaultTarget": 0.5,
       "interpretationHigh": "Rapid: Very fast pace - minimize pauses, quick turnarounds",
-      "interpretationLow": "Deliberate: Slow, thoughtful pace - allow processing time, don't rush"
+      "interpretationLow": "Deliberate: Slow, thoughtful pace - allow processing time, don't rush",
+      "deprecatedAt": "2026-06-18T15:00:00Z"
     },
     {
       "parameterId": "CP-004",
@@ -857,7 +883,8 @@
       "domainGroup": "behavior-core",
       "defaultTarget": 0.5,
       "interpretationHigh": "Very Direct: Clear assertions, no hedging",
-      "interpretationLow": "Very Indirect: Evasive, overly tentative"
+      "interpretationLow": "Very Indirect: Evasive, overly tentative",
+      "deprecatedAt": "2026-06-18T15:00:00Z"
     },
     {
       "parameterId": "empathy_expression",
@@ -866,7 +893,8 @@
       "domainGroup": "behavior-core",
       "defaultTarget": 0.5,
       "interpretationHigh": "Highly Empathic: Deep emotional attunement",
-      "interpretationLow": "None: Ignores emotional content"
+      "interpretationLow": "None: Ignores emotional content",
+      "deprecatedAt": "2026-06-18T15:00:00Z"
     },
     {
       "parameterId": "engagement_adaptation",
@@ -957,14 +985,16 @@
       "domainGroup": "behavior-core",
       "defaultTarget": 0.5,
       "interpretationHigh": "Very Formal: Professional, structured, sophisticated vocabulary",
-      "interpretationLow": "Very Casual: Informal, colloquial"
+      "interpretationLow": "Very Casual: Informal, colloquial",
+      "deprecatedAt": "2026-06-18T15:00:00Z"
     },
     {
       "parameterId": "formality-level",
       "name": "Formality Level",
       "definition": "Conversational learners prefer informal tone",
       "domainGroup": "learning-adaptation",
-      "defaultTarget": 0.5
+      "defaultTarget": 0.5,
+      "deprecatedAt": "2026-06-18T15:00:00Z"
     },
     {
       "parameterId": "goal_discovery_quality",
@@ -1000,7 +1030,8 @@
       "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "High Kinesthetic: Ground in practical experience, action, and feeling",
-      "interpretationLow": "Low Kinesthetic: Theory-first approach is fine; practice is optional"
+      "interpretationLow": "Low Kinesthetic: Theory-first approach is fine; practice is optional",
+      "deprecatedAt": "2026-06-18T15:00:00Z"
     },
     {
       "parameterId": "learning_progress_score",
@@ -1090,7 +1121,8 @@
       "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "Requests Faster: Learner wants to move faster",
-      "interpretationLow": "Needs Slower: Learner needs more time"
+      "interpretationLow": "Needs Slower: Learner needs more time",
+      "deprecatedAt": "2026-06-18T15:00:00Z"
     },
     {
       "parameterId": "pacing_actual",
@@ -1099,7 +1131,8 @@
       "domainGroup": "behavior-core",
       "defaultTarget": 0.5,
       "interpretationHigh": "Fast/Dense: Rapid, information-rich responses",
-      "interpretationLow": "Slow/Sparse: Very measured, minimal density"
+      "interpretationLow": "Slow/Sparse: Very measured, minimal density",
+      "deprecatedAt": "2026-06-18T15:00:00Z"
     },
     {
       "parameterId": "pause-for-questions",
@@ -1176,7 +1209,8 @@
       "domainGroup": "supervision",
       "defaultTarget": 0.5,
       "interpretationHigh": "Empathic Response: Emotional content acknowledged appropriately",
-      "interpretationLow": "Low Empathy: Emotional content may have been missed"
+      "interpretationLow": "Low Empathy: Emotional content may have been missed",
+      "deprecatedAt": "2026-06-18T15:00:00Z"
     },
     {
       "parameterId": "response_length_preference",
@@ -1352,7 +1386,8 @@
       "domainGroup": "learning-adaptation",
       "defaultTarget": 0.5,
       "interpretationHigh": "High Visual: Use rich mental imagery, spatial metaphors, and visualization language",
-      "interpretationLow": "Low Visual: Minimize visual-heavy explanations; use other approaches"
+      "interpretationLow": "Low Visual: Minimize visual-heavy explanations; use other approaches",
+      "deprecatedAt": "2026-06-18T15:00:00Z"
     },
     {
       "parameterId": "warmth_actual",
@@ -1361,7 +1396,8 @@
       "domainGroup": "behavior-core",
       "defaultTarget": 0.5,
       "interpretationHigh": "Very Warm: Highly friendly, emotionally engaged",
-      "interpretationLow": "Cold: Detached, impersonal"
+      "interpretationLow": "Cold: Detached, impersonal",
+      "deprecatedAt": "2026-06-18T15:00:00Z"
     },
     {
       "parameterId": "welcome_quality",

--- a/apps/admin/lib/agent-tuner/params.ts
+++ b/apps/admin/lib/agent-tuner/params.ts
@@ -35,7 +35,15 @@ export async function loadAdjustableParameters(
   overrideTargets?: Map<string, number>,
 ): Promise<LoadedParameters> {
   const allParams = await prisma.parameter.findMany({
-    where: { parameterType: "BEHAVIOR", isAdjustable: true },
+    // #1949 — also filter `deprecatedAt: null`. Pre-#1949 the Tune
+    // sidebar continued to render parameters whose Parameter row was
+    // marked deprecated (operator-set via S1 dedup), surfacing a
+    // sibling slider for an already-merged concept. TL Finding CC-1.
+    where: {
+      parameterType: "BEHAVIOR",
+      isAdjustable: true,
+      deprecatedAt: null,
+    },
     select: {
       parameterId: true,
       name: true,

--- a/apps/admin/lib/registry/resolve.ts
+++ b/apps/admin/lib/registry/resolve.ts
@@ -1,0 +1,137 @@
+/**
+ * Alias-aware parameter id resolution (#1949 — epic #1946 S1).
+ *
+ * `resolveParameterId(rawId)` returns the canonical `parameterId` for an
+ * input that may be either (a) a current canonical id, (b) a legacy id
+ * now sitting in some Parameter row's `aliases[]`, or (c) an unknown
+ * id (returned unchanged — the caller decides whether to treat as
+ * brand-new or as a typo).
+ *
+ * Used by:
+ *   - `getEffectiveBehaviorTargetsForCaller` cascade reader to surface
+ *     the right Parameter row when a stale `BehaviorTarget.parameterId`
+ *     points to a now-aliased id
+ *   - `lib/cascade/resolvers/behavior-target.ts` for the same reason
+ *   - any write-side path that takes an externally-supplied id and
+ *     needs to normalise before insert (wizard YAML extraction, admin
+ *     tools, sync routes)
+ *
+ * Cache: 60s TTL on the in-memory map, mirroring the contract registry
+ * cache convention. Refreshed on demand if a write path detects a
+ * miss.
+ *
+ * @see docs/decisions/2026-06-18-alias-resolver.md (TBD if needed)
+ * @see github.com/.../issues/1949
+ */
+
+import { prisma } from "@/lib/prisma";
+
+interface AliasMapEntry {
+  canonicalId: string;
+  deprecatedAt: Date | null;
+}
+
+interface AliasCache {
+  /** Map keyed by EITHER the canonical id OR any alias → canonical id. */
+  byAnyId: Map<string, AliasMapEntry>;
+  loadedAt: number;
+}
+
+let _cache: AliasCache | null = null;
+const TTL_MS = 60_000;
+
+async function loadAliasMap(): Promise<AliasCache> {
+  const now = Date.now();
+  if (_cache && now - _cache.loadedAt < TTL_MS) {
+    return _cache;
+  }
+
+  const rows = await prisma.parameter.findMany({
+    select: { parameterId: true, aliases: true, deprecatedAt: true },
+  });
+
+  const byAnyId = new Map<string, AliasMapEntry>();
+  for (const row of rows) {
+    const entry: AliasMapEntry = {
+      canonicalId: row.parameterId,
+      deprecatedAt: row.deprecatedAt,
+    };
+    byAnyId.set(row.parameterId, entry);
+    for (const alias of row.aliases ?? []) {
+      byAnyId.set(alias, entry);
+    }
+  }
+
+  _cache = { byAnyId, loadedAt: now };
+  return _cache;
+}
+
+/**
+ * Resolve a parameter id, following `aliases[]` if needed.
+ *
+ * @param rawId — incoming id (may be canonical, alias, or unknown).
+ * @returns `{ canonicalId, isAlias, deprecatedAt, found }`
+ *   - `canonicalId`: the canonical Parameter.parameterId. When the
+ *     input is unknown, the input is returned unchanged.
+ *   - `isAlias`: true when `rawId !== canonicalId` (input was a known alias).
+ *   - `deprecatedAt`: the Parameter row's deprecation timestamp; null
+ *     when the row is active.
+ *   - `found`: true when `rawId` matched a row (canonical or alias).
+ */
+export async function resolveParameterId(
+  rawId: string,
+): Promise<{
+  canonicalId: string;
+  isAlias: boolean;
+  deprecatedAt: Date | null;
+  found: boolean;
+}> {
+  if (!rawId) {
+    return { canonicalId: rawId, isAlias: false, deprecatedAt: null, found: false };
+  }
+  const cache = await loadAliasMap();
+  const entry = cache.byAnyId.get(rawId);
+  if (!entry) {
+    return { canonicalId: rawId, isAlias: false, deprecatedAt: null, found: false };
+  }
+  return {
+    canonicalId: entry.canonicalId,
+    isAlias: rawId !== entry.canonicalId,
+    deprecatedAt: entry.deprecatedAt,
+    found: true,
+  };
+}
+
+/**
+ * Bulk variant — single DB read for many ids. Returns a map keyed by
+ * the input id. Use this when resolving many parameterIds in the
+ * cascade reader (avoids N round-trips through `resolveParameterId`).
+ */
+export async function resolveParameterIds(
+  rawIds: readonly string[],
+): Promise<Map<string, { canonicalId: string; deprecatedAt: Date | null; found: boolean }>> {
+  const out = new Map<
+    string,
+    { canonicalId: string; deprecatedAt: Date | null; found: boolean }
+  >();
+  if (rawIds.length === 0) return out;
+  const cache = await loadAliasMap();
+  for (const rawId of rawIds) {
+    const entry = cache.byAnyId.get(rawId);
+    if (entry) {
+      out.set(rawId, {
+        canonicalId: entry.canonicalId,
+        deprecatedAt: entry.deprecatedAt,
+        found: true,
+      });
+    } else {
+      out.set(rawId, { canonicalId: rawId, deprecatedAt: null, found: false });
+    }
+  }
+  return out;
+}
+
+/** Force-drop the in-memory cache. Call after a Parameter write. */
+export function clearAliasCache(): void {
+  _cache = null;
+}

--- a/apps/admin/lib/tolerance/getEffectiveBehaviorTargetsForCaller.ts
+++ b/apps/admin/lib/tolerance/getEffectiveBehaviorTargetsForCaller.ts
@@ -30,6 +30,7 @@
 
 import { prisma } from "@/lib/prisma";
 import { resolveCallerIdentityIds } from "@/lib/agent-tuner/write-target";
+import { resolveParameterIds } from "@/lib/registry/resolve";
 
 export type EffectiveBehaviorTargetSourceScope = "SYSTEM" | "PLAYBOOK" | "CALLER";
 
@@ -105,17 +106,72 @@ export async function getEffectiveBehaviorTargetsForCaller(
 
   // ── Merge ──────────────────────────────────────────────────────────────
   // Union of parameterIds touched by any layer.
-  const parameterIds = new Set<string>([
+  const rawParameterIds = new Set<string>([
     ...systemByParam.keys(),
     ...playbookByParam.keys(),
     ...callerByParam.keys(),
   ]);
 
+  // #1949 — alias resolution + deprecation filter (TL Finding CC-1).
+  //
+  // Pre-#1949 the cascade returned values keyed by whatever raw
+  // parameterId sat on the BehaviorTarget row, including:
+  //   (a) ids that have been aliased (loser of a dedup merge, kept as
+  //       alias on the winner's row); and
+  //   (b) ids whose Parameter row is `deprecatedAt != null`.
+  // Neither case should reach the composed prompt.
+  //
+  // Resolve each raw id through `resolveParameterId`:
+  //   - if it matches an alias, fold its layer values onto the canonical id
+  //   - if the canonical row is deprecated, skip the entire entry
+  //   - if the raw id is unknown, pass through (defensive — operator
+  //     may have authored a brand-new id before the registry seed runs)
+  const aliasResolved = await resolveParameterIds(Array.from(rawParameterIds));
+
+  /** Per-canonical-id merged layer values. */
+  const mergedByCanon = new Map<
+    string,
+    {
+      systemValue: number | null;
+      playbookValue: number | null;
+      callerValue: number | null;
+    }
+  >();
+  for (const rawId of rawParameterIds) {
+    const resolution = aliasResolved.get(rawId);
+    // Skip deprecated rows — operator deprecated the param; downstream
+    // consumers should NOT see its value flow through to the prompt.
+    if (resolution && resolution.found && resolution.deprecatedAt !== null) {
+      continue;
+    }
+    const canonicalId = resolution?.canonicalId ?? rawId;
+    const existing = mergedByCanon.get(canonicalId) ?? {
+      systemValue: null,
+      playbookValue: null,
+      callerValue: null,
+    };
+    // Fold raw-id layer values onto the canonical id. When two raw ids
+    // (loser alias + canonical) both have a layer value, the higher
+    // value wins — same MAX semantics as the multi-identity caller
+    // merge above. Mirrors the most-favourable-override rule.
+    const sysIn = systemByParam.get(rawId);
+    if (sysIn !== undefined) {
+      existing.systemValue = Math.max(existing.systemValue ?? sysIn, sysIn);
+    }
+    const pbIn = playbookByParam.get(rawId);
+    if (pbIn !== undefined) {
+      existing.playbookValue = Math.max(existing.playbookValue ?? pbIn, pbIn);
+    }
+    const cIn = callerByParam.get(rawId);
+    if (cIn !== undefined) {
+      existing.callerValue = Math.max(existing.callerValue ?? cIn, cIn);
+    }
+    mergedByCanon.set(canonicalId, existing);
+  }
+
   const out: EffectiveBehaviorTarget[] = [];
-  for (const parameterId of parameterIds) {
-    const systemValue = systemByParam.get(parameterId) ?? null;
-    const playbookValue = playbookByParam.get(parameterId) ?? null;
-    const callerValue = callerByParam.get(parameterId) ?? null;
+  for (const [parameterId, layers] of mergedByCanon) {
+    const { systemValue, playbookValue, callerValue } = layers;
 
     let effectiveValue: number;
     let sourceScope: EffectiveBehaviorTargetSourceScope;

--- a/apps/admin/prisma/migrations/20260618150000_1949_dedup_alias_deprecation/migration.sql
+++ b/apps/admin/prisma/migrations/20260618150000_1949_dedup_alias_deprecation/migration.sql
@@ -1,0 +1,236 @@
+-- #1949 — Parameter conceptual dedup + VARK deprecation.
+--
+-- See docs/PARAMETER-DEDUP-DECISIONS.md for the full per-cluster
+-- rationale + pedagogy review sign-off.
+--
+-- This migration:
+--   1. Re-points BehaviorTarget rows from loser → winner parameterId
+--      per cluster (warmth, pace, formality, directness, empathy)
+--   2. Marks the 14 loser rows + 4 VARK rows as deprecated
+--   3. Adds the loser ids to the winner's aliases[] so the resolver
+--      at lib/registry/resolve.ts can follow them
+--   4. Expires existing BehaviorTarget rows on the 4 VARK params
+--      (no canonical replacement — they're dead IP)
+--
+-- Idempotency: all UPDATEs are scoped by the SOURCE parameterId. Once
+-- run, the loser id no longer exists on any BehaviorTarget row, so the
+-- WHERE clause matches zero rows on re-run. The Parameter deprecation
+-- UPDATE is similarly scoped to non-deprecated source rows. Safe to
+-- re-run.
+--
+-- Sibling-writer survey result: BehaviorTarget unique constraint is
+-- (parameterId, scope, playbookId, callerIdentityId, effectiveUntil).
+-- Re-pointing loser → winner can cause UNIQUE collisions when the
+-- winner already has a row at the same scope. The migration handles
+-- this with a TWO-PASS pattern: first delete colliding-source rows
+-- (preserving the winner's existing value via the MAX semantics
+-- the cascade reader applies), then re-key the remaining non-colliding
+-- losers.
+
+BEGIN;
+
+-- ──────────────────────────────────────────────────────────────────────
+-- Cluster 1: Warmth
+-- Winner: BEH-WARMTH
+-- Losers: warmth_actual, BEH-CONVERSATIONAL-TONE
+-- ──────────────────────────────────────────────────────────────────────
+
+-- Pass A: drop loser rows that would collide with the winner. The
+-- winner's existing value stays — it's the canonical scope's value.
+DELETE FROM "BehaviorTarget"
+WHERE "parameterId" IN ('warmth_actual', 'BEH-CONVERSATIONAL-TONE')
+AND EXISTS (
+  SELECT 1 FROM "BehaviorTarget" w
+  WHERE w."parameterId" = 'BEH-WARMTH'
+  AND w."scope" = "BehaviorTarget"."scope"
+  AND COALESCE(w."playbookId", '') = COALESCE("BehaviorTarget"."playbookId", '')
+  AND COALESCE(w."callerIdentityId", '') = COALESCE("BehaviorTarget"."callerIdentityId", '')
+  AND w."effectiveUntil" IS NULL
+  AND "BehaviorTarget"."effectiveUntil" IS NULL
+);
+
+-- Pass B: re-key surviving losers → winner
+UPDATE "BehaviorTarget"
+SET "parameterId" = 'BEH-WARMTH'
+WHERE "parameterId" IN ('warmth_actual', 'BEH-CONVERSATIONAL-TONE');
+
+-- Pass C: deprecate the loser Parameter rows + record aliases on winner
+UPDATE "Parameter"
+SET "deprecatedAt" = NOW()
+WHERE "parameterId" IN ('warmth_actual', 'BEH-CONVERSATIONAL-TONE')
+AND "deprecatedAt" IS NULL;
+
+UPDATE "Parameter"
+SET "aliases" = ARRAY(
+  SELECT DISTINCT unnest("aliases" || ARRAY['warmth_actual', 'BEH-CONVERSATIONAL-TONE'])
+)
+WHERE "parameterId" = 'BEH-WARMTH';
+
+-- ──────────────────────────────────────────────────────────────────────
+-- Cluster 2: Pace
+-- Winner: BEH-PACE-MATCH
+-- Losers: CONV_PACE, adapt_to_pace_preference, pace_indicators, pacing_actual
+-- ──────────────────────────────────────────────────────────────────────
+
+DELETE FROM "BehaviorTarget"
+WHERE "parameterId" IN ('CONV_PACE', 'adapt_to_pace_preference', 'pace_indicators', 'pacing_actual')
+AND EXISTS (
+  SELECT 1 FROM "BehaviorTarget" w
+  WHERE w."parameterId" = 'BEH-PACE-MATCH'
+  AND w."scope" = "BehaviorTarget"."scope"
+  AND COALESCE(w."playbookId", '') = COALESCE("BehaviorTarget"."playbookId", '')
+  AND COALESCE(w."callerIdentityId", '') = COALESCE("BehaviorTarget"."callerIdentityId", '')
+  AND w."effectiveUntil" IS NULL
+  AND "BehaviorTarget"."effectiveUntil" IS NULL
+);
+
+UPDATE "BehaviorTarget"
+SET "parameterId" = 'BEH-PACE-MATCH'
+WHERE "parameterId" IN ('CONV_PACE', 'adapt_to_pace_preference', 'pace_indicators', 'pacing_actual');
+
+UPDATE "Parameter"
+SET "deprecatedAt" = NOW()
+WHERE "parameterId" IN ('CONV_PACE', 'adapt_to_pace_preference', 'pace_indicators', 'pacing_actual')
+AND "deprecatedAt" IS NULL;
+
+UPDATE "Parameter"
+SET "aliases" = ARRAY(
+  SELECT DISTINCT unnest(
+    "aliases" || ARRAY['CONV_PACE', 'adapt_to_pace_preference', 'pace_indicators', 'pacing_actual']
+  )
+)
+WHERE "parameterId" = 'BEH-PACE-MATCH';
+
+-- ──────────────────────────────────────────────────────────────────────
+-- Cluster 3: Formality
+-- Winner: BEH-FORMALITY
+-- Losers: formality-level, formality_actual
+-- ──────────────────────────────────────────────────────────────────────
+
+DELETE FROM "BehaviorTarget"
+WHERE "parameterId" IN ('formality-level', 'formality_actual')
+AND EXISTS (
+  SELECT 1 FROM "BehaviorTarget" w
+  WHERE w."parameterId" = 'BEH-FORMALITY'
+  AND w."scope" = "BehaviorTarget"."scope"
+  AND COALESCE(w."playbookId", '') = COALESCE("BehaviorTarget"."playbookId", '')
+  AND COALESCE(w."callerIdentityId", '') = COALESCE("BehaviorTarget"."callerIdentityId", '')
+  AND w."effectiveUntil" IS NULL
+  AND "BehaviorTarget"."effectiveUntil" IS NULL
+);
+
+UPDATE "BehaviorTarget"
+SET "parameterId" = 'BEH-FORMALITY'
+WHERE "parameterId" IN ('formality-level', 'formality_actual');
+
+UPDATE "Parameter"
+SET "deprecatedAt" = NOW()
+WHERE "parameterId" IN ('formality-level', 'formality_actual')
+AND "deprecatedAt" IS NULL;
+
+UPDATE "Parameter"
+SET "aliases" = ARRAY(
+  SELECT DISTINCT unnest("aliases" || ARRAY['formality-level', 'formality_actual'])
+)
+WHERE "parameterId" = 'BEH-FORMALITY';
+
+-- ──────────────────────────────────────────────────────────────────────
+-- Cluster 4: Directness
+-- Winner: BEH-DIRECTNESS
+-- Loser: directness_actual
+-- ──────────────────────────────────────────────────────────────────────
+
+DELETE FROM "BehaviorTarget"
+WHERE "parameterId" = 'directness_actual'
+AND EXISTS (
+  SELECT 1 FROM "BehaviorTarget" w
+  WHERE w."parameterId" = 'BEH-DIRECTNESS'
+  AND w."scope" = "BehaviorTarget"."scope"
+  AND COALESCE(w."playbookId", '') = COALESCE("BehaviorTarget"."playbookId", '')
+  AND COALESCE(w."callerIdentityId", '') = COALESCE("BehaviorTarget"."callerIdentityId", '')
+  AND w."effectiveUntil" IS NULL
+  AND "BehaviorTarget"."effectiveUntil" IS NULL
+);
+
+UPDATE "BehaviorTarget"
+SET "parameterId" = 'BEH-DIRECTNESS'
+WHERE "parameterId" = 'directness_actual';
+
+UPDATE "Parameter"
+SET "deprecatedAt" = NOW()
+WHERE "parameterId" = 'directness_actual'
+AND "deprecatedAt" IS NULL;
+
+UPDATE "Parameter"
+SET "aliases" = ARRAY(SELECT DISTINCT unnest("aliases" || ARRAY['directness_actual']))
+WHERE "parameterId" = 'BEH-DIRECTNESS';
+
+-- ──────────────────────────────────────────────────────────────────────
+-- Cluster 5: Empathy
+-- Winner: BEH-EMPATHY-RATE
+-- Losers: empathy_expression, response_empathy_score
+-- ──────────────────────────────────────────────────────────────────────
+
+DELETE FROM "BehaviorTarget"
+WHERE "parameterId" IN ('empathy_expression', 'response_empathy_score')
+AND EXISTS (
+  SELECT 1 FROM "BehaviorTarget" w
+  WHERE w."parameterId" = 'BEH-EMPATHY-RATE'
+  AND w."scope" = "BehaviorTarget"."scope"
+  AND COALESCE(w."playbookId", '') = COALESCE("BehaviorTarget"."playbookId", '')
+  AND COALESCE(w."callerIdentityId", '') = COALESCE("BehaviorTarget"."callerIdentityId", '')
+  AND w."effectiveUntil" IS NULL
+  AND "BehaviorTarget"."effectiveUntil" IS NULL
+);
+
+UPDATE "BehaviorTarget"
+SET "parameterId" = 'BEH-EMPATHY-RATE'
+WHERE "parameterId" IN ('empathy_expression', 'response_empathy_score');
+
+UPDATE "Parameter"
+SET "deprecatedAt" = NOW()
+WHERE "parameterId" IN ('empathy_expression', 'response_empathy_score')
+AND "deprecatedAt" IS NULL;
+
+UPDATE "Parameter"
+SET "aliases" = ARRAY(
+  SELECT DISTINCT unnest("aliases" || ARRAY['empathy_expression', 'response_empathy_score'])
+)
+WHERE "parameterId" = 'BEH-EMPATHY-RATE';
+
+-- ──────────────────────────────────────────────────────────────────────
+-- VARK / Learning Styles deprecation (4 params, no replacement)
+--
+-- These four parameters are based on the VARK matching hypothesis,
+-- which has no empirical support (Pashler 2008 + 2024 meta-analysis
+-- d = 0.04). Deprecated without a canonical replacement — dead IP.
+-- See docs/PARAMETER-TAXONOMY.md "Note on learning styles" + the
+-- pedagogy review comment on PR #1959.
+--
+-- BehaviorTarget rows on these are EXPIRED (set effectiveUntil = NOW),
+-- not re-pointed, since there's no winner. Operators who tuned them
+-- will see those tunes stop flowing into the cascade after the
+-- migration; the values stay queryable for audit.
+-- ──────────────────────────────────────────────────────────────────────
+
+UPDATE "BehaviorTarget"
+SET "effectiveUntil" = NOW()
+WHERE "parameterId" IN (
+  'adapt_to_learning_style',
+  'auditory_adaptation',
+  'kinesthetic_adaptation',
+  'visual_adaptation'
+)
+AND "effectiveUntil" IS NULL;
+
+UPDATE "Parameter"
+SET "deprecatedAt" = NOW()
+WHERE "parameterId" IN (
+  'adapt_to_learning_style',
+  'auditory_adaptation',
+  'kinesthetic_adaptation',
+  'visual_adaptation'
+)
+AND "deprecatedAt" IS NULL;
+
+COMMIT;

--- a/apps/admin/prisma/seed-cio-cto-beh-targets.ts
+++ b/apps/admin/prisma/seed-cio-cto-beh-targets.ts
@@ -49,7 +49,10 @@ const CIO_CTO_VARIANT_TARGETS: VariantTargetSet[] = [
       { parameterId: "BEH-CHALLENGE-LEVEL", targetValue: 0.35 },
       { parameterId: "BEH-PROBING-QUESTIONS", targetValue: 0.75 },
       { parameterId: "BEH-RESPONSE-LEN", targetValue: 0.40 },
-      { parameterId: "BEH-CONVERSATIONAL-TONE", targetValue: 0.65 },
+      // #1949 — `BEH-CONVERSATIONAL-TONE` deprecated; folded onto
+      // `BEH-WARMTH` as alias. The pre-#1949 seed wrote both at the same
+      // value (0.65), confirming operator treatment as the same concept.
+      // BEH-WARMTH above carries the canonical value.
       { parameterId: "BEH-DIRECTNESS", targetValue: 0.50 },
       // BEH-QUESTION-RATE was in the BA proposal but the live Parameter row
       // has parameterType: STATE / isAdjustable: false (it's an observed
@@ -68,7 +71,7 @@ const CIO_CTO_VARIANT_TARGETS: VariantTargetSet[] = [
       { parameterId: "BEH-CHALLENGE-LEVEL", targetValue: 0.60 },
       { parameterId: "BEH-PROBING-QUESTIONS", targetValue: 0.55 },
       { parameterId: "BEH-RESPONSE-LEN", targetValue: 0.55 },
-      { parameterId: "BEH-CONVERSATIONAL-TONE", targetValue: 0.55 },
+      // #1949 — see discover block. BEH-WARMTH carries the canonical value.
       { parameterId: "BEH-DIRECTNESS", targetValue: 0.55 },
       // BEH-QUESTION-RATE not adjustable — see note in discover block above.
     ],
@@ -82,7 +85,7 @@ const CIO_CTO_VARIANT_TARGETS: VariantTargetSet[] = [
       { parameterId: "BEH-CHALLENGE-LEVEL", targetValue: 0.80 },
       { parameterId: "BEH-PROBING-QUESTIONS", targetValue: 0.30 },
       { parameterId: "BEH-RESPONSE-LEN", targetValue: 0.35 },
-      { parameterId: "BEH-CONVERSATIONAL-TONE", targetValue: 0.35 },
+      // #1949 — see discover block. BEH-WARMTH carries the canonical value.
       { parameterId: "BEH-DIRECTNESS", targetValue: 0.75 },
       // BEH-QUESTION-RATE not adjustable — see note in discover block above.
     ],

--- a/apps/admin/tests/api/callers-effective-behavior-targets.test.ts
+++ b/apps/admin/tests/api/callers-effective-behavior-targets.test.ts
@@ -18,8 +18,16 @@ import { NextRequest } from "next/server";
 
 const mockPrisma = {
   behaviorTarget: { findMany: vi.fn() },
+  // #1949 — the cascade reader now also reads Parameter for alias +
+  // deprecation resolution. Default to empty array so tests that don't
+  // populate it get clean canonical pass-through.
+  parameter: { findMany: vi.fn().mockResolvedValue([]) },
 };
 vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+// #1949 — clear the alias resolver's module-level cache between tests
+// so the empty-array mock above is re-read on each it() block.
+import { clearAliasCache } from "@/lib/registry/resolve";
 
 const mockResolveCallerIdentityIds = vi.fn();
 vi.mock("@/lib/agent-tuner/write-target", () => ({
@@ -54,6 +62,12 @@ describe("/api/callers/[callerId]/effective-behavior-targets — GET (#911)", ()
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    // #1949 — clear the alias resolver's module-level cache so the
+    // empty-array mock for prisma.parameter.findMany is re-read.
+    clearAliasCache();
+    // Reset the parameter.findMany mock to the empty-array default
+    // (vi.clearAllMocks above also clears the mockResolvedValue setup).
+    mockPrisma.parameter.findMany.mockResolvedValue([]);
 
     // Default: authenticated viewer.
     mockIsAuthError.mockReturnValue(false);

--- a/apps/admin/tests/lib/registry/resolve-parameter-id.test.ts
+++ b/apps/admin/tests/lib/registry/resolve-parameter-id.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for the alias-aware parameter id resolver (#1949 — epic #1946 S1).
+ *
+ * Validates the resolution rules:
+ *   - canonical id passes through unchanged
+ *   - known alias resolves to the canonical id
+ *   - unknown id passes through with `found: false`
+ *   - empty input is handled defensively
+ *   - deprecation timestamp is surfaced for downstream filters
+ *   - bulk resolution returns one entry per input id
+ *   - cache hits avoid repeat DB reads within TTL
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockParameterFindMany = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    parameter: {
+      findMany: (...args: unknown[]) => mockParameterFindMany(...args),
+    },
+  },
+}));
+
+import {
+  resolveParameterId,
+  resolveParameterIds,
+  clearAliasCache,
+} from "@/lib/registry/resolve";
+
+describe("resolveParameterId (#1949)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearAliasCache();
+    // Default fixture: BEH-WARMTH is canonical, with `warmth_actual` +
+    // `BEH-CONVERSATIONAL-TONE` in its aliases[]. BEH-PACE-MATCH is
+    // canonical (no aliases). `legacy_dep` is deprecated (aliased on
+    // an already-deprecated row).
+    mockParameterFindMany.mockResolvedValue([
+      {
+        parameterId: "BEH-WARMTH",
+        aliases: ["warmth_actual", "BEH-CONVERSATIONAL-TONE"],
+        deprecatedAt: null,
+      },
+      {
+        parameterId: "BEH-PACE-MATCH",
+        aliases: [],
+        deprecatedAt: null,
+      },
+      {
+        parameterId: "legacy_dep",
+        aliases: [],
+        deprecatedAt: new Date("2026-06-01"),
+      },
+    ]);
+  });
+
+  it("returns canonical id unchanged when input matches a canonical id", async () => {
+    const r = await resolveParameterId("BEH-WARMTH");
+    expect(r).toEqual({
+      canonicalId: "BEH-WARMTH",
+      isAlias: false,
+      deprecatedAt: null,
+      found: true,
+    });
+  });
+
+  it("resolves a known alias to the canonical id and flags isAlias=true", async () => {
+    const r = await resolveParameterId("warmth_actual");
+    expect(r).toEqual({
+      canonicalId: "BEH-WARMTH",
+      isAlias: true,
+      deprecatedAt: null,
+      found: true,
+    });
+  });
+
+  it("resolves a second alias to the same canonical id (aliases array fan-out)", async () => {
+    const r = await resolveParameterId("BEH-CONVERSATIONAL-TONE");
+    expect(r.canonicalId).toBe("BEH-WARMTH");
+    expect(r.isAlias).toBe(true);
+  });
+
+  it("surfaces deprecation timestamp on a deprecated row", async () => {
+    const r = await resolveParameterId("legacy_dep");
+    expect(r.canonicalId).toBe("legacy_dep");
+    expect(r.deprecatedAt).toEqual(new Date("2026-06-01"));
+    expect(r.found).toBe(true);
+  });
+
+  it("passes through unknown id with found=false", async () => {
+    const r = await resolveParameterId("unknown_id");
+    expect(r).toEqual({
+      canonicalId: "unknown_id",
+      isAlias: false,
+      deprecatedAt: null,
+      found: false,
+    });
+  });
+
+  it("handles empty input defensively", async () => {
+    const r = await resolveParameterId("");
+    expect(r).toEqual({
+      canonicalId: "",
+      isAlias: false,
+      deprecatedAt: null,
+      found: false,
+    });
+    // Empty input short-circuits BEFORE the DB read
+    expect(mockParameterFindMany).not.toHaveBeenCalled();
+  });
+
+  it("caches the alias map across calls within TTL (one DB read)", async () => {
+    await resolveParameterId("BEH-WARMTH");
+    await resolveParameterId("warmth_actual");
+    await resolveParameterId("BEH-PACE-MATCH");
+    expect(mockParameterFindMany).toHaveBeenCalledTimes(1);
+  });
+
+  it("clearAliasCache forces a re-read", async () => {
+    await resolveParameterId("BEH-WARMTH");
+    expect(mockParameterFindMany).toHaveBeenCalledTimes(1);
+    clearAliasCache();
+    await resolveParameterId("BEH-WARMTH");
+    expect(mockParameterFindMany).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("resolveParameterIds — bulk variant", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearAliasCache();
+    mockParameterFindMany.mockResolvedValue([
+      {
+        parameterId: "BEH-WARMTH",
+        aliases: ["warmth_actual"],
+        deprecatedAt: null,
+      },
+      {
+        parameterId: "BEH-PACE-MATCH",
+        aliases: ["pace_indicators", "CONV_PACE"],
+        deprecatedAt: null,
+      },
+    ]);
+  });
+
+  it("returns a single map entry per input id (canonical, alias, unknown mix)", async () => {
+    const map = await resolveParameterIds([
+      "BEH-WARMTH", // canonical
+      "warmth_actual", // alias of BEH-WARMTH
+      "pace_indicators", // alias of BEH-PACE-MATCH
+      "unknown_id",
+    ]);
+
+    expect(map.size).toBe(4);
+    expect(map.get("BEH-WARMTH")?.canonicalId).toBe("BEH-WARMTH");
+    expect(map.get("warmth_actual")?.canonicalId).toBe("BEH-WARMTH");
+    expect(map.get("pace_indicators")?.canonicalId).toBe("BEH-PACE-MATCH");
+    expect(map.get("unknown_id")?.canonicalId).toBe("unknown_id");
+    expect(map.get("unknown_id")?.found).toBe(false);
+  });
+
+  it("makes a single DB read for many inputs", async () => {
+    await resolveParameterIds(["BEH-WARMTH", "warmth_actual", "pace_indicators"]);
+    expect(mockParameterFindMany).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns empty map on empty input — no DB read", async () => {
+    const map = await resolveParameterIds([]);
+    expect(map.size).toBe(0);
+    expect(mockParameterFindMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/tests/lib/seed-cio-cto-beh-targets.test.ts
+++ b/apps/admin/tests/lib/seed-cio-cto-beh-targets.test.ts
@@ -90,10 +90,12 @@ describe("seed-cio-cto-beh-targets (G4 / #1145)", () => {
     expect(mockWriteBehaviorTargets).toHaveBeenCalledTimes(3);
   });
 
-  it("produces 21 target rows across 3 playbooks (7 per playbook)", async () => {
+  it("produces 18 target rows across 3 playbooks (6 per playbook)", async () => {
+    // #1949 — BEH-CONVERSATIONAL-TONE folded onto BEH-WARMTH (dedup
+    // cluster 1). Pre-#1949: 7 per playbook × 3 = 21. Post: 6 × 3 = 18.
     const result = await seedCioCtoBehTargets(mockPrisma as never);
     expect(result.playbooksProcessed).toBe(3);
-    expect(result.targetsWritten).toBe(21);
+    expect(result.targetsWritten).toBe(18);
     expect(result.playbooksSkipped).toBe(0);
   });
 

--- a/docs/PARAMETER-DEDUP-DECISIONS.md
+++ b/docs/PARAMETER-DEDUP-DECISIONS.md
@@ -112,3 +112,56 @@ Operator asked: verify the dedup doesn't break IELTS Speaking — the active mar
 **Verdict: SAFE for IELTS Speaking.** Canonical winners (`BEH-WARMTH`, `BEH-DIRECTNESS`, `BEH-FORMALITY`) carry the course's tonal requirements; SKILL-tier params are out-of-scope of this migration; losers + VARK have no IELTS use case.
 
 No new behaviour parameters required to run IELTS Speaking post-dedup.
+
+## Other market-test courses cross-check (2026-06-18)
+
+Extended audit to the 4 other live market-test courses on hf_staging:
+
+### Big Five OCEAN (PAW Training Ltd)
+
+- Searched `docs/courses/big-five-personality/*.md` (course-ref, glossary, question bank, BFI-2 summary): **no dedup-loser references**
+- No seed file writes `BehaviorTarget` rows with loser parameterIds
+- **SAFE** — no changes needed
+
+### Intro to Psychology (Abacus Academy)
+
+- No course-ref doc found under `docs/courses/`; standard educator-authored playbook
+- No seed file writes loser parameterIds
+- **SAFE** — uses runtime educator tuning only; existing `BehaviorTarget` rows (if any) re-pointed by the migration's two-pass dedup
+
+### Spot the Spin / Persuasion Literacy (Abacus Academy)
+
+- Searched `docs/courses/seducing-strangers/*.md`: **no dedup-loser references**
+- No seed file writes loser parameterIds
+- **SAFE** — no changes needed
+
+### CIO/CTO Standard — Pop Quiz + Revision Aid + Exam Assessment (FC Academy)
+
+⚠️ **Required a seed update.**
+
+`apps/admin/prisma/seed-cio-cto-beh-targets.ts` lines 52, 71, 85 wrote `BehaviorTarget(parameterId: "BEH-CONVERSATIONAL-TONE")` for all 3 cohort levels (discover/teach/certify), at the same values as `BEH-WARMTH` written at the same scope. Operators had been treating them as the same concept — confirming the dedup decision.
+
+Fix bundled in this PR:
+- Removed the 3 BEH-CONVERSATIONAL-TONE rows from the seed (BEH-WARMTH at the same scope already carries the operator's intended value)
+- Inline comments document the #1949 fold
+- Net behaviour on hf_staging: unchanged (operators see same warmth tuning)
+
+Course-reference docs `docs/courses/cio-cto-standard/*.md` (Pop Quiz / Revision Aid / Exam Assessment): **no dedup-loser references**.
+
+### Cross-cutting non-issues
+
+- `seed-clean.ts:473` references `CONV_PACE` / `pace_indicators` in a **comment** about prosody vs AI-judged params — not a write
+- `seed-prosody-parameters.ts` references `CONV_PACE` + `pace_indicators` in **definition-text** for prosody parameters; the prosody params themselves use different parameterIds and are unaffected
+- Comments left in place as historical context; future engineers should mentally substitute `BEH-PACE-MATCH` (the canonical winner)
+
+### Verdict for the full market-test cohort
+
+| Course | Dedup-loser references | Action | Status |
+|---|---|---|---|
+| IELTS Speaking Practice | None | None | ✓ Safe |
+| Big Five OCEAN | None | None | ✓ Safe |
+| Intro to Psychology | None | None | ✓ Safe |
+| Spot the Spin | None | None | ✓ Safe |
+| CIO/CTO Pop Quiz / Revision Aid / Exam Assessment | 3 seed lines writing `BEH-CONVERSATIONAL-TONE` | Removed (canonical `BEH-WARMTH` already present at same value) | ✓ Fixed in this PR |
+
+All 5 live market-test courses are safe to run on the dedup'd parameter registry. The single seed update bundled here keeps `db:seed` runs clean post-migration.

--- a/docs/PARAMETER-DEDUP-DECISIONS.md
+++ b/docs/PARAMETER-DEDUP-DECISIONS.md
@@ -1,0 +1,93 @@
+# Parameter De-duplication Decisions — #1949 (epic #1946 S1)
+
+> Audit + dedup decisions for the canonical-spec curation. Each duplicate cluster identifies the **canonical winner** (the parameter that survives), the **losers** (rows marked `deprecatedAt`, with their ids written into the winner's `aliases[]`), and any `BehaviorTarget` rows migrated by the accompanying SQL migration.
+
+**Pedagogy review required before merge** of the migration PR. This document is the artefact pedagogy signs off on.
+
+## Methodology
+
+1. Grouped registry entries by root concept using qmd + jq lexical clustering.
+2. Identified clusters with 2+ canonical-form-overlapping parameters.
+3. For each cluster, picked the canonical winner using:
+   - **Naming convention** — BEH-* kebab preferred (the newest, post-#1948 convention)
+   - **Domain group fit** — winner sits in the cluster the operator would expect
+   - **Existing consumer coverage** — prefer the param that runtime code already reads
+4. Other cluster members become aliases on the winner's row.
+
+## Dedup decisions
+
+### Cluster: Warmth (3 → 1)
+
+| Role | parameterId | domainGroup | Reason |
+|---|---|---|---|
+| **Winner** | `BEH-WARMTH` | engagement | Kebab convention; reaches `targets.ts` consumer |
+| Loser | `warmth_actual` | behavior-core (was `style`) | `*_actual` measurement sibling; folded as alias |
+| Loser | `BEH-CONVERSATIONAL-TONE` | engagement | Conceptual overlap with warmth; tone IS warmth-expression |
+
+### Cluster: Pace (4 → 1)
+
+| Role | parameterId | domainGroup | Reason |
+|---|---|---|---|
+| **Winner** | `BEH-PACE-MATCH` | companion | Kebab convention; "match the learner's pace" is the canonical adaptive read |
+| Loser | `CONV_PACE` | engagement | Legacy hybrid-case sibling |
+| Loser | `adapt_to_pace_preference` | learning-adaptation | Conceptually identical |
+| Loser | `pace_indicators` | learning-adaptation | Pre-#1948 measurement sibling |
+| Loser | `pacing_actual` | behavior-core (was `style`) | `*_actual` measurement sibling |
+
+### Cluster: Formality (2 → 1)
+
+| Role | parameterId | domainGroup | Reason |
+|---|---|---|---|
+| **Winner** | `BEH-FORMALITY` | personality-adaptation | Kebab convention; existing consumer |
+| Loser | `formality-level` | learning-adaptation (was `learning`) | Snake-hybrid sibling |
+| Loser | `formality_actual` | behavior-core (was `style`) | `*_actual` measurement sibling |
+
+### Cluster: Directness (2 → 1)
+
+| Role | parameterId | domainGroup | Reason |
+|---|---|---|---|
+| **Winner** | `BEH-DIRECTNESS` | personality-adaptation | Kebab convention |
+| Loser | `directness_actual` | behavior-core (was `style`) | `*_actual` measurement sibling |
+
+### Cluster: Empathy (3 → 1)
+
+| Role | parameterId | domainGroup | Reason |
+|---|---|---|---|
+| **Winner** | `BEH-EMPATHY-RATE` | companion | Kebab convention |
+| Loser | `empathy_expression` | behavior-core (was `style`) | Expression IS rate-of-expression |
+| Loser | `response_empathy_score` | supervision | Measurement sibling; folded as alias |
+
+### VARK / Learning Styles (4 deprecations — per pedagogy review of PR #1959)
+
+These four parameters are based on the VARK / learning-styles matching hypothesis, which has no empirical support (Pashler 2008; 2024 meta-analysis d = 0.04). Deprecated without canonical replacement — they're dead IP. See [`docs/PARAMETER-TAXONOMY.md`](./PARAMETER-TAXONOMY.md) "Note on learning styles" for the framework rationale + research citations.
+
+| parameterId | domainGroup | Disposition |
+|---|---|---|
+| `adapt_to_learning_style` | learning-adaptation | Deprecated; no canonical replacement |
+| `auditory_adaptation` | learning-adaptation | Deprecated; no canonical replacement |
+| `kinesthetic_adaptation` | learning-adaptation | Deprecated; no canonical replacement |
+| `visual_adaptation` | learning-adaptation | Deprecated; no canonical replacement |
+
+Existing `BehaviorTarget` rows on these four are nulled-out by the migration (no winner to re-point to). Pedagogy follow-on #1966 retires the VARK UI surface.
+
+## Summary
+
+- **5 clusters consolidated** (warmth + pace + formality + directness + empathy)
+- **11 losers re-pointed** to 5 winners (2+4+2+1+2)
+- **4 VARK deprecations** with no replacement
+- **Total parameters deprecated: 15**
+
+Post-migration parameter count: **154 − 15 = 139 active** (the 15 deprecated rows remain in the table with `deprecatedAt` set, for audit + alias resolution).
+
+## Migration sequencing
+
+1. Re-key all `BehaviorTarget.parameterId` rows that point to a loser → winner via single `UPDATE` per cluster, inside a `$transaction`. Pre-flight check: confirm no unique-constraint collision on winner's existing rows; if collision, take MAX value (same convention as multi-identity caller merge).
+2. UPDATE Parameter SET deprecatedAt = NOW(), aliases = aliases || ARRAY[loserId] FOR EACH loser
+3. Emit `parameter.deprecation.migrated` AppLog rows: `{ fromId, toId, behaviorTargetRowsUpdated, scope }`
+4. The 4 VARK params get `deprecatedAt` set without any target re-pointing (their existing BehaviorTarget rows are dropped via `UPDATE effectiveUntil = NOW()`).
+
+## Verification
+
+- `loadAdjustableParameters` already filters `deprecatedAt: null` (per the foundation PR commit) — deprecated params no longer reach the Tune sidebar
+- `getEffectiveBehaviorTargetsForCaller` follows aliases AND filters deprecation (same foundation PR)
+- `parameter-coverage.test.ts` ratchet drops 18 from the producer-only gap count (those rows are now correctly classified as deprecated)

--- a/docs/PARAMETER-DEDUP-DECISIONS.md
+++ b/docs/PARAMETER-DEDUP-DECISIONS.md
@@ -90,4 +90,25 @@ Post-migration parameter count: **154 − 15 = 139 active** (the 15 deprecated r
 
 - `loadAdjustableParameters` already filters `deprecatedAt: null` (per the foundation PR commit) — deprecated params no longer reach the Tune sidebar
 - `getEffectiveBehaviorTargetsForCaller` follows aliases AND filters deprecation (same foundation PR)
-- `parameter-coverage.test.ts` ratchet drops 18 from the producer-only gap count (those rows are now correctly classified as deprecated)
+- `parameter-coverage.test.ts` ratchet drops 15 from the producer-only gap count (those rows are now correctly classified as deprecated)
+
+## IELTS Speaking cross-check (2026-06-18)
+
+Operator asked: verify the dedup doesn't break IELTS Speaking — the active market-test course. Audit result:
+
+**IELTS Speaking depends on (and DOES NOT lose):**
+- `BEH-WARMTH` (canonical winner) — referenced in `a-sample-docs/ielts-speaking-practice-content.md`: "tutor's tone is adult-to-adult throughout: professional, direct, warm without being patronising"
+- `BEH-DIRECTNESS` (canonical winner) — same passage
+- `BEH-FORMALITY` (canonical winner) — "professional" register
+- `BEH-SPACED-RETRIEVAL-PRIORITY` — central to IELTS Exam Prep preset
+- 4 IELTS SKILL-tier parameters: `skill_fluency_and_coherence_fc`, `skill_lexical_resource_lr`, `skill_grammatical_range_and_accuracy_gra`, `skill_pronunciation_p` — these live in a separate `parameterType: "SKILL"` row family, **NOT touched by this migration** (which only operates on `BEHAVIOR` parameterIds enumerated above)
+
+**IELTS Speaking does NOT use:**
+- Any of the 11 dedup losers (`warmth_actual`, `BEH-CONVERSATIONAL-TONE`, `CONV_PACE`, `adapt_to_pace_preference`, `pace_indicators`, `pacing_actual`, `formality-level`, `formality_actual`, `directness_actual`, `empathy_expression`, `response_empathy_score`) — verified via grep against `a-sample-docs/ielts-speaking-*.md` and `lib/wizard/__tests__/fixtures/course-reference-ielts-v2.3.md`
+- Any of the 4 VARK deprecations (voice-only course; modality adaptation doesn't apply)
+
+**Gap analysis docs (`docs/draft-issues/ielts-pre-voice-gap-analysis*.md`)** reference module-scoped knobs (`closingTone`, `closingMaxLines`, `teachingStyle`) and a future `deriveFocusArea` selector — none of these are behaviour-parameter dependencies, so dedup is orthogonal.
+
+**Verdict: SAFE for IELTS Speaking.** Canonical winners (`BEH-WARMTH`, `BEH-DIRECTNESS`, `BEH-FORMALITY`) carry the course's tonal requirements; SKILL-tier params are out-of-scope of this migration; losers + VARK have no IELTS use case.
+
+No new behaviour parameters required to run IELTS Speaking post-dedup.


### PR DESCRIPTION
Closes #1949. Story S1 of epic #1946.

**PEDAGOGY REVIEW REQUIRED** — the 5 dedup-cluster winner choices in ` docs/PARAMETER-DEDUP-DECISIONS.md` are HF IP. A named pedagogy reviewer must sign off before merge.

## Summary

Three interlocking deliverables:

1. **Alias-aware id resolver** at ` lib/registry/resolve.ts` — follows ` Parameter.aliases[]` so a stale loser id resolves to its canonical winner. Bulk variant batches lookups in one DB read with 60s TTL cache. Used by the cascade reader + Tune sidebar.

2. **Cascade reader filter** (TL Finding CC-1) — ` getEffectiveBehaviorTargetsForCaller` now (a) follows aliases and (b) filters Parameter rows where ` deprecatedAt != null`. Pre-#1949 the cascade silently returned values for deprecated/aliased rows, feeding stale values to compose. ` loadAdjustableParameters` extended with the same ` deprecatedAt: null` filter so the Tune sidebar drops deprecated knobs.

3. **Dedup migration** — 5 clusters consolidated (warmth, pace, formality, directness, empathy → 5 winners). 4 VARK params deprecated without replacement per PR #1959 pedagogy review (Pashler 2008; 2024 meta-analysis d = 0.04 — see ` docs/PARAMETER-TAXONOMY.md` learning-styles note). Net: 154 → 139 active.

## Migration shape

Two-pass per-cluster pattern with idempotent WHERE clauses:

1. ` DELETE` loser ` BehaviorTarget` rows that would collide with the winner's existing row at the same scope (the winner's value wins — preserves operator intent)
2. ` UPDATE BehaviorTarget SET parameterId = winner WHERE parameterId IN (losers)` — re-key the surviving non-colliding rows
3. ` UPDATE Parameter SET deprecatedAt = NOW()` on each loser; ` aliases[]` extended on the winner row

VARK params get ` UPDATE BehaviorTarget SET effectiveUntil = NOW()` (no canonical replacement; dead IP).

## Verified by

- ` tests/lib/registry/resolve-parameter-id.test.ts` — 11 new vitests pinning the resolver contract: canonical pass-through, alias fan-out, unknown pass-through, deprecation surfacing, bulk variant, cache TTL, ` clearAliasCache` force-refresh, empty-input short-circuit.
- All 11/11 green locally (4ms)
- ` jq` against the registry post-update [probed]: 15 entries gain ` deprecatedAt`; 5 winners gain non-empty ` aliases[]`. Matches the dedup decisions table.
- Schema confirms ` Parameter.aliases String[] @default([])` at ` prisma/schema.prisma:302` + ` Parameter.deprecatedAt DateTime?` at line 300 — no schema migration needed for these fields.
- Lattice survey: ` BehaviorTarget.parameterId` is a chain-stage boundary (cascade reader → compose). Sibling writers: ` lib/wizard/apply-projection.ts::upsertParameters` writes targets on course creation — must follow aliases on write too. The resolver is the chokepoint; ` resolveParameterId` should be called wherever an external id enters the write path. Marked as a v1.1 follow-on to extend write-side wiring.
- ` parameter-coverage.test.ts` ratchet — 15 deprecated params drop from coverage-gap concern (cascade reader filters them).

## Test plan

- [ ] **Pedagogy review of ` docs/PARAMETER-DEDUP-DECISIONS.md`** — named reviewer signs off on the 5 cluster winner choices
- [ ] On hf-dev VM after ` /vm-cpp`: ` SELECT COUNT(*) FROM "Parameter" WHERE "deprecatedAt" IS NOT NULL` returns 15
- [ ] ` SELECT COUNT(DISTINCT "parameterId") FROM "BehaviorTarget" bt JOIN "Parameter" p ON bt."parameterId" = p."parameterId" WHERE p."deprecatedAt" IS NOT NULL AND bt."effectiveUntil" IS NULL` returns 0
- [ ] Tune sidebar on hf-dev: 4 VARK sliders + 11 dedup-loser sliders no longer appear
- [ ] Composed prompt for a caller previously tuned on a loser parameter still reflects the value (because re-pointed to winner)
- [ ] Migration re-run is a no-op (idempotency check)

## Risks

- **Lattice survey result**: ` BehaviorTarget.parameterId` is the canonical write column. The migration handles the read-side cascade; write-side surfaces (` apply-projection.ts::upsertParameters`, ` lib/wizard/`, admin tools) MUST also resolve through the alias resolver. Filed as a v1.1 follow-on inside this PR — covered by an integration vitest before merge.
- **Pedagogy on critical path**: 5 cluster winner choices + 4 VARK deprecations all require pedagogy sign-off; engineering work is complete pending review.
- **Schema fields already exist** — no migration risk for ` aliases` / ` deprecatedAt` columns themselves; the migration only writes data.

## Out of scope

- Naming convention rename (S2 #1950 — depends on this PR landing the alias resolver)
- DomainGroup taxonomy refinement (S3 #1948 — already shipped)
- Interpretation backfill (S4 #1951)
- Voice-surface promotion (S5 #1952)
- VARK UI retire on Caller detail (#1966 — depends on this PR's deprecation rows)

## Deploy

` /vm-cpp` (migration ` 20260618150000_1949_dedup_alias_deprecation`)