### PR TITLE
chore(ci): ratchet step runs always — closes the silent-drift hole

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,15 @@ jobs:
       # win" hint. Started enforcing on 2026-05-14 after discovering that the
       # ratchet existed but wasn't wired into CI — by then tsc_errors had
       # drifted 574 → 625 silently. See PR for context.
+      #
+      # `if: always()` — defends against the 2026-06 drift mechanism that
+      # produced PRs #1998-#2008 (8/8 merged with Lint red). When ESLint
+      # exits 1, GitHub Actions skips subsequent steps; the ratchet step
+      # was never running for weeks, letting lint_warnings drift 4544 → 4809
+      # silently. The ratchet must measure the codebase regardless of lint
+      # syntax — both signals are independent and both matter.
       - name: Ratchet check (blocking — no new tsc/lint debt)
+        if: always()
         run: npm run ratchet:check
 
       # knip — dead-code detection. Informational for now; a future PR will


### PR DESCRIPTION
## Summary

Adds `if: always()` to the Ratchet check step in `.github/workflows/test.yml`. Closes the structural drift mechanism that produced the #1998–#2008 8-PR streak.

## The structural failure

Before this PR, the Lint & Type Check job's step ordering was:

```yaml
- Run ESLint         # exits 1 on any error
- TypeScript ...     # continue-on-error: true
- Ratchet check      # blocking — but SKIPPED by GHA when lint exits 1
```

When lint exited 1, GitHub Actions short-circuited the rest of the job. So the ratchet step never ran. Between `#865` closeout (Feb 2026) and 2026-06-19, `lint_warnings` drifted 4544 → 4809 with zero CI signal. Errors accumulated to 52 and 8 consecutive PRs merged red without anyone seeing the ratchet's "you've grown the warn debt by 265" complaint.

PR #2016 fixed the content (demoted 3 rules to warn). PR #2018 cleared one cohort (purity, 6 sites) and re-promoted the rule. This PR fixes the **gate mechanics** so the next regression can't recreate the same silent drift.

## The 1-line change

```yaml
- name: Ratchet check (blocking — no new tsc/lint debt)
  if: always()                          # ← new
  run: npm run ratchet:check
```

`if: always()` runs the step regardless of upstream failures (but still skipped on job cancellation). Both lint and ratchet now report independently — when both fail, both messages land in the same CI run instead of forcing a fix-lint-then-re-push round-trip.

## Scope

Just the ratchet step. The sibling blocking checks downstream of lint (`KNOWLEDGE-MAP.md ratchet`, `AI-CAPABILITIES.md drift guard`, `Incident-guard ritual`) have similar drift potential but weren't part of the observed incident. One concern per commit per project convention. If we want to harden those too, follow-on issue.

## Test plan

- [ ] CI on this PR passes (the change is a no-op for green-lint runs).
- [ ] Future verification: introduce a draft PR with both a deliberate lint error AND a deliberate warning increase. Confirm CI reports BOTH failures, not just lint.

## Verified by

Reproducible probe — confirms every step after `Run ESLint` was `skipped` when lint failed on PR #2008:

```
gh api repos/WANDERCOLTD/HF/actions/jobs/82310017006 --jq '.steps[] | "\(.name): \(.conclusion)"'
```

That probe returns `TypeScript type check (informational): skipped`, `Ratchet check (blocking ...): skipped`, etc. — every downstream step skipped because lint exited 1.

Compare to the green run from PR #2016 (commit fd2a69a2) where lint passed and the ratchet ran:

```
gh api repos/WANDERCOLTD/HF/actions/jobs/82316246640 --jq '.steps[] | "\(.name): \(.conclusion)"'
```

That run shows `Ratchet check (blocking ...): success` — and was the first time the ratchet had run for weeks.

Workflow file path: `.github/workflows/test.yml` lines 12-119 — step ordering verified by direct read.

Drift evidence: `.ratchet.json` lint_warnings baseline was 4544 pre-#2016; CI summary line from `gh api repos/WANDERCOLTD/HF/actions/runs/27813806905/logs` (#2008) read `✖ 4861 problems (52 errors, 4809 warnings)`. The 4544 → 4809 gap is the silent drift.

Lattice survey (per `.claude/rules/lattice-survey.md`): workflow file edit, Guards pillar reinforcement. Sibling writers: none — no other workflow step or YAML mutates this step's behavior. Cascade: N/A. Default-deny: N/A. Convention conflict: comment added in-place documents the WHY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)