### PR TITLE
feat(measurement): #1967 M4 structural pass 2 — 32 more deferred params reclassified (34 → 2)

### DIFF
--- a/apps/admin/docs-archive/bdd-specs/behavior-parameters.registry.json
+++ b/apps/admin/docs-archive/bdd-specs/behavior-parameters.registry.json
@@ -338,7 +338,10 @@
       "interpretationLow": "Conceptual: Uses 'consider', 'reflect', 'understand' \u2014 grounds learning in thought",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor action-oriented vs abstract vocabulary; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -367,7 +370,10 @@
       "interpretationLow": "Direct Explanation: Explains concepts in their own terms without analogies",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor analogy-usage frequency; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -380,7 +386,10 @@
       "interpretationLow": "Consistent: Sticks with one approach throughout the session",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor teaching-modality switching frequency; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -409,7 +418,10 @@
       "interpretationLow": "Trust & Continue: Assumes understanding unless the learner signals confusion",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor comprehension-check frequency; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -422,7 +434,10 @@
       "interpretationLow": "Sparse: One idea at a time with space to absorb before adding more",
       "usage": {
         "compose": "transform-direct",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor concept-density per exchange; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -464,7 +479,10 @@
       "interpretationLow": "Approximate: Uses plain-language descriptions, favours intuition over precision",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor technical-term definition precision; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -477,7 +495,10 @@
       "interpretationLow": "Narrative: Explains through stories and sequential descriptions",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor visual/spatial-structure descriptive language; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -527,7 +548,10 @@
       "interpretationLow": "Minimal Examples: Brief or no examples \u2014 relies on abstract explanation",
       "usage": {
         "compose": "transform-direct",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor concrete-example richness; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -540,7 +564,10 @@
       "interpretationLow": "Consistent: Repeats and reinforces the same explanation with more detail",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor re-explanation variety on learner confusion; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -553,7 +580,10 @@
       "interpretationLow": "Analytical: Factual, logical language \u2014 'note that', 'observe that'",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor sensory / emotional language usage; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -601,7 +631,10 @@
       "interpretationLow": "Independent: Sets the task and lets the learner work through it alone",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor step-by-step guidance during practice; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -614,7 +647,10 @@
       "interpretationLow": "Text-Focused: Relies on logical reasoning and verbal explanation",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor mental-imagery / visualisation density; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -673,7 +709,10 @@
       "interpretationLow": "Flowing: Uses natural prose and connected paragraphs",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor list / hierarchy / structured-format organisation; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -701,7 +740,10 @@
       "interpretationLow": "Mix It Up: Deliberately varies approaches even when one is working well",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor stickiness to learner's preferred modality; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -714,7 +756,10 @@
       "interpretationLow": "Single Channel: Relies on one primary teaching approach regardless of content",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor teaching-channel variety; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -743,7 +788,10 @@
       "interpretationLow": "Core Only: Sticks to the main rule or concept without exploring exceptions",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor edge-case / nuance exploration depth; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -811,7 +859,10 @@
       "interpretationLow": "Discussion-Based: Learning through conversation and explanation, few exercises",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor hands-on exercise inclusion rate; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -824,7 +875,10 @@
       "interpretationLow": "Explanation-Heavy: Most of the session is spent on teaching and explaining",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor explanation-to-practice ratio; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -868,7 +922,10 @@
       "interpretationLow": "Accepting: Accepts answers at face value without probing deeper",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor follow-up question depth; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -912,7 +969,10 @@
       "interpretationLow": "Theoretical: Stays within the academic or abstract domain",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor abstract-to-practical example bridging; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -925,7 +985,10 @@
       "interpretationLow": "Say Once: States concepts once and moves on without repetition",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor in-session repetition frequency; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -938,7 +1001,10 @@
       "interpretationLow": "On Request: Only repeats when the learner explicitly asks",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor proactive repeat / rephrase offers; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -982,7 +1048,10 @@
       "interpretationLow": "Steady: Maintains a consistent pace without deliberate rhythmic variation",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor pace / cadence / flow attention; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -995,7 +1064,10 @@
       "interpretationLow": "Minimal Scaffolding: Presents the full task and lets the learner structure their approach",
       "usage": {
         "compose": "transform-direct",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor structural scaffolding for complex tasks; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -1024,7 +1096,10 @@
       "interpretationLow": "Sequential: Uses 'first', 'then', 'next' \u2014 maps concepts to time",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor spatial / location-based metaphor usage; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -1052,7 +1127,10 @@
       "interpretationLow": "Plain Language: Avoids jargon, uses everyday words to explain concepts",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor formal-vocabulary vs everyday-language balance; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -1081,7 +1159,10 @@
       "interpretationLow": "Concise: Brief, to-the-point explanations \u2014 says it once, clearly",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor spoken-explanation elaboration richness; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -1113,7 +1194,10 @@
       "interpretationLow": "Try First: Asks the learner to attempt the problem before showing solutions",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor worked-example demonstration before learner-try; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -1126,7 +1210,10 @@
       "interpretationLow": "Verbal Only: Teaches entirely through conversation without written supplements",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Sets tutor written-reference / summary supplement rate; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript \u2014 SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
+        }
       }
     },
     {
@@ -1559,7 +1646,10 @@
       "interpretationLow": "Use few engagement prompts; deliver content cleanly without inviting tangents.",
       "usage": {
         "compose": "semantics-block",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Folk-pedagogy preference assertion (\"Conversational learners like to be drawn into dialogue\"); learner-type claim that is not derivable from a single transcript. See BEH-PROBING-QUESTIONS / BEH-SOCRATIC-QUESTIONING sibling tutor-knob axes for the measurable tutor-behavior side of dialogue-drawing engagement."
+        }
       }
     },
     {
@@ -1661,7 +1751,10 @@
       "interpretationLow": "Explain briefly; cover the headline answer and only the rationale the learner needs to act.",
       "usage": {
         "compose": "transform-direct",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Folk-pedagogy preference assertion (\"Reading learners can handle detailed explanations\"); learner-type claim that is not derivable from a single transcript. See BEH-DEFINITION-PRECISION / BEH-VERBAL-ELABORATION sibling tutor-knob axes for the measurable explanation-depth tutor-behavior."
+        }
       }
     },
     {
@@ -2260,7 +2353,10 @@
       "interpretationLow": "Lead with direct explanation; offer questions only as comprehension checks.",
       "usage": {
         "compose": "transform-direct",
-        "measurement": "deferred-#1967"
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Folk-pedagogy preference assertion (\"Conversational learners engage well with questions\"); learner-type claim that is not derivable from a single transcript. See BEH-PROBING-QUESTIONS sibling tutor-knob axis for the measurable Socratic-question-frequency tutor-behavior."
+        }
       }
     },
     {

--- a/apps/admin/tests/lib/measurement/parameter-measurement-coverage.test.ts
+++ b/apps/admin/tests/lib/measurement/parameter-measurement-coverage.test.ts
@@ -98,18 +98,21 @@ function buildEvidenceMap(): Map<string, Set<string>> {
 const EVIDENCE = buildEvidenceMap();
 
 /**
- * 2026-06-19 incumbent (post-M4 structural pass) — M1 backfilled 82
- * params; M4 reclassified 9 (3 measured via STYLE-001 alias, 6
- * operator-only); the M4 structural pass (this commit) reclassified
- * 14 more without pedagogy input: 1 stale row already wired via
- * parametersAsDirectives (BEH-ABSTRACT-VS-CONCRETE), 5 legacy
- * lowercase folk-pedagogy assertions paired with their canonical
- * BEH-* siblings, 8 ADAPT-stage decision rules that are not
- * EXTRACT-stage observables. Leaves 34 active params on
- * "deferred-#1967" awaiting pedagogy review per
- * `docs/M4-pedagogy-review.md`.
+ * 2026-06-19 incumbent (post-M4 structural pass 2) — M1 backfilled
+ * 82 params; M4 reclassified 9 (PR #2006); M4 structural pass 1
+ * (PR #2008) reclassified 14 without pedagogy input; M4 structural
+ * pass 2 (this commit) reclassified another 32 without pedagogy
+ * input using the same decision tree: 29 tutor-emit directives
+ * ("How much the AI [verb]…" / "Whether the AI [verb]…" — no
+ * learner-side signal back) + 3 folk-pedagogy assertions
+ * ("Conversational learners…" / "Reading learners…" — learner-type
+ * claims paired with measurable BEH-* sibling tutor-knob axes).
+ * Leaves 2 active params on "deferred-#1967" that GENUINELY need
+ * pedagogy: BEH-ABSTRACT-OK (learner-state observable — could be
+ * measure) and BEH-ERROR-ELABORATION (definition wording ambiguous
+ * — could be measure OR folk-pedagogy).
  */
-const EXPECTED_GAP_COUNT = 34;
+const EXPECTED_GAP_COUNT = 2;
 
 type Classification =
   | "measured"

--- a/docs/M4-pedagogy-review.md
+++ b/docs/M4-pedagogy-review.md
@@ -1,18 +1,20 @@
 # M4 — Pedagogy review worksheet (epic #1967)
 
-Of the 57 deferred params (`measurement: "deferred-#1967"`) M1 surfaced, M4 reclassified 9 in the same PR (3 measured via STYLE-001 alias-citation; 6 operator-only tutor knobs). **The M4 structural pass (2026-06-19) reclassified 14 more without pedagogy input** using the decision tree in [`.claude/rules/parameter-measurement-coverage.md`](../.claude/rules/parameter-measurement-coverage.md). The remaining **34 active rows** below need pedagogy review.
+Of the 57 deferred params (`measurement: "deferred-#1967"`) M1 surfaced, M4 reclassified 9 in the same PR (3 measured via STYLE-001 alias-citation; 6 operator-only tutor knobs). **The M4 structural pass 1 (2026-06-19, PR #2008) reclassified 14 more without pedagogy input** using the decision tree in [`.claude/rules/parameter-measurement-coverage.md`](../.claude/rules/parameter-measurement-coverage.md). **The M4 structural pass 2 (2026-06-19, this commit) reclassified a further 32 without pedagogy input** using the same decision tree more aggressively.
+
+The remaining **2 active rows** below GENUINELY need pedagogy review — both are learner-state questions (not tutor knobs) and the decision tree cannot classify them mechanically.
 
 **For each row, the reviewer picks one of:**
 
 - **`measure`** — author a MEASURE AnalysisSpec that scores this from transcript. Note the proposed spec id.
-- **`operator-only`** — non-measurable tutor knob; reclassify in registry as `usage.measurement: { kind: "operator-only", reason: "..." }`. Use one of the three reason templates in the decision tree (tutor-emit directive / folk-pedagogy assertion / ADAPT-stage decision rule).
+- **`operator-only`** — non-measurable; reclassify in registry as `usage.measurement: { kind: "operator-only", reason: "..." }`. Use one of the three reason templates in the decision tree (tutor-emit directive / folk-pedagogy assertion / ADAPT-stage decision rule).
 - **`defer`** — genuinely cannot decide today; keep as `"deferred-#1967"`.
 
 Closing the loop for `measure` rows also closes the M2 loop-closure ratchet by 1 if an AGGREGATE / ADAPT spec already consumes the param — or the same PR extends one to do so.
 
-## Structural pass completed (2026-06-19) — DO NOT review again
+## Structural passes completed (2026-06-19) — DO NOT review again
 
-The 14 rows below were structurally classified without pedagogy input and now carry an `operator-only` measurement kind in the registry. Tracked here for audit trail:
+### Pass 1 (PR #2008, 14 rows)
 
 | parameterId | shape | drop-rationale |
 |---|---|---|
@@ -20,54 +22,31 @@ The 14 rows below were structurally classified without pedagogy input and now ca
 | `analogy-usage`, `concept-density`, `example-richness`, `repetition-frequency`, `scaffolding` | folk-pedagogy assertion | Learner-preference statements paired with BEH-* siblings; not derivable from one transcript |
 | `BEH-ADVANCE-READINESS`, `BEH-CHALLENGE-LEVEL`, `BEH-FOUNDATION-FOCUS`, `BEH-INTERLEAVING`, `BEH-NEW-CONTENT-RATE`, `BEH-PREREQUISITE-CALLBACK`, `BEH-PRODUCTIVE-STRUGGLE`, `BEH-SPACED-RETRIEVAL-PRIORITY` | ADAPT-stage decision rule | Consumed by ADAPT-runner against aggregated mastery; not an EXTRACT-stage observable |
 
-## `curriculum-adaptation` (12 params remaining — 8 already classified above)
+### Pass 2 (this commit, 32 rows)
 
-| parameterId | definition | proposed classification |
-|---|---|---|
-| `BEH-ANALOGY-USAGE` | How often the AI uses analogies and metaphors to bridge from familiar concepts to new ones. | _(reviewer)_ |
-| `BEH-CHECK-FOR-UNDERSTANDING` | How frequently the AI pauses to verify the learner has understood before moving on. | _(reviewer)_ |
-| `BEH-CONCEPT-DENSITY` | How many new ideas the AI introduces in a single exchange. | _(reviewer)_ |
-| `BEH-EXAMPLE-RICHNESS` | How many concrete examples the AI provides when explaining a concept. | _(reviewer)_ |
-| `BEH-EXPLANATION-VARIETY` | Whether the AI tries different approaches when a learner doesn't understand the first time. | _(reviewer)_ |
-| `BEH-GUIDED-PRACTICE` | How much step-by-step support the AI provides during practice activities. | _(reviewer)_ |
-| `BEH-NUANCE-EXPLORATION` | How deeply the AI explores edge cases, exceptions, and subtle distinctions. | _(reviewer)_ |
-| `BEH-PRACTICE-RATIO` | The balance between explanation and hands-on practice in each session. | _(reviewer)_ |
-| `BEH-PROBING-QUESTIONS` | How often the AI asks deeper follow-up questions to extend the learner's thinking. | _(reviewer)_ |
-| `BEH-REPETITION-FREQUENCY` | How often the AI restates or revisits key concepts within a session. | _(reviewer)_ |
-| `BEH-SCAFFOLDING` | How much structural support the AI provides to help the learner tackle complex tasks. | _(reviewer)_ |
-| `BEH-WORKED-EXAMPLES` | Whether the AI demonstrates complete solutions before asking the learner to try. | _(reviewer)_ |
+**29 tutor-emit directives** (curriculum-adaptation 12 + learning-adaptation 17) — definitions all read "How [much/often/many] the AI [verb]…" or "Whether the AI [verb]…". The AI is told via prompt; no learner-side signal reflects it back. SUPERVISE-stage compliance check is a separate concern.
 
-## `learning-adaptation` (21 params remaining — 6 already classified above: `BEH-ABSTRACT-VS-CONCRETE` + 5 legacy lowercase)
+| Cluster | parameterIds |
+|---|---|
+| curriculum-adaptation tutor-emit | `BEH-ANALOGY-USAGE`, `BEH-CHECK-FOR-UNDERSTANDING`, `BEH-CONCEPT-DENSITY`, `BEH-EXAMPLE-RICHNESS`, `BEH-EXPLANATION-VARIETY`, `BEH-GUIDED-PRACTICE`, `BEH-NUANCE-EXPLORATION`, `BEH-PRACTICE-RATIO`, `BEH-PROBING-QUESTIONS`, `BEH-REPETITION-FREQUENCY`, `BEH-SCAFFOLDING`, `BEH-WORKED-EXAMPLES` |
+| learning-adaptation tutor-emit | `BEH-ACTION-VERBS`, `BEH-APPROACH-SWITCHING`, `BEH-DEFINITION-PRECISION`, `BEH-DIAGRAM-LANGUAGE`, `BEH-FEELING-LANGUAGE`, `BEH-IMAGERY-DENSITY`, `BEH-LIST-STRUCTURE`, `BEH-MODALITY-CONSISTENCY`, `BEH-MODALITY-VARIETY`, `BEH-PRACTICE-EXERCISES`, `BEH-REAL-WORLD-EXAMPLES`, `BEH-REPETITION-OFFER`, `BEH-RHYTHM-ATTENTION`, `BEH-SPATIAL-METAPHOR`, `BEH-TERMINOLOGY-FORMAL`, `BEH-VERBAL-ELABORATION`, `BEH-WRITTEN-ALTERNATIVE` |
 
-| parameterId | definition | proposed classification |
-|---|---|---|
-| `BEH-ABSTRACT-OK` | How comfortable the learner is with theoretical and abstract concepts versus concrete ones. | _(reviewer)_ |
-| `BEH-ACTION-VERBS` | Whether the AI uses action-oriented, practical language versus abstract terminology. | _(reviewer)_ |
-| `BEH-APPROACH-SWITCHING` | How freely the AI switches between different teaching modalities during a session. | _(reviewer)_ |
-| `BEH-DEFINITION-PRECISION` | How precisely the AI defines technical terms and concepts. | _(reviewer)_ |
-| `BEH-DIAGRAM-LANGUAGE` | How much the AI describes concepts using visual/spatial structures (diagrams, charts, maps). | _(reviewer)_ |
-| `BEH-ENGAGEMENT-PROMPTS` | Conversational learners like to be drawn into dialogue | _(reviewer)_ |
-| `BEH-EXPLANATION-DEPTH` | Reading learners can handle detailed explanations | _(reviewer)_ |
-| `BEH-FEELING-LANGUAGE` | How much the AI uses sensory and emotional language (feel, sense, touch, experience). | _(reviewer)_ |
-| `BEH-IMAGERY-DENSITY` | How much the AI uses vivid mental imagery and visualisation in explanations. | _(reviewer)_ |
-| `BEH-LIST-STRUCTURE` | How much the AI organises information into numbered lists, hierarchies, and structured formats. | _(reviewer)_ |
-| `BEH-MODALITY-CONSISTENCY` | Whether the AI sticks to the learner's preferred learning modality or varies approaches. | _(reviewer)_ |
-| `BEH-MODALITY-VARIETY` | How many different teaching channels the AI uses based on the content being taught. | _(reviewer)_ |
-| `BEH-PRACTICE-EXERCISES` | How much the AI includes hands-on activities and exercises in the learning experience. | _(reviewer)_ |
-| `BEH-REAL-WORLD-EXAMPLES` | How much the AI connects abstract concepts to practical, everyday applications. | _(reviewer)_ |
-| `BEH-REPETITION-OFFER` | How proactively the AI offers to repeat or rephrase key points. | _(reviewer)_ |
-| `BEH-RHYTHM-ATTENTION` | How much the AI attends to the pace, cadence, and flow of spoken delivery. | _(reviewer)_ |
-| `BEH-SOCRATIC-QUESTIONING` | Conversational learners engage well with questions | _(reviewer)_ |
-| `BEH-SPATIAL-METAPHOR` | How much the AI uses spatial organisation and location-based metaphors. | _(reviewer)_ |
-| `BEH-TERMINOLOGY-FORMAL` | How much the AI uses formal, subject-specific vocabulary versus everyday language. | _(reviewer)_ |
-| `BEH-VERBAL-ELABORATION` | How richly and extensively the AI elaborates on concepts through spoken explanation. | _(reviewer)_ |
-| `BEH-WRITTEN-ALTERNATIVE` | How much the AI offers written references, summaries, or notes alongside spoken teaching. | _(reviewer)_ |
+**3 folk-pedagogy assertions** — definitions read "[LearnerType] learners [verb] …", paired with measurable BEH-* tutor-knob sibling axes.
 
-## `reinforcement` (1 params)
+| parameterId | sibling axis cited in reason |
+|---|---|
+| `BEH-ENGAGEMENT-PROMPTS` | `BEH-PROBING-QUESTIONS` / `BEH-SOCRATIC-QUESTIONING` |
+| `BEH-EXPLANATION-DEPTH` | `BEH-DEFINITION-PRECISION` / `BEH-VERBAL-ELABORATION` |
+| `BEH-SOCRATIC-QUESTIONING` | `BEH-PROBING-QUESTIONS` |
 
-| parameterId | definition | proposed classification |
-|---|---|---|
-| `BEH-ERROR-ELABORATION` | Detailed feedback learners want thorough error explanations | _(reviewer)_ |
+---
+
+## Remaining 2 rows (genuine pedagogy decision required)
+
+| parameterId | definition | why not auto-classified | proposed paths |
+|---|---|---|---|
+| `BEH-ABSTRACT-OK` | How comfortable the learner is with theoretical and abstract concepts versus concrete ones. | LEARNER-STATE, not tutor knob. Could be derived from transcript by analysing learner's engagement with abstract-probe questions across calls. Genuine pedagogy decision: measure (author a spec) vs operator-only (intake-captured profile field, not transcript-derived). | (a) MEASURE — author `ielts-abstract-comfort.spec.json` analysing learner abstract-engagement signal; (b) OPERATOR-ONLY — captured at intake / profile, no transcript inference; (c) DEFER |
+| `BEH-ERROR-ELABORATION` | Detailed feedback learners want thorough error explanations | Definition wording is genuinely ambiguous. Reads as a folk-pedagogy assertion ("learners want…"), but the parameter name suggests a tutor-behavior knob (how much the AI elaborates on errors). Could be measured by counting feedback-block token length on error turns. | (a) MEASURE — author a small spec counting feedback-block tokens on error-correction turns; (b) OPERATOR-ONLY — tutor-emit directive (rewrite the definition to match other tutor-emit rows); (c) FOLK-PEDAGOGY — operator-only with the standard folk-pedagogy reason template |
 
 ---
 
@@ -84,3 +63,5 @@ For each `operator-only` row:
 
 1. Update the registry row: `usage.measurement: { kind: "operator-only", reason: "<>40 chars matching one of the three reason templates in `.claude/rules/parameter-measurement-coverage.md`" }`.
 2. Run `npx vitest run tests/lib/measurement/parameter-measurement-coverage.test.ts`. Drop `EXPECTED_GAP_COUNT` by the count moved.
+
+When the 2 remaining rows resolve, the ratchet hits 0 and the M4 epic closes.


### PR DESCRIPTION
## Summary

Applies the M4 decision tree more aggressively to the 34 rows that survived structural pass 1 (PR #2008). **32 of 34** fit the templates without pedagogy input. Ratchet drops 34 → 2.

| Shape | Count | Pattern matched |
|---|---|---|
| Tutor-emit directive | 29 | "How [much/often/many] the AI [verb]…" or "Whether the AI [verb]…" — AI told via prompt, no learner-side signal back |
| Folk-pedagogy assertion | 3 | "[LearnerType] learners [verb]…" — paired with measurable BEH-* sibling tutor-knob axes |
| Retained for pedagogy | 2 | `BEH-ABSTRACT-OK` (learner-state observable), `BEH-ERROR-ELABORATION` (definition wording genuinely ambiguous) |

After this pass, the pedagogy reviewer's worksheet shrinks from 34 rows to **2 rows with 3 proposed paths each** — a 2-row decision instead of a 48-row backlog.

## Verified by

**Lattice survey:** ran the 5-pillar cross-check before touching the registry.

- **Coverage:** `parameter-measurement-coverage.test.ts` ratchet drops 34 → 2. All 32 new reasons carry 270+ chars; the >40-char floor (from PR #2008) is well-cleared. Verified `npx vitest run tests/lib/measurement/parameter-measurement-coverage.test.ts` passes 6/6 in the worktree.
- **Chain Contracts:** all 29 tutor-emit reclassifications cite the SUPERVISE-stage compliance check as the separate concern — the EXTRACT-stage observability question is structurally moot.
- **Cascade:** all 32 are BEH-* IDs already covered by the `behavior-target` family prefix-match in `lib/cascade/effective-value.ts::FAMILIES`. No new cascade family needed.
- **Rules:** uses the templates in `.claude/rules/parameter-measurement-coverage.md` (extended by PR #2008) verbatim. The folk-pedagogy assertions cite sibling tutor-knob axes by ID.
- **Guards:** no new ESLint surface needed — same vitest backstop as PR #2008.

**Inverse-probe on negative claims** per `.claude/rules/agent-report-verification.md`:

- "29 of the 34 are tutor-emit directives" — inverse-probe: grep'd each definition for the "[learner-type] learners" pattern; none of the 29 match. All 29 read "the AI [verb]…" form. Verified by reading definitions row-by-row.
- "3 folk-pedagogy assertions match the legacy lowercase pattern from PR #2008" — inverse-probe: compared each to the 5 legacy lowercase (`analogy-usage` etc.) shape. All 3 follow the same "[learner-type] learners [verb]…" form. Confirmed.
- "BEH-ABSTRACT-OK is learner-state, not tutor knob" — read the definition literally: "How comfortable the **learner** is…" — the subject is the learner, not the AI. Confirmed by direct read.
- "BEH-ERROR-ELABORATION is ambiguous" — read the definition: "Detailed feedback learners want thorough error explanations." Wording mixes "learners want" (folk-pedagogy framing) with parameter name implying AI behaviour (elaboration). The ambiguity is real; deferred.

## Files

- `apps/admin/docs-archive/bdd-specs/behavior-parameters.registry.json` — 32 rows reclassified
- `apps/admin/tests/lib/measurement/parameter-measurement-coverage.test.ts` — ratchet 34 → 2
- `docs/M4-pedagogy-review.md` — pass-2 audit section added; remaining 2 rows now carry 3 proposed paths each

## What this leaves

- 2 rows for genuine pedagogy decision
- M2 loop-closure ratchet unchanged (still at the same gap count; per-param specSlug claims weren't added)
- When the 2 remaining resolve, M4 closes the loop entirely

## Test plan

- [x] `npx vitest run tests/lib/measurement/parameter-measurement-coverage.test.ts` — passes 6/6
- [x] Each new reason >40 chars (lowest is 270+)
- [x] Decision-tree shape applied: tutor-emit / folk-pedagogy / ADAPT-stage templates from PR #2008
- [ ] Pedagogy reviewer addresses the 2 remaining rows via worksheet's 3-path proposals

🤖 Generated with [Claude Code](https://claude.com/claude-code)