### PR TITLE
docs(2031): AnalysisSpec.domain is free-form — close audit-finding #3 as won't-fix

### DIFF
--- a/apps/admin/app/api/lab/upload/route.ts
+++ b/apps/admin/app/api/lab/upload/route.ts
@@ -147,6 +147,13 @@ export async function POST(req: Request) {
       outputType,
       specRole,
       specType: featureSet.specType as SpecType,
+      // LastParms audit (#2031) finding #3: this fallback to "general" is
+      // benign. `AnalysisSpec.domain` is a free-form `String?` (see
+      // prisma/schema.prisma) used as a UI grouping label, NOT a constrained
+      // taxonomy. Seed corpus already carries ~40 distinct values including
+      // "admin", "chat", "pipeline", "wizard", "cieh-level2-food-safety" —
+      // none of which match the `Parameter.domainGroup` canonical taxonomy.
+      // No `canonical-spec-domain.ts` helper is warranted. Closed won't-fix.
       domain: (featureSet.scoringSpec as any)?.domain || "general",
       priority: featureSet.specType === "SYSTEM" ? 50 : 10,
       isActive: true,


### PR DESCRIPTION
## Summary

LastParms audit (2026-06-19) finding #3 surveyed `domain: (featureSet.scoringSpec as any)?.domain || "general"` at `apps/admin/app/api/lab/upload/route.ts:150` to determine whether it matched the silent off-taxonomy class addressed by PR #2029 (sync-parameters) + PR #2030 (lab/features/activate).

Verdict: **Case (b) — won't-fix.** `AnalysisSpec.domain` is genuinely free-form. Added a 7-line comment above the line so the next auditor doesn't re-investigate.

## Decision evidence

`AnalysisSpec.domain` has NONE of the structural traits of `Parameter.domainGroup`:

| Property | `Parameter.domainGroup` | `AnalysisSpec.domain` |
|---|---|---|
| Type | String, **canonical 13-value taxonomy** | `String?` |
| Constraint | Enforced via `CANONICAL_DOMAIN_GROUPS` set + helper | None — bare optional column |
| Seed corpus values | 13 fixed | ~40+ distinct, free-form |
| Schema comment | n/a | `// e.g., "personality", "memory", "engagement"` |
| Consumers | Strict taxonomy check + ratchet vitest | String-compare (`=== "voice"`), free-form mapping with default |

A `canonical-spec-domain.ts` helper would be parallel infrastructure with no canonical set to enforce — and would have to enumerate ~40 distinct values plus accept further growth (every new spec defines its own).

## Verified by

- **Schema**: `apps/admin/prisma/schema.prisma:3047` — `domain   String? // e.g., "personality", "memory", "engagement"`
- **Sibling `Parameter.domainGroup` taxonomy**: `apps/admin/app/api/admin/sync-parameters/route.ts:22-35` — 13 fixed values, ZERO overlap with the AnalysisSpec.domain corpus
- **Seed scan**: `grep '"domain"' apps/admin/docs-archive/bdd-specs/*.spec.json` → 40+ distinct values
- **5 distinct representative values** [verified] found in seed corpus:
  1. `admin`
  2. `pipeline`
  3. `cieh-level2-food-safety`
  4. `wizard`
  5. `learning-adaptation`
- **Consumer cross-check**:
  - `apps/admin/lib/prompt/composition/transforms/identity.ts:32,41,70,75,78` — string compare against `"voice"` only [verified]
  - `apps/admin/lib/ops/memory-extract.ts:207-230` — `domainToCategory` uses free-form mapping with `taxonomyConfig.defaultCategory` fallback [verified]
  - `apps/admin/lib/prompt/PromptTemplateCompiler.ts:165,226` — string passthrough [verified]

The fallback `|| "general"` joins ~40 other free-form labels and violates no taxonomy.

## Lattice survey

- DB column mutation: yes — `AnalysisSpec.domain` write.
- Sibling-writer survey: 7 writers identified (`app/api/specs/import/route.ts`, `app/api/specs/create/route.ts`, `app/api/x/spec-schema/route.ts`, etc.) — all carry free-form strings; no convergence design needed.
- Default-deny gates: none — schema is `String?` with no CHECK constraint, no ESLint guard, no taxonomy ratchet for this column.
- Cascade respect: not cascadable.
- Convention conflict: none — single in-use shape (free-form string).
- Decision: documented finding, no code path warranted.

## Test plan

- [x] Schema-level evidence collected from `prisma/schema.prisma`
- [x] Seed-corpus evidence collected (5 distinct values + ~40+ total)
- [x] Sibling-taxonomy cross-check (canonical-domain-group vs spec.domain)
- [x] Consumer-side check (3 reader sites — all tolerate free-form)
- [x] Comment lands in source so next auditor doesn't re-walk

Closes audit-finding #3 of epic #2031.

Related: #2029 (sync-parameters), #2030 (lab/features/activate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)