### PR TITLE
feat(measurement): #1967 M4 structural pass — 14 deferred params (no pedagogy needed)

### DIFF
--- a/.claude/rules/parameter-measurement-coverage.md
+++ b/.claude/rules/parameter-measurement-coverage.md
@@ -30,10 +30,10 @@ When you add or modify a parameter row in
      specs measure this param.
    - `usage.measurement: { kind: "operator-only", reason: "..." }` —
      explicit non-measurable tutor knob (M4, 2026-06-18). The reason
-     must be >20 chars and explain why the param isn't learner-
-     derivable from transcript (typical case: tutor-emit behaviour
-     directive that the LLM expresses but no learner-side signal
-     reflects). Excluded from the gap ratchet.
+     must be **>40 chars** (M4 structural pass tightened from 20 to
+     force substantive justification) and follow the decision tree
+     below to declare WHICH non-measurable shape applies. Excluded
+     from the gap ratchet.
    - `usage.measurement: "deferred-#1967"` — explicit producer-only
      debt. Acceptable but counts against the gap ratchet.
    - `usage.measurement: "deprecated"` — only valid when
@@ -72,30 +72,119 @@ or update the citation.
 
 ## Ratchet
 
-`EXPECTED_GAP_COUNT` caps the `deferred` count. 2026-06-18 incumbent
-post-M4: **48 active parameters** still declare `"deferred-#1967"`
-(M4 reclassified 9 of the original 57 — 3 measured via STYLE-001
-alias-citation, 6 operator-only). Pedagogy review per
+`EXPECTED_GAP_COUNT` caps the `deferred` count. 2026-06-19 incumbent
+post-M4-structural-pass: **34 active parameters** still declare
+`"deferred-#1967"`. The M4 reclassification ratchet history:
+
+- M1 (#1998) — backfilled 82 active params from existing spec corpus
+- M4 (#2006) — reclassified 9 (3 measured via STYLE-001 alias-
+  citation, 6 operator-only) → ratchet 57 → 48
+- M4 structural pass (this commit) — reclassified 14 without
+  pedagogy input using the decision tree above (1 stale row already
+  wired via `parametersAsDirectives`, 5 folk-pedagogy preference
+  assertions paired with BEH-* siblings, 8 ADAPT-stage decision
+  rules) → ratchet 48 → 34
+
+Pedagogy review per
 [`docs/M4-pedagogy-review.md`](../../docs/M4-pedagogy-review.md)
-drives the remaining 48 monotonically toward 0.
+drives the remaining 34 monotonically toward 0.
+
+## Decision tree — how to classify a non-measurable parameter
+
+Born of the M4 structural pass (2026-06-19, this commit) — the M4
+worksheet ([`docs/M4-pedagogy-review.md`](../../docs/M4-pedagogy-review.md))
+named only two forks (`measure` / `operator-only` / `defer`) but
+investigation surfaced THREE structurally distinct shapes of "not
+measurable", and an ADAPT-stage shape the worksheet didn't name.
+Use this tree when an active parameter is producer-only and you
+need to classify it:
+
+```
+Q1: Is the parameter transcript-derivable from a single call?
+     (would a human listening to one transcript reliably score it?)
+
+  YES → measured. Author or cite the AnalysisSpec.
+        usage.measurement: { specSlug: "..." } or { specSlugs: [...] }
+        Ratchet stays.
+
+  NO → continue Q2.
+
+Q2: WHY isn't it transcript-derivable? Pick one shape:
+
+  (a) TUTOR-EMIT DIRECTIVE
+      The LLM expresses the behaviour (response length, pause
+      tolerance, turn length, chunk size, response style); no
+      learner-side signal reflects it back. SUPERVISE-stage
+      compliance checks are a separate concern.
+      Reason template:
+        "Sets tutor [behaviour]; tutor-emit directive expressed
+         via prompt composition. Not learner-derivable from
+         transcript."
+      Examples: BEH-RESPONSE-LEN, BEH-TURN-LENGTH, BEH-CHUNK-SIZE,
+      BEH-PAUSE-TOLERANCE, BEH-ABSTRACT-VS-CONCRETE.
+
+  (b) FOLK-PEDAGOGY PREFERENCE ASSERTION
+      The row describes a learner-preference claim ("visual learners
+      respond well to analogies", "fast pace learners can handle
+      more concepts at once"). Not an observable; a hypothesis.
+      Typically paired with a measurable BEH-* sibling that captures
+      the tutor-behaviour knob. Reference the sibling.
+      Reason template:
+        "Folk-pedagogy preference assertion (\"<quote from
+         definition>\"); learner-preference signal that is not
+         derivable from a single transcript. See <BEH-SIBLING-ID>
+         sibling for the measurable tutor-behavior knob."
+      Examples: analogy-usage, concept-density, example-richness,
+      repetition-frequency, scaffolding (all paired with their
+      BEH-* siblings).
+
+  (c) ADAPT-STAGE DECISION RULE
+      The parameter is consumed by the ADAPT-runner to make
+      curriculum-sequencing decisions against aggregated mastery —
+      not transcript-observable at the EXTRACT stage. The operator
+      sets the target band; ADAPT reads it; no EXTRACT signal
+      produces it. Per `docs/CHAIN-CONTRACTS.md`, ADAPT consumes
+      CallScore + writes CallerTarget — it isn't itself a CallScore
+      producer.
+      Reason template:
+        "ADAPT-stage curriculum-sequencing decision rule (<what it
+         decides>); operator sets the target band, ADAPT-runner
+         reads it against aggregated mastery. Not a transcript-
+         observable EXTRACT signal — measurement does not apply at
+         the EXTRACT stage."
+      Examples: BEH-ADVANCE-READINESS, BEH-CHALLENGE-LEVEL,
+      BEH-FOUNDATION-FOCUS, BEH-INTERLEAVING, BEH-NEW-CONTENT-RATE,
+      BEH-PREREQUISITE-CALLBACK, BEH-PRODUCTIVE-STRUGGLE,
+      BEH-SPACED-RETRIEVAL-PRIORITY.
+
+  All three shapes use the same `{ kind: "operator-only", reason }`
+  shape. The reason text carries the semantic distinction. Future
+  tooling MAY add a discriminated kind (`adapt-stage-producer` etc.)
+  but the data model stays single-kind today to avoid premature
+  schema fanout — the reason templates above are the structural
+  contract.
+
+  None of these match? → "deferred-#1967" + bump ratchet. Explain
+  in the PR body what classification you considered and rejected.
+```
 
 ## When you DON'T need an AnalysisSpec
 
-Some parameters are operator-only knobs that don't need scoring:
+Quick reference — the three families covered by the tree above:
 
 - Default-targets settings (`BEH-DEFAULT-TARGETS-QUALITY` etc.) are
   set by the wizard; they aren't transcript-derivable.
-- Pure config knobs that drive prompt construction without ever
-  needing a learner-state signal back.
-- Tutor-emit behaviour directives (`BEH-WARMTH`'s sibling knobs
-  like `BEH-PAUSE-TOLERANCE`, `BEH-RESPONSE-LEN`, `BEH-TURN-LENGTH`)
-  — the LLM expresses them but no learner-side signal reflects them
-  back as a measurable score. SUPERVISE-stage compliance checks are
-  a separate concern (see #1967 epic notes).
+- Pure config knobs that drive prompt construction without a
+  learner-state signal back (tree shape (a) — tutor-emit directive).
+- Folk-pedagogy preference assertions (tree shape (b)) — paired
+  with a BEH-* sibling that captures the measurable tutor-behaviour
+  knob.
+- ADAPT-stage decision rules (tree shape (c)) — consumed by ADAPT
+  against aggregated mastery, not produced by EXTRACT.
 
-For these, declare `usage.measurement: { kind: "operator-only",
-reason: "..." }` with a substantive (>20 char) reason. Excluded
-from the gap ratchet.
+Declare `usage.measurement: { kind: "operator-only", reason: "..." }`
+with a substantive (**>40 char**) reason matching one of the
+templates above. Excluded from the gap ratchet.
 
 ## When adding a new parameter
 

--- a/apps/admin/docs-archive/bdd-specs/behavior-parameters.registry.json
+++ b/apps/admin/docs-archive/bdd-specs/behavior-parameters.registry.json
@@ -39,7 +39,10 @@
       "interpretationLow": "Lead with specific examples and demonstrations; abstract patterns emerge from them.",
       "usage": {
         "compose": "prompt-injection",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Surfaced via parametersAsDirectives compose dispatcher (promptInjection.section: STYLE, condition: when-non-default); tutor-emit style directive set by operator-tuned BehaviorTarget, not learner-state derivable from one transcript."
+        }
       }
     },
     {
@@ -166,7 +169,10 @@
       "interpretationLow": "Avoid analogies; explain concepts directly and on their own terms.",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Folk-pedagogy preference assertion (\"visual learners respond well to analogies\"); learner-preference signal that is not derivable from a single transcript. See BEH-ANALOGY-USAGE sibling for the measurable tutor-behavior knob."
+        }
       }
     },
     {
@@ -345,7 +351,10 @@
       "interpretationLow": "Thorough Mastery: Stays on a topic until deep understanding is confirmed",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "ADAPT-stage curriculum-sequencing decision rule (when to advance learner to new material); operator sets the target band, ADAPT-runner reads it against aggregated mastery. Not a transcript-observable EXTRACT signal \u2014 measurement does not apply at the EXTRACT stage."
+        }
       }
     },
     {
@@ -384,7 +393,10 @@
       "interpretationLow": "Comfortable: Keeps problems within easy reach to build confidence",
       "usage": {
         "compose": "transform-direct",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "ADAPT-stage curriculum-sequencing decision rule (difficulty of presented problems); operator sets the target band, ADAPT-runner reads it against aggregated mastery. Not a transcript-observable EXTRACT signal \u2014 measurement does not apply at the EXTRACT stage."
+        }
       }
     },
     {
@@ -573,7 +585,10 @@
       "interpretationLow": "Forward-Moving: Focuses on current material, addressing gaps only when they block progress",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "ADAPT-stage curriculum-sequencing decision rule (prerequisite-gap-fill priority); operator sets the target band, ADAPT-runner reads it against aggregated mastery. Not a transcript-observable EXTRACT signal \u2014 measurement does not apply at the EXTRACT stage."
+        }
       }
     },
     {
@@ -642,7 +657,10 @@
       "interpretationLow": "Focused Blocks: Concentrates on one topic at a time without mixing",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "ADAPT-stage curriculum-sequencing decision rule (mix-in rate of previous-topic review); operator sets the target band, ADAPT-runner reads it against the schedule. Not a transcript-observable EXTRACT signal \u2014 measurement does not apply at the EXTRACT stage."
+        }
       }
     },
     {
@@ -709,7 +727,10 @@
       "interpretationLow": "Review First: Extensive review of existing material before introducing anything new",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "ADAPT-stage curriculum-sequencing decision rule (introduction rate of fresh material vs review); operator sets the target band, ADAPT-runner reads it against aggregated mastery. Not a transcript-observable EXTRACT signal \u2014 measurement does not apply at the EXTRACT stage."
+        }
       }
     },
     {
@@ -816,7 +837,10 @@
       "interpretationLow": "Standalone: Teaches each concept independently without referencing prior knowledge",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "ADAPT-stage curriculum-sequencing decision rule (linkback rate to previously learned concepts); operator sets the target band, ADAPT-runner emits the directive. Not a transcript-observable EXTRACT signal \u2014 measurement does not apply at the EXTRACT stage."
+        }
       }
     },
     {
@@ -857,7 +881,10 @@
       "interpretationLow": "Quick Rescue: Steps in quickly with hints or answers when difficulty is detected",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "ADAPT-stage curriculum-sequencing decision rule (struggle-tolerance window before scaffold-step-in); operator sets the target band, ADAPT-runner reads it against the live signal. Not a transcript-observable EXTRACT signal \u2014 measurement does not apply at the EXTRACT stage."
+        }
       }
     },
     {
@@ -981,7 +1008,10 @@
       "interpretationLow": "Forward Focus: Prioritises new material over reviewing fading knowledge",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "ADAPT-stage curriculum-sequencing decision rule (review-schedule aggression for fading material); operator sets the target band, ADAPT-runner reads it against the schedule. Not a transcript-observable EXTRACT signal \u2014 measurement does not apply at the EXTRACT stage."
+        }
       }
     },
     {
@@ -1324,7 +1354,10 @@
       "interpretationLow": "Introduce one concept at a time; allow each to settle before adding the next.",
       "usage": {
         "compose": "transform-direct",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Folk-pedagogy preference assertion (\"fast pace learners can handle more concepts at once\"); learner-preference signal that is not derivable from a single transcript. See BEH-CONCEPT-DENSITY sibling for the measurable tutor-behavior knob."
+        }
       }
     },
     {
@@ -1609,7 +1642,10 @@
       "interpretationLow": "Provide one focused example per concept; trust generalisation from a single case.",
       "usage": {
         "compose": "transform-direct",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Folk-pedagogy preference assertion (\"visual learners benefit from concrete examples\"); learner-preference signal that is not derivable from a single transcript. See BEH-EXAMPLE-RICHNESS sibling for the measurable tutor-behavior knob."
+        }
       }
     },
     {
@@ -2085,7 +2121,10 @@
       "interpretationLow": "State each key point once; trust the learner to retain it without explicit repetition.",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Folk-pedagogy preference assertion (\"slow pace learners benefit from repetition\"); learner-preference signal that is not derivable from a single transcript. See BEH-REPETITION-FREQUENCY sibling for the measurable tutor-behavior knob."
+        }
       }
     },
     {
@@ -2202,7 +2241,10 @@
       "interpretationLow": "Provide minimal scaffolding; let the learner build their own structure from the content flow.",
       "usage": {
         "compose": "transform-direct",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Folk-pedagogy preference assertion (\"guided learners need structured support\"); learner-preference signal that is not derivable from a single transcript. See BEH-SCAFFOLDING sibling for the measurable tutor-behavior knob."
+        }
       }
     },
     {

--- a/apps/admin/tests/lib/measurement/parameter-measurement-coverage.test.ts
+++ b/apps/admin/tests/lib/measurement/parameter-measurement-coverage.test.ts
@@ -98,13 +98,18 @@ function buildEvidenceMap(): Map<string, Set<string>> {
 const EVIDENCE = buildEvidenceMap();
 
 /**
- * 2026-06-18 incumbent (post-M4) — M1 backfilled 82 params from the
- * existing spec corpus; M4 reclassified 9 more (3 measured via
- * STYLE-001 alias, 6 operator-only), leaving 48 active params still
- * producer-only debt. Pedagogy review per
- * `docs/M4-pedagogy-review.md` drives the remaining 48 toward 0.
+ * 2026-06-19 incumbent (post-M4 structural pass) — M1 backfilled 82
+ * params; M4 reclassified 9 (3 measured via STYLE-001 alias, 6
+ * operator-only); the M4 structural pass (this commit) reclassified
+ * 14 more without pedagogy input: 1 stale row already wired via
+ * parametersAsDirectives (BEH-ABSTRACT-VS-CONCRETE), 5 legacy
+ * lowercase folk-pedagogy assertions paired with their canonical
+ * BEH-* siblings, 8 ADAPT-stage decision rules that are not
+ * EXTRACT-stage observables. Leaves 34 active params on
+ * "deferred-#1967" awaiting pedagogy review per
+ * `docs/M4-pedagogy-review.md`.
  */
-const EXPECTED_GAP_COUNT = 48;
+const EXPECTED_GAP_COUNT = 34;
 
 type Classification =
   | "measured"
@@ -180,14 +185,19 @@ describe("Parameter measurement coverage (M1 — link 7 of the Lattice chain)", 
     expect(measured.length).toBeGreaterThan(50);
   });
 
-  it("every operator-only entry has a substantive reason (>20 chars)", () => {
+  it("every operator-only entry has a substantive reason (>40 chars)", () => {
+    // Lattice gap fill (M4 structural pass): bumped from >20 to >40 chars
+    // to force authors to cite WHY a row is non-measurable (tutor-emit
+    // directive / folk-pedagogy assertion / ADAPT-stage decision rule /
+    // sibling reference), not just "operator only". Existing 6 + 14 new
+    // rows all carry 100+ char reasons; the bar is empirically light.
     const tooShort = operatorOnly.filter(
-      (x) => (x.c.detail ?? "").trim().length < 20,
+      (x) => (x.c.detail ?? "").trim().length < 40,
     );
     expect(
       tooShort.length,
-      `operator-only params with empty/short reason:\n  ${tooShort
-        .map((x) => x.p.parameterId)
+      `operator-only params with empty/short reason (<40 chars):\n  ${tooShort
+        .map((x) => `${x.p.parameterId}: "${(x.c.detail ?? "").slice(0, 60)}..."`)
         .join("\n  ")}`,
     ).toBe(0);
   });

--- a/docs/M4-pedagogy-review.md
+++ b/docs/M4-pedagogy-review.md
@@ -1,46 +1,47 @@
 # M4 — Pedagogy review worksheet (epic #1967)
 
-Of the 57 deferred params (`measurement: "deferred-#1967"`) M1 surfaced, M4 reclassified 9 in the same PR (3 measured via STYLE-001 alias-citation; 6 operator-only tutor knobs). The remaining 48 listed below need pedagogy review.
+Of the 57 deferred params (`measurement: "deferred-#1967"`) M1 surfaced, M4 reclassified 9 in the same PR (3 measured via STYLE-001 alias-citation; 6 operator-only tutor knobs). **The M4 structural pass (2026-06-19) reclassified 14 more without pedagogy input** using the decision tree in [`.claude/rules/parameter-measurement-coverage.md`](../.claude/rules/parameter-measurement-coverage.md). The remaining **34 active rows** below need pedagogy review.
 
 **For each row, the reviewer picks one of:**
 
 - **`measure`** — author a MEASURE AnalysisSpec that scores this from transcript. Note the proposed spec id.
-- **`operator-only`** — non-measurable tutor knob; reclassify in registry as `usage.measurement: { kind: "operator-only", reason: "..." }`.
+- **`operator-only`** — non-measurable tutor knob; reclassify in registry as `usage.measurement: { kind: "operator-only", reason: "..." }`. Use one of the three reason templates in the decision tree (tutor-emit directive / folk-pedagogy assertion / ADAPT-stage decision rule).
 - **`defer`** — genuinely cannot decide today; keep as `"deferred-#1967"`.
 
 Closing the loop for `measure` rows also closes the M2 loop-closure ratchet by 1 if an AGGREGATE / ADAPT spec already consumes the param — or the same PR extends one to do so.
 
-## `curriculum-adaptation` (20 params)
+## Structural pass completed (2026-06-19) — DO NOT review again
+
+The 14 rows below were structurally classified without pedagogy input and now carry an `operator-only` measurement kind in the registry. Tracked here for audit trail:
+
+| parameterId | shape | drop-rationale |
+|---|---|---|
+| `BEH-ABSTRACT-VS-CONCRETE` | tutor-emit directive | Already wired to STYLE section via `parametersAsDirectives` (#1907); stale `deferred-#1967` row |
+| `analogy-usage`, `concept-density`, `example-richness`, `repetition-frequency`, `scaffolding` | folk-pedagogy assertion | Learner-preference statements paired with BEH-* siblings; not derivable from one transcript |
+| `BEH-ADVANCE-READINESS`, `BEH-CHALLENGE-LEVEL`, `BEH-FOUNDATION-FOCUS`, `BEH-INTERLEAVING`, `BEH-NEW-CONTENT-RATE`, `BEH-PREREQUISITE-CALLBACK`, `BEH-PRODUCTIVE-STRUGGLE`, `BEH-SPACED-RETRIEVAL-PRIORITY` | ADAPT-stage decision rule | Consumed by ADAPT-runner against aggregated mastery; not an EXTRACT-stage observable |
+
+## `curriculum-adaptation` (12 params remaining — 8 already classified above)
 
 | parameterId | definition | proposed classification |
 |---|---|---|
-| `BEH-ADVANCE-READINESS` | How quickly the AI moves the learner to new material based on demonstrated understanding. | _(reviewer)_ |
 | `BEH-ANALOGY-USAGE` | How often the AI uses analogies and metaphors to bridge from familiar concepts to new ones. | _(reviewer)_ |
-| `BEH-CHALLENGE-LEVEL` | The difficulty of questions and problems the AI presents to the learner. | _(reviewer)_ |
 | `BEH-CHECK-FOR-UNDERSTANDING` | How frequently the AI pauses to verify the learner has understood before moving on. | _(reviewer)_ |
 | `BEH-CONCEPT-DENSITY` | How many new ideas the AI introduces in a single exchange. | _(reviewer)_ |
 | `BEH-EXAMPLE-RICHNESS` | How many concrete examples the AI provides when explaining a concept. | _(reviewer)_ |
 | `BEH-EXPLANATION-VARIETY` | Whether the AI tries different approaches when a learner doesn't understand the first time. | _(reviewer)_ |
-| `BEH-FOUNDATION-FOCUS` | How much the AI prioritises filling gaps in prerequisite knowledge before advancing. | _(reviewer)_ |
 | `BEH-GUIDED-PRACTICE` | How much step-by-step support the AI provides during practice activities. | _(reviewer)_ |
-| `BEH-INTERLEAVING` | How much the AI mixes review of previous topics into current learning. | _(reviewer)_ |
-| `BEH-NEW-CONTENT-RATE` | How quickly the AI introduces fresh material versus reviewing what's already been taught. | _(reviewer)_ |
 | `BEH-NUANCE-EXPLORATION` | How deeply the AI explores edge cases, exceptions, and subtle distinctions. | _(reviewer)_ |
 | `BEH-PRACTICE-RATIO` | The balance between explanation and hands-on practice in each session. | _(reviewer)_ |
-| `BEH-PREREQUISITE-CALLBACK` | How often the AI explicitly links current material back to previously learned concepts. | _(reviewer)_ |
 | `BEH-PROBING-QUESTIONS` | How often the AI asks deeper follow-up questions to extend the learner's thinking. | _(reviewer)_ |
-| `BEH-PRODUCTIVE-STRUGGLE` | How long the AI lets a learner work through difficulty before stepping in to help. | _(reviewer)_ |
 | `BEH-REPETITION-FREQUENCY` | How often the AI restates or revisits key concepts within a session. | _(reviewer)_ |
 | `BEH-SCAFFOLDING` | How much structural support the AI provides to help the learner tackle complex tasks. | _(reviewer)_ |
-| `BEH-SPACED-RETRIEVAL-PRIORITY` | How aggressively the AI schedules review of material showing signs of fading. | _(reviewer)_ |
 | `BEH-WORKED-EXAMPLES` | Whether the AI demonstrates complete solutions before asking the learner to try. | _(reviewer)_ |
 
-## `learning-adaptation` (27 params)
+## `learning-adaptation` (21 params remaining — 6 already classified above: `BEH-ABSTRACT-VS-CONCRETE` + 5 legacy lowercase)
 
 | parameterId | definition | proposed classification |
 |---|---|---|
 | `BEH-ABSTRACT-OK` | How comfortable the learner is with theoretical and abstract concepts versus concrete ones. | _(reviewer)_ |
-| `BEH-ABSTRACT-VS-CONCRETE` | Visual learners prefer concrete over abstract | _(reviewer)_ |
 | `BEH-ACTION-VERBS` | Whether the AI uses action-oriented, practical language versus abstract terminology. | _(reviewer)_ |
 | `BEH-APPROACH-SWITCHING` | How freely the AI switches between different teaching modalities during a session. | _(reviewer)_ |
 | `BEH-DEFINITION-PRECISION` | How precisely the AI defines technical terms and concepts. | _(reviewer)_ |
@@ -61,11 +62,6 @@ Closing the loop for `measure` rows also closes the M2 loop-closure ratchet by 1
 | `BEH-TERMINOLOGY-FORMAL` | How much the AI uses formal, subject-specific vocabulary versus everyday language. | _(reviewer)_ |
 | `BEH-VERBAL-ELABORATION` | How richly and extensively the AI elaborates on concepts through spoken explanation. | _(reviewer)_ |
 | `BEH-WRITTEN-ALTERNATIVE` | How much the AI offers written references, summaries, or notes alongside spoken teaching. | _(reviewer)_ |
-| `analogy-usage` | Visual learners respond well to analogies | _(reviewer)_ |
-| `concept-density` | Fast pace learners can handle more concepts at once | _(reviewer)_ |
-| `example-richness` | Visual learners benefit from concrete examples | _(reviewer)_ |
-| `repetition-frequency` | Slow pace learners benefit from repetition | _(reviewer)_ |
-| `scaffolding` | Guided learners need structured support | _(reviewer)_ |
 
 ## `reinforcement` (1 params)
 
@@ -86,5 +82,5 @@ For each `measure` row:
 
 For each `operator-only` row:
 
-1. Update the registry row: `usage.measurement: { kind: "operator-only", reason: "<>20 chars explaining why this isn't measurable" }`.
+1. Update the registry row: `usage.measurement: { kind: "operator-only", reason: "<>40 chars matching one of the three reason templates in `.claude/rules/parameter-measurement-coverage.md`" }`.
 2. Run `npx vitest run tests/lib/measurement/parameter-measurement-coverage.test.ts`. Drop `EXPECTED_GAP_COUNT` by the count moved.


### PR DESCRIPTION
## Summary

Triage of the 48 `deferred-#1967` rows that landed with the M4 worksheet
(PR #2006) surfaced that 14 are reclassifiable **without pedagogy input**
— stale rows already wired by `parametersAsDirectives`, folk-pedagogy
preference assertions paired with measurable BEH-* siblings, and
ADAPT-stage decision rules that aren't EXTRACT-stage observables. This
PR ships the structural pass + the missing decision-tree taxonomy in
the rule file. Ratchet drops 48 → 34. 34 still need pedagogy review.

| Cluster | Count | Shape |
|---|---|---|
| C0 | 1 | Stale row — already wired via `parametersAsDirectives` (#1907) |
| C1 | 5 | Folk-pedagogy preference assertions paired with BEH-* siblings |
| C4 | 8 | ADAPT-stage curriculum-sequencing decision rules |

All 14 use `{ kind: "operator-only", reason }` with 220+ char reasons
matching one of three templates now documented in the rule file.

## Verified by

**Lattice survey:** ran the 5-pillar cross-check per
`.claude/rules/lattice-survey.md` before touching the registry:

- **Coverage:** 14 rows drop from `deferred-#1967` → `operator-only`;
  `parameter-measurement-coverage.test.ts` ratchet drops 48 → 34.
  Verified `npx vitest run tests/lib/measurement/parameter-measurement-coverage.test.ts`
  passes 6/6.
- **Cascade:** all 14 are already-cascadable BEH-* IDs (or paired with
  one); legacy lowercase rows are *not* cascade-resolvable today and
  their definitions describe folk-pedagogy assertions, not tutor knobs
  — so they're classified `operator-only` with sibling-reference
  reasons rather than alias-rebound. Verified by reading
  `lib/cascade/effective-value.ts::FAMILIES` + the `behavior-target`
  family prefix-match.
- **Chain Contracts:** the 8 C4 ADAPT-stage rows are reclassified per
  `docs/CHAIN-CONTRACTS.md` §"Stage boundary inventory" (ADAPT is a
  consumer of CallScore + producer of CallerTarget — not itself an
  EXTRACT producer). Verified via direct read; no row mismatches the
  ADAPT-stage shape.
- **Rules:** `.claude/rules/parameter-measurement-coverage.md` extended
  with a Decision tree section naming the three structural shapes:
  tutor-emit directive / folk-pedagogy assertion / ADAPT-stage decision
  rule. Each shape carries a reason template. The vitest reason check
  bumped from >20 to >40 chars to force authors to cite WHICH shape
  applies, not just "operator only".
- **Guards:** no ESLint rule today gates the `deferred-#1967` →
  classification transition. The vitest tightening serves as the
  structural backstop until an edit-time rule lands (follow-on, see
  Open work below).

**Test results in the worktree** (`HF-m4-structural` off `origin/main`,
ahead of `main` by 1 commit):

- `npx vitest run tests/lib/measurement/ tests/lib/registry/` → **14 files / 88 tests pass.**
- `npx tsc --noEmit` → 39 errors, all pre-existing, none in touched
  files (matches `.ratchet.json::tsc_errors=39`).
- `npx eslint tests/lib/measurement/parameter-measurement-coverage.test.ts` → clean (pre-push hook confirms no lint errors in changed files).

**Inverse-probe on negative claims** per
`.claude/rules/agent-report-verification.md`:

- "No ESLint rule today gates `deferred-#1967` reclassification" —
  inverse-probe: `ls eslint-rules/ | grep -iE 'measurement|deferred|registry'` returned only
  `no-bare-parameter-id.mjs` and `no-bare-call-score-write.mjs` (the M3
  CallScore-write gate). Confirmed: no reclassification gate exists.
- "No alias resolver redirects the 5 legacy lowercase IDs at runtime"
  — read `lib/registry/resolve.ts`: resolver reads `prisma.parameter.aliases[]`
  from DB. Registry inspection shows none of the 5 BEH-* siblings
  has the lowercase ID in its `aliases[]` array. Confirmed: legacy
  IDs are NOT redirected; they remain distinct rows. Classified
  `operator-only` with explicit sibling-reference reasons rather than
  deleted, preserving any downstream readers that may still cite them.

## What's NOT in this PR (open work)

- **34 active rows still need pedagogy review** (12 in
  `curriculum-adaptation`, 21 in `learning-adaptation`, 1 in
  `reinforcement`). The worksheet still lists them.
- **ESLint guard for reclassification quality** — the vitest reason
  check is the current backstop. An edit-time `hf-measurement/no-thin-reclassification-reason`
  rule would catch sooner. Open as a follow-on.
- **#1857's 12 new parameter candidates** (`BEH-SAY-CADENCE`,
  `BEH-CUE-CARD-HIT-RATE`, etc.) drafted in
  `docs/draft-issues/new-parameter-candidates-2026-06-17.md` are still
  not in the registry. Some would resolve C5 worksheet rows. Tracked
  separately.

## Files

- `apps/admin/docs-archive/bdd-specs/behavior-parameters.registry.json` — 14 rows reclassified
- `apps/admin/tests/lib/measurement/parameter-measurement-coverage.test.ts` — ratchet 48 → 34, reason check >20 → >40
- `.claude/rules/parameter-measurement-coverage.md` — decision-tree section added, ratchet history updated
- `docs/M4-pedagogy-review.md` — 14 classified rows moved to "structural pass completed" audit section; remaining 34 still need review

## Test plan

- [x] `npx vitest run tests/lib/measurement/ tests/lib/registry/` — passes 88/88
- [x] `npx tsc --noEmit` — 39 errors, all pre-existing (none in touched files)
- [x] Pre-push lint check — clean on changed files
- [ ] Reviewer reads the decision tree, confirms the three reason templates match the M4 worksheet's eventual classifications
- [ ] Pedagogy reviewer continues against the remaining 34 rows using the decision tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)