### PR TITLE
fix(lint): #2042 allow-list 2 legitimate bypasses — caller reset + GDPR drain

### DIFF
--- a/apps/admin/eslint-rules/no-bare-behavior-target-write.mjs
+++ b/apps/admin/eslint-rules/no-bare-behavior-target-write.mjs
@@ -65,6 +65,15 @@ const ALLOWED_PATH_SUFFIXES = [
   "app/api/x/create-domains/route.ts",
   "app/api/x/seed-domains/route.ts",
   "app/api/x/seed-transcripts/route.ts",
+  // Caller reset bulk-deletes CALLER-scope rows (same destructive shape
+  // as the seed routes above; canonical helpers don't model bulk-clear).
+  "app/api/callers/[callerId]/reset/route.ts",
+  // GDPR DRAIN — playbook deletion SET NULL on dependent BehaviorTarget
+  // rows. Same shape as the goalsNullified / callsNullified /
+  // composedPromptsNullified `updateMany` siblings in the same helper;
+  // the canonical write helpers model individual knob writes with cache
+  // invalidation, not bulk FK detachment on parent deletion.
+  "lib/gdpr/delete-playbook-data.ts",
 ];
 
 const ALLOWED_PATH_CONTAINS = [


### PR DESCRIPTION
## Summary

Closes the sweep gap from PR #2042. Main has been red on Lint & Type Check since #2042 landed (commit 4904792f) because 2 pre-existing bare `prisma.behaviorTarget` writers were not refactored alongside the `ops:880` path. Both are legitimate bypass shapes already named in the rule's own ALLOWED_PATH_SUFFIXES comment.

| Site | Shape | Allow-list rationale |
|---|---|---|
| `app/api/callers/[callerId]/reset/route.ts:143` | `tx.behaviorTarget.deleteMany({ scope: "CALLER" })` | Admin caller reset — same destructive-bulk shape as the seed routes already in the list (`seed-system`, `create-domains`, etc.). Canonical helpers model per-knob writes, not bulk-clear. |
| `lib/gdpr/delete-playbook-data.ts:76` | `client.behaviorTarget.updateMany({ where: { playbookId }, data: { playbookId: null } })` | GDPR playbook drain — SET NULL pattern on parent deletion. Same shape as the `goalsNullified` / `callsNullified` / `composedPromptsNullified` siblings in the same helper. Canonical helpers model knob writes with cache invalidation, not bulk FK detachment. |

## Test plan

- [ ] Lint & Type Check passes on this PR (verifies the 2 errors are gone)
- [ ] After merge: main goes green; PR #2024 + PR #1964's next CI run flips green without further rebase

## Verified by

Reproduction of the 2 errors on origin/main HEAD:

```
gh api repos/WANDERCOLTD/HF/commits/4904792f/check-runs \
  --jq '.check_runs[] | select(.name == "Lint & Type Check") | .conclusion'
# → "failure"
```

Exact violation count + paths verified with `gh api`:

```
gh run view 27828623806 --log-failed > /tmp/lint.log
grep -c "  error  " /tmp/lint.log
# → 2
```

Site reads — confirmed the call shape AND the file's surrounding behaviour matches the allow-list category:

```
cat apps/admin/app/api/callers/[callerId]/reset/route.ts | sed -n '130,150p'
# → tx.behaviorTarget.deleteMany inside an admin reset transaction

cat apps/admin/lib/gdpr/delete-playbook-data.ts | sed -n '60,90p'
# → client.behaviorTarget.updateMany alongside 5 sibling SET NULL updateMany calls
```

No other latent violations:

```
grep -rn "behaviorTarget\.\(create\|update\|upsert\|delete\|createMany\|updateMany\|deleteMany\)" \
  apps/admin/lib/gdpr/ apps/admin/app/api/callers/
# → exactly 2 hits, the 2 sites this PR allows
```

Lattice survey (per `.claude/rules/lattice-survey.md`):
- **Surface**: allow-list of a Guards-pillar ESLint rule.
- **Sibling writers**: 4 sibling rules listed in the rule's docstring (`no-bare-parameter-write`, `no-bare-call-create`, `no-bare-call-score-write`, `no-bare-module-progress-update`). Each has its own allow-list — not affected.
- **Cascade respect**: N/A.
- **Default-deny gates**: N/A.
- **Convention conflict**: none — entries fit the rule's existing DESTRUCTIVE-OK + drain-shape categories; per-entry rationale comments inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)