### PR TITLE
chore(kb): regen generated/* after #2033 helpers landed

### DIFF
--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-18T21:47:16.248Z",
+  "generatedAt": "2026-06-19T12:57:42.504Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1850,
-  "edgeCount": 4350,
+  "fileCount": 1853,
+  "edgeCount": 4354,
   "skippedEdges": 1,
   "edges": [
     {
@@ -238,6 +238,10 @@
     {
       "from": "app/api/admin/sync-parameters/route.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/admin/sync-parameters/route.ts",
+      "to": "lib/registry/canonical-domain-group.ts"
     },
     {
       "from": "app/api/admin/sync-parameters/route.ts",
@@ -5022,6 +5026,18 @@
     {
       "from": "app/api/lab/features/[id]/activate/route.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/lab/features/[id]/activate/route.ts",
+      "to": "lib/registry/canonical-directionality.ts"
+    },
+    {
+      "from": "app/api/lab/features/[id]/activate/route.ts",
+      "to": "lib/registry/canonical-domain-group.ts"
+    },
+    {
+      "from": "app/api/lab/features/[id]/activate/route.ts",
+      "to": "lib/registry/canonical-scale-type.ts"
     },
     {
       "from": "app/api/lab/features/[id]/activate/route.ts",
@@ -17512,7 +17528,7 @@
     {
       "path": "app/api/admin/sync-parameters/route.ts",
       "inDegree": 0,
-      "outDegree": 3
+      "outDegree": 4
     },
     {
       "path": "app/api/admin/terminology/route.ts",
@@ -19097,7 +19113,7 @@
     {
       "path": "app/api/lab/features/[id]/activate/route.ts",
       "inDegree": 0,
-      "outDegree": 6
+      "outDegree": 9
     },
     {
       "path": "app/api/lab/features/[id]/route.ts",
@@ -25268,6 +25284,21 @@
       "path": "lib/recompose/preview.ts",
       "inDegree": 1,
       "outDegree": 1
+    },
+    {
+      "path": "lib/registry/canonical-directionality.ts",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "lib/registry/canonical-domain-group.ts",
+      "inDegree": 2,
+      "outDegree": 0
+    },
+    {
+      "path": "lib/registry/canonical-scale-type.ts",
+      "inDegree": 1,
+      "outDegree": 0
     },
     {
       "path": "lib/registry/index.ts",

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-18T21:47:16.892Z",
+  "generatedAt": "2026-06-19T12:57:42.841Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-18T21:47:14.026Z",
+  "generatedAt": "2026-06-19T12:57:41.401Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-18T21:47:17.607Z",
+  "generatedAt": "2026-06-19T12:57:43.217Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/parameter-inventory.json
+++ b/docs/kb/generated/parameter-inventory.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-18T21:47:19.820Z",
+  "generatedAt": "2026-06-19T12:57:44.536Z",
   "generator": "scripts/capture/parameter-inventory.ts",
   "parameterCount": 154,
   "active": 139,

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,6 +1,6 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-18T21:47:14.917Z",
+  "generatedAt": "2026-06-19T12:57:41.855Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {


### PR DESCRIPTION
Mechanical KB regen. Track B (PR #2033) added imports → coupling graph + operator-surfaces files would flag KB Integrity on the next PR. Ran the 6 kb:* scripts; 6 generated JSON files updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)