### PR TITLE
fix(prisma): #1949 migration — BehaviorTarget.callerId (not callerIdentityId)

### DIFF
--- a/apps/admin/prisma/migrations/20260618150000_1949_dedup_alias_deprecation/migration.sql
+++ b/apps/admin/prisma/migrations/20260618150000_1949_dedup_alias_deprecation/migration.sql
@@ -19,7 +19,7 @@
 -- re-run.
 --
 -- Sibling-writer survey result: BehaviorTarget unique constraint is
--- (parameterId, scope, playbookId, callerIdentityId, effectiveUntil).
+-- (parameterId, scope, playbookId, callerId, effectiveUntil).
 -- Re-pointing loser → winner can cause UNIQUE collisions when the
 -- winner already has a row at the same scope. The migration handles
 -- this with a TWO-PASS pattern: first delete colliding-source rows
@@ -44,7 +44,7 @@ AND EXISTS (
   WHERE w."parameterId" = 'BEH-WARMTH'
   AND w."scope" = "BehaviorTarget"."scope"
   AND COALESCE(w."playbookId", '') = COALESCE("BehaviorTarget"."playbookId", '')
-  AND COALESCE(w."callerIdentityId", '') = COALESCE("BehaviorTarget"."callerIdentityId", '')
+  AND COALESCE(w."callerId", '') = COALESCE("BehaviorTarget"."callerId", '')
   AND w."effectiveUntil" IS NULL
   AND "BehaviorTarget"."effectiveUntil" IS NULL
 );
@@ -79,7 +79,7 @@ AND EXISTS (
   WHERE w."parameterId" = 'BEH-PACE-MATCH'
   AND w."scope" = "BehaviorTarget"."scope"
   AND COALESCE(w."playbookId", '') = COALESCE("BehaviorTarget"."playbookId", '')
-  AND COALESCE(w."callerIdentityId", '') = COALESCE("BehaviorTarget"."callerIdentityId", '')
+  AND COALESCE(w."callerId", '') = COALESCE("BehaviorTarget"."callerId", '')
   AND w."effectiveUntil" IS NULL
   AND "BehaviorTarget"."effectiveUntil" IS NULL
 );
@@ -114,7 +114,7 @@ AND EXISTS (
   WHERE w."parameterId" = 'BEH-FORMALITY'
   AND w."scope" = "BehaviorTarget"."scope"
   AND COALESCE(w."playbookId", '') = COALESCE("BehaviorTarget"."playbookId", '')
-  AND COALESCE(w."callerIdentityId", '') = COALESCE("BehaviorTarget"."callerIdentityId", '')
+  AND COALESCE(w."callerId", '') = COALESCE("BehaviorTarget"."callerId", '')
   AND w."effectiveUntil" IS NULL
   AND "BehaviorTarget"."effectiveUntil" IS NULL
 );
@@ -147,7 +147,7 @@ AND EXISTS (
   WHERE w."parameterId" = 'BEH-DIRECTNESS'
   AND w."scope" = "BehaviorTarget"."scope"
   AND COALESCE(w."playbookId", '') = COALESCE("BehaviorTarget"."playbookId", '')
-  AND COALESCE(w."callerIdentityId", '') = COALESCE("BehaviorTarget"."callerIdentityId", '')
+  AND COALESCE(w."callerId", '') = COALESCE("BehaviorTarget"."callerId", '')
   AND w."effectiveUntil" IS NULL
   AND "BehaviorTarget"."effectiveUntil" IS NULL
 );
@@ -178,7 +178,7 @@ AND EXISTS (
   WHERE w."parameterId" = 'BEH-EMPATHY-RATE'
   AND w."scope" = "BehaviorTarget"."scope"
   AND COALESCE(w."playbookId", '') = COALESCE("BehaviorTarget"."playbookId", '')
-  AND COALESCE(w."callerIdentityId", '') = COALESCE("BehaviorTarget"."callerIdentityId", '')
+  AND COALESCE(w."callerId", '') = COALESCE("BehaviorTarget"."callerId", '')
   AND w."effectiveUntil" IS NULL
   AND "BehaviorTarget"."effectiveUntil" IS NULL
 );


### PR DESCRIPTION
## Summary

The migration \`20260618150000_1949_dedup_alias_deprecation\` from PR #1970 referenced \`BehaviorTarget.callerIdentityId\` at 6 sites. The actual column is \`callerId\` (a FK to \`CallerIdentity.id\`). 6 references replaced via sed.

**Effect of the bug (cascade):** migration aborted at line 50 on every hf-* DB → Prisma marked it failed in \`_prisma_migrations\` → all subsequent migration deploys blocked → \`tests/api/callers-effective-behavior-targets.test.ts\` + \`tests/lib/tolerance/get-effective-behavior-targets-for-caller.test.ts\` failed on every PR at \`lib/registry/resolve.ts:49\` → PRs #1973 and #1982 were admin-merged because of this cascade.

## Test plan

- [x] Schema probe confirms column is \`callerId\` (see \`Verified by\` SELECT)
- [x] \`grep -c callerIdentityId migration.sql\` returned 6 pre-edit, 0 post-edit
- [x] Live psql re-run against hf_sandbox returned COMMIT (clean row updates per cluster)
- [x] VM: \`prisma migrate resolve --applied\` + \`prisma migrate deploy\` returned "No pending migrations to apply"
- [ ] CI green
- [ ] Other envs (test, prod): \`/vm-cpp\` to apply the corrected migration

## Verified by

Schema probe — shows column is \`callerId\`, not \`callerIdentityId\`:

\`\`\`sql
SELECT column_name FROM information_schema.columns WHERE table_name='BehaviorTarget' AND column_name IN ('callerId','callerIdentityId');
-- Result: callerId (1 row); callerIdentityId NOT returned
\`\`\`

Migration-state probe — confirms hf_sandbox is now at post-fix state:

\`\`\`sql
SELECT migration_name, finished_at IS NOT NULL AS applied FROM _prisma_migrations WHERE migration_name LIKE '%1949%';
-- Result: 20260618150000_1949_dedup_alias_deprecation | t
\`\`\`

Vitest target that was failing on every PR pre-fix:

- \`tests/api/callers-effective-behavior-targets.test.ts\`
- \`tests/lib/tolerance/get-effective-behavior-targets-for-caller.test.ts\` — \`getEffectiveBehaviorTargetsForCaller should return the CALLER override value when a CALLER row exists\`

VM HTTP probe (post-fix dev server health):

\`\`\`
curl -sS -o /dev/null -w "HTTP %{code}\n" --max-time 10 http://localhost:3000/
\`\`\`

Refs: #1949 (registry S1 epic), PR #1970 (which shipped the broken migration)

Deploy command: \`/vm-cpp\` (other envs need to re-run migrate deploy; hf-dev already at post-fix state)