### PR TITLE
chore(lint): demote 3 React Compiler rules to warn — restore Lint gate honesty

### DIFF
--- a/.claude/rules/react-hooks-compiler-rules-warn.md
+++ b/.claude/rules/react-hooks-compiler-rules-warn.md
@@ -1,0 +1,125 @@
+# React Compiler rules — warn, not error
+
+> The 3 React-Compiler-family rules in `eslint-plugin-react-hooks`
+> (`static-components`, `purity`, `preserve-manual-memoization`) are
+> intentionally configured at `"warn"` severity, not `"error"`. The
+> `rules-of-hooks` rule (classic React) remains at `"error"`. The
+> `.ratchet.json` `lint_warnings` baseline locks the current violation
+> count so the codebase can't regress while a follow-on epic pays them
+> down.
+>
+> Sibling to the `.claude/rules/*-coverage.md` Coverage-pillar gates
+> (registry-consumer / route-auth-zod / tier-visibility / parameter):
+> same generic shape (incumbent count frozen via ratchet, future
+> regressions blocked). Different surface — this one is ESLint rule
+> severity, not test-driven coverage.
+
+## Rule
+
+`apps/admin/eslint.config.mjs`:
+
+- `react-hooks/rules-of-hooks` → `"error"` (classic React Hooks rule;
+  zero current violations; future regressions block CI)
+- `react-hooks/static-components` → `"warn"` (React Compiler family)
+- `react-hooks/purity` → `"warn"` (React Compiler family)
+- `react-hooks/preserve-manual-memoization` → `"warn"` (React Compiler
+  family)
+
+The ratchet (`.ratchet.json::lint_warnings`) holds the post-demote
+warning count. The ratchet step in `.github/workflows/test.yml` (Lint
+& Type Check job) refuses any increase.
+
+## Why this exists
+
+PRs #1998 through #2008 (8 consecutive merges, 2026-06-18 → 2026-06-19)
+all merged with the Lint & Type Check job RED at the "Run ESLint" step.
+Admins overrode the merge gate every time. Verified by:
+
+```
+for pr in 1998 2002 2003 2004 2005 2006 2007 2008; do
+  gh pr view $pr --json statusCheckRollup,state -q \
+    '"PR \#\(.number): Lint=\(.statusCheckRollup[] | select(.name == "Lint & Type Check") | .conclusion), State=\(.state)"'
+done
+```
+
+All 8: `Lint=FAILURE, State=MERGED`. The original `#865` closeout claim
+"zero current violations after #876 + #894; future regressions block CI"
+had drifted silently because:
+
+1. The Lint step (`npm run lint`) exits 1 when ESLint reports any error.
+2. The ratchet step is AFTER lint in the same job (`test.yml` lines 51-70).
+3. GitHub Actions skips later steps in a job when an earlier step fails.
+4. So the ratchet check never ran → warning counts drifted from baseline
+   (4544 → 4809 between #865 closeout and 2026-06-19) without producing
+   a single signal in CI.
+5. Meanwhile errors accumulated to 52 — the operator-visible signal was
+   8 weeks of "RED CI, merge anyway."
+
+The exact failure distribution from #2008 (`gh run view 27813806905
+--log-failed`):
+
+| Rule | Count | Message |
+|---|---|---|
+| `react-hooks/preserve-manual-memoization` | 34 | "Compilation Skipped: Existing memoization could not be preserved" |
+| `react-hooks/static-components` | 12 | "Cannot create components during render" |
+| `react-hooks/purity` | 6 | "Cannot call impure function during render" |
+
+All 3 are React Compiler-family rules. The classic `rules-of-hooks` had
+ZERO violations — kept at error.
+
+A guard that fires red on every PR but gets bypassed on every merge is
+worse than no guard — it consumes attention without producing signal.
+Demoting restores honesty. The ratchet keeps the count frozen so the
+debt can't grow while a pay-down effort follows.
+
+## How to fix a regression
+
+The ratchet (lint_warnings) refuses any increase. If your PR adds new
+violations:
+
+| Failure shape | Fix |
+|---|---|
+| `lint_warnings: NNNN (+M over baseline NNNN)` from `npm run ratchet:check` | Fix the new violations OR run `npm run ratchet:lock` ONLY if you have an explicit operator-approved decision to grow the debt (rare). |
+| `lint_errors: N (+N over baseline 0)` | The new violation hit a rule still at `"error"` severity (most likely `rules-of-hooks`). Fix the violation; do NOT demote. |
+
+## When this rule should be revisited
+
+When a follow-on epic pays down the React Compiler violations to zero:
+
+1. Audit `npm run lint` output. Confirm 0 errors AND <5 occurrences of
+   the 3 rule names in any file.
+2. Promote each rule back to `"error"` in `eslint.config.mjs`.
+3. Update the comment block to reflect the new floor.
+4. Run `npm run ratchet:lock` to drop `lint_warnings` to the new floor.
+
+Until then: the warn floor + ratchet is the honest contract.
+
+## Existing enforcement
+
+| Location | Mechanism | What it prevents |
+|---|---|---|
+| `apps/admin/eslint.config.mjs` lines ~519-541 | Rule severity at "warn" | Spurious CI red on incumbent violations |
+| `.ratchet.json::lint_warnings` (4861 as of 2026-06-19) | Count-cap ratchet (#227) | New violations growing the warn count |
+| `.github/workflows/test.yml` step "Ratchet check (blocking)" | Runs `npm run ratchet:check` after lint passes | Silent drift like the 4544→4809 lapse |
+| This rule | Author discipline | Confusion when a future contributor sees "warn" and assumes the rule is unimportant |
+
+## When NOT to apply
+
+This rule covers the THREE specific React Compiler-family rules listed
+above. It does NOT apply to:
+
+- `react-hooks/rules-of-hooks` — classic Rules of Hooks; stays at error.
+- Other ESLint rules at `"warn"` severity — those have their own ratchet
+  enforcement via `lint_warnings`.
+- The custom `hf-*` rules under `apps/admin/eslint-rules/*` — those are
+  catalogued separately in `docs/kb/guard-registry.md`.
+
+## Related
+
+- [`.claude/rules/lattice-survey.md`](./lattice-survey.md) — pre-coding
+  Lattice survey discipline
+- [`.claude/rules/verify-before-fix.md`](./verify-before-fix.md) —
+  the citation-discipline this rule's "8/8 verified" PR list satisfies
+- [`apps/admin/scripts/check-ratchet.sh`](../../apps/admin/scripts/check-ratchet.sh)
+  — the ratchet runner
+- `#865` closeout — the original promotion to "error" that drifted

--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,7 +1,7 @@
 {
   "tsc_errors": 39,
   "lint_errors": 0,
-  "lint_warnings": 4544,
+  "lint_warnings": 4861,
   "quarantined_tests": 36,
   "knip_unused": 162,
   "same_issue_fix_chain_max": 10,

--- a/apps/admin/eslint.config.mjs
+++ b/apps/admin/eslint.config.mjs
@@ -516,21 +516,27 @@ const eslintConfig = defineConfig([
       "@typescript-eslint/no-unsafe-function-type": "warn",
       "@typescript-eslint/no-require-imports": "warn",
       "@typescript-eslint/no-empty-object-type": "warn",
-      // react-hooks ratchet (#865 closeout):
-      // - 4 rules at "error" (rules-of-hooks, static-components, purity,
-      //   preserve-manual-memoization) — zero current violations after #876 + #894;
-      //   future regressions block CI.
-      // - Remaining rules stay "warn" — non-zero counts accepted as ratchet-locked
-      //   forward-compat debt; `.ratchet.json` (lint_warnings) only allows the count
-      //   to decrease over time. See #865 closeout for rationale.
+      // react-hooks ratchet (#865 closeout, demoted 2026-06-19 per
+      // `.claude/rules/react-hooks-compiler-rules-warn.md`):
+      // - `rules-of-hooks` stays at "error" — the classic React-Hooks rule
+      //   that's been stable for years and produces zero current violations.
+      // - The 3 React-Compiler-family rules (`static-components`, `purity`,
+      //   `preserve-manual-memoization`) were demoted to "warn" after 8/8
+      //   consecutive PRs (#1998-#2008, 2026-06-18→19) merged with this gate
+      //   red. The original #865 closeout claim ("zero current violations
+      //   after #876 + #894; future regressions block CI") had drifted —
+      //   52 errors accumulated under the radar because lint exit 1 masked
+      //   the ratchet step that followed. Demote restores honesty; the
+      //   ratchet (lint_warnings) freezes the count so regressions can't
+      //   grow. Pay-down epic tracked separately.
       "react-hooks/exhaustive-deps": "warn",
       "react-hooks/set-state-in-effect": "warn",
       "react-hooks/refs": "warn",
       "react-hooks/immutability": "warn",
       "react-hooks/rules-of-hooks": "error",
-      "react-hooks/static-components": "error",
-      "react-hooks/purity": "error",
-      "react-hooks/preserve-manual-memoization": "error",
+      "react-hooks/static-components": "warn",
+      "react-hooks/purity": "warn",
+      "react-hooks/preserve-manual-memoization": "warn",
       "prefer-const": "warn",
       "@next/next/no-img-element": "warn",
       "@next/next/no-html-link-for-pages": "warn",


### PR DESCRIPTION
## Summary

PRs #1998-#2008 (8 consecutive merges 2026-06-18→19) all merged with the Lint & Type Check job RED. The three React-Compiler-family rules in `eslint-plugin-react-hooks` accumulated 52 errors that nobody fixed and nobody blocked merges on — a guard with zero teeth is worse than no guard.

Three changes:

- **`apps/admin/eslint.config.mjs`** — demote `react-hooks/static-components`, `react-hooks/purity`, and `react-hooks/preserve-manual-memoization` from `"error"` to `"warn"`. `rules-of-hooks` stays at `"error"`. Update the `#865` closeout comment block to reflect the drift instead of leaving the stale "zero current violations" claim.
- **`.ratchet.json`** — bump `lint_warnings: 4544 → 4861` (4809 current + 52 demoted). The next CI ratchet step (which has been skipped for weeks because lint exited 1 before it could run) now passes from a fresh baseline.
- **`.claude/rules/react-hooks-compiler-rules-warn.md`** — Lattice rule documenting the decision, the 8/8 verified streak, exact error distribution, and the path to re-promote each rule when a pay-down epic clears the violations.

## Failure-mode analysis

The `#865` closeout in February promoted the 4 React-Compiler-family rules to error claiming "zero current violations after #876 + #894; future regressions block CI." That claim drifted silently because:

1. `npm run lint` exits 1 on any error.
2. The ratchet step is AFTER lint in the same job (`apps/admin/scripts/check-ratchet.sh` invoked at `.github/workflows/test.yml` lines 51-70).
3. GitHub Actions skips later steps when an earlier step fails.
4. Result: the ratchet never ran. Warnings drifted 4544 → 4809 and errors accumulated to 52 with zero CI signal.
5. The visible signal was 8 consecutive PRs merging with "Lint & Type Check FAILURE" — and 8 consecutive admin overrides.

A guard that fires red on every PR but gets bypassed on every merge is worse than no guard. It consumes attention without producing signal and trains the team to ignore the red checkmark.

## Why warn + ratchet (path A + ratchet) instead of paying down the violations

The 52 violations are spread across ~50 files and involve React Compiler memoization preservation patterns. A surgical fix is a multi-PR epic, not an overnight job. Demoting + ratcheting:

- Restores honesty: lint passes when nothing has regressed.
- Locks in the floor: ratchet refuses any increase in `lint_warnings`.
- Preserves the pay-down path: re-promote each rule when violations hit zero (procedure documented in the rule file).
- Frees the merge gate for unrelated work.

## Test plan

- [ ] CI Lint & Type Check job passes on this PR (the first time in 9 PRs).
- [ ] CI Ratchet check passes (also blocked-by-lint-fail for weeks).
- [ ] Spot-check: introduce a trivial new `react-hooks/purity` violation in a draft PR; confirm the ratchet now refuses the increase (manual verification after merge).
- [ ] Spot-check: confirm a new `react-hooks/rules-of-hooks` violation still blocks at error severity.

## Verified by

Streak of red-gate merges — reproducible via `gh api`:

```bash
for pr in 1998 2002 2003 2004 2005 2006 2007 2008; do
  gh api "repos/WANDERCOLTD/HF/pulls/$pr" --jq '"PR #\(.number): state=\(.state)"' 
  gh api "repos/WANDERCOLTD/HF/commits/$(gh api repos/WANDERCOLTD/HF/pulls/$pr --jq .head.sha)/check-runs" \
    --jq '.check_runs[] | select(.name == "Lint & Type Check") | "  Lint=\(.conclusion)"'
done
```

| PR | Lint result | State |
|---|---|---|
| #1998 | FAILURE | MERGED |
| #2002 | FAILURE | MERGED |
| #2003 | FAILURE | MERGED |
| #2004 | FAILURE | MERGED |
| #2005 | FAILURE | MERGED |
| #2006 | FAILURE | MERGED |
| #2007 | FAILURE | MERGED |
| #2008 | FAILURE | MERGED |

Exact error distribution from #2008 (`gh api repos/WANDERCOLTD/HF/actions/runs/27813806905/logs` then grep error lines):

| Rule | Count | Message |
|---|---|---|
| `react-hooks/preserve-manual-memoization` | 34 | "Compilation Skipped: Existing memoization could not be preserved" |
| `react-hooks/static-components` | 12 | "Cannot create components during render" |
| `react-hooks/purity` | 6 | "Cannot call impure function during render" |
| **Total** | **52** | (matches summary line `✖ 4861 problems (52 errors, 4809 warnings)`) |

Workflow gating mechanism cite: `.github/workflows/test.yml` lines 51-70 — lint step (`npm run lint`) exits 1; ratchet step (`npm run ratchet:check`, calls `apps/admin/scripts/check-ratchet.sh`) is the next step but gets skipped because GitHub Actions short-circuits on step failure. Verified by reading the workflow file directly.

Sample command used during research: `gh run view 27813806905 --log-failed 2>&1 | grep "  error  " | wc -l` returned 52. Filtered by message: `Compilation Skipped` 34, `Cannot create components` 12, `Cannot call impure` 6.

Lattice survey (per `.claude/rules/lattice-survey.md`):
- **Surface**: ESLint rule severity + ratchet baseline (Guards pillar + Coverage pillar via ratchet).
- **Sibling writers**: none — no other writer touches these 3 rule severities or the `lint_warnings` baseline.
- **Cascade respect**: N/A (no cascade family for ESLint rule severity).
- **Default-deny gates**: N/A.
- **Convention conflict**: yes — `#865` closeout comment claimed "zero current violations". That claim is now stale and corrected in-place in this PR.

## Follow-on

A pay-down epic to repair the 52 violations and re-promote each rule back to `"error"`. Not in scope here; the rule file documents the trigger condition (audit, fix, promote, lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)