### PR TITLE
chore(dev-testing): polish — fake names + welcome msg + tab cleanup

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -425,7 +425,7 @@ export default function CourseDetailPage() {
     // through `LEGACY_TAB_REDIRECTS` → 'journey'.
     { id: 'curriculum', label: <TabWithHelp tabId="curriculum">Curriculum</TabWithHelp>, icon: <GraduationCap size={14} /> },
     { id: 'learners', label: <TabWithHelp tabId="learners">Learners</TabWithHelp>, icon: <Users2 size={14} /> },
-    { id: 'proof', label: <TabWithHelp tabId="proof">Proof Points</TabWithHelp>, icon: <BarChart3 size={14} /> },
+    { id: 'proof', label: <TabWithHelp tabId="proof">Proof</TabWithHelp>, icon: <BarChart3 size={14} /> },
     { id: 'goals', label: <TabWithHelp tabId="goals">Goals</TabWithHelp>, icon: <Target size={14} /> },
     // Sprint 2 SP2-B — Skills Framework Inspector beta tab. Renders the
     // structural rubric the educator authored (Framework Map lens default).

--- a/apps/admin/components/callers/CallerDetailPage.tsx
+++ b/apps/admin/components/callers/CallerDetailPage.tsx
@@ -94,21 +94,14 @@ export default function CallerDetailPage() {
     artifacts: "overview-v2",
   };
   const rawTab = searchParams.get("tab");
-  // S5 of #1555 — `?v=3` opens the Snapshot v3 beta tab when the
-  // environment flag is on. Two layers of opt-in: (1) build-time env
-  // var `NEXT_PUBLIC_SNAPSHOT_V3_ENABLED=true`, (2) explicit `?v=3` on
-  // the URL. The flag without the URL param leaves the existing
-  // experience untouched ("no regression" acceptance); the URL param
-  // without the flag is also a no-op so a bookmarked beta link can't
-  // leak across deploys.
-  const snapshotV3FlagEnabled =
-    process.env.NEXT_PUBLIC_SNAPSHOT_V3_ENABLED === "true";
-  const snapshotV3Requested = searchParams.get("v") === "3";
-  const snapshotV3Active = snapshotV3FlagEnabled && snapshotV3Requested;
-  // Wave E — HF_TAB_LAYOUT FF drives visible-tab composition. `both`
-  // (default) shows v3 primary (Attainment + Adaptations) + legacy
-  // with amber Retiring pill. `retire` hides legacy from the bar and
-  // redirects URL hits via `retirementRedirect` below.
+  // Snapshot v3 promoted to primary tab 2026-06-19. Downstream render
+  // branches still check `snapshotV3Active`; keep the const true so the
+  // existing call sites need no further changes in this PR.
+  const snapshotV3Active = true;
+  // HF_TAB_LAYOUT FF drives visible-tab composition. Default `retire`
+  // hides legacy tabs from the bar and redirects URL hits via
+  // `retirementRedirect`. Set NEXT_PUBLIC_HF_TAB_LAYOUT=both to surface
+  // the legacy tabs with the amber Retiring pill during a transition.
   const tabLayout = getTabLayout();
   const tabLayoutResult = computeVisibleTabs(tabLayout);
   // Tabs that may render but DO NOT appear in the tab bar (legacy / hidden).
@@ -116,13 +109,6 @@ export default function CallerDetailPage() {
   // tab bar itself is built from the VISIBLE_TABS subset below.
   const validTabs: SectionId[] = ["overview", "overview-v2", "uplift", "uplift-v2", "calls-prompts", "tune", "how", "what", "progress-v2", "artifacts", "ai-call", "session-flow", "attainment", "adaptations", "snapshot-v3"];
   const VISIBLE_TABS = new Set<SectionId>(tabLayoutResult.visible);
-  // Snapshot v3 stays gated behind the `?v=3` URL param even when
-  // HF_TAB_LAYOUT=both — beta gate, until the dedicated promotion lands.
-  // Operators who want it visible flip `NEXT_PUBLIC_SNAPSHOT_V3_ENABLED=true`
-  // AND `?v=3`.
-  if (!snapshotV3Active) {
-    VISIBLE_TABS.delete("snapshot-v3");
-  }
   // Wave E — retire-mode redirect: if the raw tab is a retiring one and
   // the FF flipped to `retire`, route the user to the v3 replacement so
   // bookmarked URLs don't 404.
@@ -734,12 +720,8 @@ export default function CallerDetailPage() {
   const allSections = useMemo<{ id: SectionId; label: React.ReactNode; icon: React.ReactNode; count?: number; special?: boolean; group: "history" | "caller" | "shared" | "action" }[]>(() => {
     if (!data) return [];
     return [
-      // S5 of #1555 — Snapshot v3 beta tab. Only visible when
-      // `?v=3` + `NEXT_PUBLIC_SNAPSHOT_V3_ENABLED=true`; otherwise the
-      // entry is in allSections (so the render branch is reachable for
-      // URL-typed access) but not in VISIBLE_TABS (so the tab bar stays
-      // unchanged).
-      { id: "snapshot-v3", label: "Snapshot (beta)", icon: <span aria-hidden>✨</span>, group: "shared" },
+      // Snapshot v3 — primary entry tab (promoted out of beta 2026-06-19).
+      { id: "snapshot-v3", label: "Snapshot", icon: <span aria-hidden>✨</span>, group: "shared" },
       { id: "overview-v2", label: <TabWithHelp tabId="overview-v2">Overview</TabWithHelp>, icon: <span aria-hidden>🧭</span>, group: "shared" },
       { id: "calls-prompts", label: <TabWithHelp tabId="calls-prompts">Calls</TabWithHelp>, icon: <Phone size={13} />, count: data.counts.calls, group: "history" },
       { id: "tune", label: <TabWithHelp tabId="tune">Tune</TabWithHelp>, icon: <SlidersHorizontal size={13} />, count: data.counts.prompts || undefined, group: "caller" },

--- a/apps/admin/hooks/useJourneyChat.ts
+++ b/apps/admin/hooks/useJourneyChat.ts
@@ -357,22 +357,30 @@ export function useJourneyChat({ callerId, forceFirstCall, callerRole }: UseJour
       const progressRes = await fetch(url('/api/student/progress', callerId));
       const progressData = await progressRes.json();
 
-      const inst = progressData.institutionName || 'your institution';
+      const inst = progressData.institutionName;
       const teacher = progressData.teacherName;
       const goals = progressData.goals ?? [];
 
+      const greeting = inst
+        ? `Welcome to ${inst}! ${teacher ? `${teacher} set this up for you. ` : ''}I'm your AI study partner — ready to help you learn through conversation.`
+        : `Welcome! ${teacher ? `${teacher} set this up for you. ` : ''}I'm your AI study partner — ready to help you learn through conversation.`;
+
       pushItems(
         dividerItem('Welcome'),
-        textItem('assistant', `Welcome to ${inst}! ${teacher ? `${teacher} set this up for you. ` : ''}I'm your AI study partner — ready to help you learn through conversation.`),
+        textItem('assistant', greeting),
       );
 
       const goalsEnabled = welcomeConfigRef.current?.goals?.enabled !== false;
       if (goalsEnabled && goals.length > 0) {
-        const goalList = goals.map((g: { name: string }) => `• ${g.name}`).join('\n');
-        pushItems(textItem('assistant', `Here are your learning goals:\n${goalList}`));
+        const MAX_VISIBLE_GOALS = 4;
+        const visibleGoals = goals.slice(0, MAX_VISIBLE_GOALS);
+        const overflow = goals.length - visibleGoals.length;
+        const goalList = visibleGoals.map((g: { name: string }) => `• ${g.name}`).join('\n');
+        const tail = overflow > 0 ? `\n• …and ${overflow} more` : '';
+        pushItems(textItem('assistant', `Here's what we'll work on:\n${goalList}${tail}`));
       }
 
-      pushItems(textItem('assistant', "You'll have AI-powered practice sessions that adapt to how you're doing. Let's get started!"));
+      pushItems(textItem('assistant', "We'll adapt as we go. Let's get started!"));
 
       const hasMorePhases = welcomeQueueRef.current.length > 0;
 

--- a/apps/admin/lib/fake-names.ts
+++ b/apps/admin/lib/fake-names.ts
@@ -2,53 +2,55 @@
  * Fake name generator for sim launch.
  * Used when no learner name is provided — produces a realistic-sounding
  * but clearly fictional name instead of a serial number.
+ *
+ * Pool: classic Hollywood / golden-age cinema first + last names. Mix and
+ * match produces plausible "old movie" names without trademark issues.
+ * Replaces the pre-2026-06-19 international pool which was reading as
+ * stereotyping rather than realism.
  */
 
 const FIRST_NAMES = [
-  // Original set
-  "Alex", "Blake", "Casey", "Dana", "Elise", "Finn", "Grace", "Harper",
-  "Imani", "Jordan", "Kai", "Leila", "Morgan", "Nadia", "Omar", "Priya",
-  "Quinn", "Remy", "Sage", "Tara", "Uma", "Val", "Wren", "Xio",
-  "Yara", "Zeke", "Aiden", "Bea", "Cole", "Dani", "Eden", "Frankie",
-  "Glen", "Hazel", "Iris", "Jules", "Kieran", "Luca", "Mila", "Nico",
-  "Olive", "Phoenix", "River", "Sasha", "Theo", "Uri", "Vera", "Winter",
-  // Expanded set
-  "Amara", "Bodhi", "Caleb", "Darcy", "Emeka", "Fatima", "Gael", "Hana",
-  "Idris", "Juno", "Kofi", "Layla", "Mateo", "Nia", "Oscar", "Paloma",
-  "Quincy", "Rowan", "Sienna", "Tariq", "Umi", "Vivian", "Wyatt", "Xena",
-  "Yusuf", "Zara", "Arlo", "Brynn", "Cyrus", "Dahlia", "Ezra", "Freya",
-  "Gia", "Henrik", "Ines", "Jasper", "Kira", "Leo", "Maren", "Nash",
-  "Orla", "Piper", "Rae", "Stellan", "Tessa", "Ugo", "Vesper", "Wells",
-  "Ximena", "Yael", "Zion", "Asha", "Beckett", "Cleo", "Diego", "Elowen",
-  "Felix", "Gemma", "Hugo", "Isla", "Joaquin", "Kaia", "Levi", "Maeve",
-  "Nolan", "Opal", "Pascal", "Rhea", "Soren", "Thalia", "Ulric", "Viola",
-  "Wes", "Xiomara", "Yolanda", "Zev",
+  // Leading men — Golden Age
+  "Humphrey", "Cary", "James", "Gary", "Spencer", "Clark", "Henry", "Gregory",
+  "Burt", "Frank", "Errol", "Tyrone", "John", "Robert", "William", "Charles",
+  "Orson", "Marlon", "Montgomery", "Kirk", "Yul", "Charlton", "Anthony", "Rock",
+  "Tony", "Sidney", "Paul", "Steve", "Jack", "Dustin", "Richard", "Peter",
+  "George", "Edward", "David", "Michael", "Donald", "Walter", "Joseph", "Lee",
+  // Leading ladies — Golden Age
+  "Audrey", "Katharine", "Bette", "Joan", "Vivien", "Ingrid", "Lauren", "Grace",
+  "Marilyn", "Rita", "Ava", "Lana", "Judy", "Mae", "Greta", "Carole",
+  "Olivia", "Barbara", "Veronica", "Faye", "Natalie", "Shirley", "Jane", "Doris",
+  "Sophia", "Elizabeth", "Deborah", "Maureen", "Susan", "Eva", "Gloria", "Joanne",
+  "Anne", "Mary", "Helen", "Ruth", "Dorothy", "Rosalind", "Claudette", "Myrna",
+  // New Hollywood / 70s-80s
+  "Diane", "Meryl", "Sissy", "Glenn", "Sigourney", "Goldie", "Geena",
+  "Holly", "Demi", "Sharon", "Michelle", "Julianne", "Frances", "Annette", "Andie",
+  "Harrison", "Al", "Warren", "Gene", "Robin", "Bill",
+  "Bruce", "Mel", "Kevin", "Tom", "Denzel", "Morgan", "Samuel", "Wesley",
 ];
 
 const LAST_NAMES = [
-  // Original set
-  "Ahmed", "Baxter", "Chen", "Diallo", "Evans", "Ferreira", "Garcia",
-  "Hassan", "Ishida", "James", "Kim", "Larson", "Moreau", "Nakamura",
-  "Osei", "Patel", "Quinn", "Reyes", "Sharma", "Torres", "Ueda",
-  "Vasquez", "Walsh", "Xu", "Yamamoto", "Zhao", "Anders", "Brooks",
-  "Costa", "Dubois", "Ellis", "Foster", "Grant", "Hill", "Ibarra",
-  "Jensen", "Khan", "Lima", "Mori", "Nour", "Ortiz", "Park", "Reid",
-  "Santos", "Taylor", "Vance", "Wood", "Young", "Zola",
-  // Expanded set
-  "Adeyemi", "Bergström", "Cho", "Delgado", "Eriksen", "Fernandez", "Gupta",
-  "Hernandez", "Ivanova", "Johansson", "Kato", "Lindqvist", "Mendes", "Novak",
-  "Okafor", "Petrov", "Ramirez", "Sato", "Tanaka", "Urdaneta", "Volkov",
-  "Weber", "Xiong", "Yilmaz", "Zheng", "Abadi", "Björk", "Cabrera",
-  "Dempsey", "Engström", "Fong", "Gomes", "Horváth", "Ikeda", "Jaffe",
-  "Kowalski", "Lam", "Müller", "Nguyen", "Okamoto", "Popov", "Qureshi",
-  "Rossi", "Sundaram", "Tremblay", "Uribe", "Vieira", "Whitfield", "Yoo",
-  "Zambrano", "Ashworth", "Bello", "Castellanos", "Doyle", "Esposito", "Falk",
-  "Guzmán", "Hawkins", "Ito", "Jansen", "Kemp", "Lombardi", "Magnusson",
-  "Nkosi", "Olsson", "Pascual", "Rinaldi", "Söderberg", "Thorne", "Uchida",
-  "Valdez", "Winters", "Yanez", "Ziegler",
+  // Golden Age — leading men
+  "Bogart", "Grant", "Stewart", "Cooper", "Tracy", "Gable", "Fonda", "Peck",
+  "Lancaster", "Sinatra", "Flynn", "Power", "Wayne", "Mitchum", "Holden", "Laughton",
+  "Welles", "Brando", "Clift", "Douglas", "Brynner", "Heston", "Quinn", "Hudson",
+  "Curtis", "Poitier", "Newman", "McQueen", "Nicholson", "Hoffman", "Burton", "Sellers",
+  "Scott", "Robinson", "Niven", "Lemmon", "Cotten", "Marvin", "Cobb", "Hayden",
+  // Golden Age — leading ladies
+  "Hepburn", "Davis", "Crawford", "Leigh", "Bergman", "Bacall", "Kelly", "Monroe",
+  "Hayworth", "Turner", "Gardner", "Garland", "West", "Garbo", "Lombard",
+  "Stanwyck", "Lake", "Dunaway", "Wood", "MacLaine", "Day",
+  "Loren", "Taylor", "Kerr", "Hayward", "Swanson", "Loy",
+  "Russell", "Colbert",
+  // New Hollywood / 70s-80s
+  "Keaton", "Streep", "Spacek", "Close", "Weaver", "Hawn", "Midler", "Hunt",
+  "Stone", "Pfeiffer", "McDormand", "Bening", "MacDowell",
+  "Ford", "Pacino", "Redford", "Beatty", "Hackman", "Williams", "Murray",
+  "Willis", "Gibson", "Costner", "Hanks", "Washington", "Freeman", "Jackson", "Snipes",
+  "Reeves", "Cruise", "Penn", "Cage", "Travolta", "Spader", "Goldblum",
 ];
 
-/** Returns a random fake full name, e.g. "Elise Moreau" */
+/** Returns a random fake full name, e.g. "Audrey Bogart" */
 export function randomFakeName(): string {
   const first = FIRST_NAMES[Math.floor(Math.random() * FIRST_NAMES.length)];
   const last = LAST_NAMES[Math.floor(Math.random() * LAST_NAMES.length)];

--- a/apps/admin/lib/tab-layout.ts
+++ b/apps/admin/lib/tab-layout.ts
@@ -29,10 +29,14 @@ import type { SectionId } from "@/components/callers/caller-detail/types";
 
 export type TabLayout = "both" | "retire";
 
-/** Resolves the FF from `NEXT_PUBLIC_HF_TAB_LAYOUT`. Defaults to `both`. */
+/**
+ * Resolves the FF from `NEXT_PUBLIC_HF_TAB_LAYOUT`. Defaults to `retire`
+ * (legacy tabs hidden, v3 surfaces primary). Set the env-var explicitly to
+ * `both` to surface legacy + amber Retiring pills during a transition.
+ */
 export function getTabLayout(): TabLayout {
-  if (typeof process === "undefined") return "both";
-  return process.env.NEXT_PUBLIC_HF_TAB_LAYOUT === "retire" ? "retire" : "both";
+  if (typeof process === "undefined") return "retire";
+  return process.env.NEXT_PUBLIC_HF_TAB_LAYOUT === "both" ? "both" : "retire";
 }
 
 /**

--- a/apps/admin/tests/lib/tab-layout.test.ts
+++ b/apps/admin/tests/lib/tab-layout.test.ts
@@ -39,18 +39,18 @@ afterEach(() => {
 });
 
 describe("getTabLayout", () => {
-  it("defaults to 'both' when env var unset", () => {
-    expect(getTabLayout()).toBe("both");
-  });
-
-  it("returns 'both' when env var is any string other than 'retire'", () => {
-    process.env.NEXT_PUBLIC_HF_TAB_LAYOUT = "anything";
-    expect(getTabLayout()).toBe("both");
-  });
-
-  it("returns 'retire' when env var explicitly set", () => {
-    process.env.NEXT_PUBLIC_HF_TAB_LAYOUT = "retire";
+  it("defaults to 'retire' when env var unset", () => {
     expect(getTabLayout()).toBe("retire");
+  });
+
+  it("returns 'retire' when env var is any string other than 'both'", () => {
+    process.env.NEXT_PUBLIC_HF_TAB_LAYOUT = "anything";
+    expect(getTabLayout()).toBe("retire");
+  });
+
+  it("returns 'both' when env var explicitly set", () => {
+    process.env.NEXT_PUBLIC_HF_TAB_LAYOUT = "both";
+    expect(getTabLayout()).toBe("both");
   });
 });
 


### PR DESCRIPTION
## Summary

Findings from 2026-06-19 DEV-testing session, four small polishes:

1. **`fake-names.ts`** — replace international name pool with classic Hollywood first + last names (Bogart, Hepburn, Stewart, Brando, McQueen, Streep…). Same mix-and-match shape; reads as realistic-old-movie names instead of stereotyping.
2. **`useJourneyChat.ts` onboarding welcome** —
   - Drop the "Welcome to your institution!" fallback when `institutionName` is null; lead with "Welcome!" instead.
   - Cap goal bullet list to top 4 + "…and N more" overflow line. IELTS-shape courses with ~12 micro-goals were unreadable.
   - Tighten closing line to "We'll adapt as we go. Let's get started!"
3. **Tab cleanup** —
   - `tab-layout.ts`: flip `getTabLayout()` default `both` → `retire`. Legacy Overview / Progress / Uplift / Profile-as-`how` hidden by default. `NEXT_PUBLIC_HF_TAB_LAYOUT=both` re-surfaces them.
   - `CallerDetailPage.tsx`: promote Snapshot v3 out of beta — drop the `NEXT_PUBLIC_SNAPSHOT_V3_ENABLED` + `?v=3` gate; relabel "Snapshot (beta)" → "Snapshot".
   - `tab-layout.test.ts`: update default-state assertions.
4. **Course detail tab bar** — `Proof Points` → `Proof` to recover horizontal space for Settings on operator view. (Design tab removal already shipped in #1943.)

## Verified by

- `tests/lib/tab-layout.test.ts` — 12/12 green after default flip.
- `tsc --noEmit` — no new errors in any of the 6 touched files (pre-existing main errors in unrelated files: PlaybookDetail/StudentProgress drift in `page.tsx:1372/1720`, untouched here).

## Test plan

- [ ] Caller-detail tab bar reads: Snapshot · Calls · Tune · Attainment · Adaptations · Session Flow · Call — no legacy tabs, no "Retiring" pills.
- [ ] Course-detail tab bar fits horizontally on operator view; Settings tab fully visible.
- [ ] Newly-created sim callers get classic-Hollywood names (Audrey Bogart, Henry Lancaster…).
- [ ] Learner-side onboarding welcome: ≤ 4 goals visible + overflow tail; no "Welcome to your institution!" when institution is null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)