### PR TITLE
chore(kb): regen generated/* after #2042 (S2 update-system-targets.ts) + #1964 landed

### DIFF
--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-19T12:57:42.504Z",
+  "generatedAt": "2026-06-19T14:33:40.280Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1853,
-  "edgeCount": 4354,
+  "fileCount": 1854,
+  "edgeCount": 4357,
   "skippedEdges": 1,
   "edges": [
     {
@@ -1558,6 +1558,10 @@
     {
       "from": "app/api/calls/[callId]/ops/[opId]/route.ts",
       "to": "lib/metering/index.ts"
+    },
+    {
+      "from": "app/api/calls/[callId]/ops/[opId]/route.ts",
+      "to": "lib/ops/update-system-targets.ts"
     },
     {
       "from": "app/api/calls/[callId]/ops/[opId]/route.ts",
@@ -14396,6 +14400,14 @@
       "to": "lib/enrollment/resolve-playbook.ts"
     },
     {
+      "from": "lib/ops/update-system-targets.ts",
+      "to": "lib/cascade/effective-value.ts"
+    },
+    {
+      "from": "lib/ops/update-system-targets.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
       "from": "lib/ops/update-targets.ts",
       "to": "lib/prisma.ts"
     },
@@ -17983,7 +17995,7 @@
     {
       "path": "app/api/calls/[callId]/ops/[opId]/route.ts",
       "inDegree": 0,
-      "outDegree": 4
+      "outDegree": 5
     },
     {
       "path": "app/api/calls/[callId]/pinned-card/route.ts",
@@ -22997,7 +23009,7 @@
     },
     {
       "path": "lib/cascade/effective-value.ts",
-      "inDegree": 13,
+      "inDegree": 14,
       "outDegree": 7
     },
     {
@@ -24736,6 +24748,11 @@
       "outDegree": 2
     },
     {
+      "path": "lib/ops/update-system-targets.ts",
+      "inDegree": 1,
+      "outDegree": 2
+    },
+    {
       "path": "lib/ops/update-targets.ts",
       "inDegree": 2,
       "outDegree": 2
@@ -24917,7 +24934,7 @@
     },
     {
       "path": "lib/prisma.ts",
-      "inDegree": 674,
+      "inDegree": 675,
       "outDegree": 0
     },
     {
@@ -26694,7 +26711,7 @@
   "highCoupling": [
     {
       "path": "lib/prisma.ts",
-      "inDegree": 674,
+      "inDegree": 675,
       "outDegree": 0
     },
     {

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-19T12:57:42.841Z",
+  "generatedAt": "2026-06-19T14:33:41.011Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-19T12:57:41.401Z",
+  "generatedAt": "2026-06-19T14:33:37.594Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-19T12:57:43.217Z",
+  "generatedAt": "2026-06-19T14:33:42.437Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/parameter-inventory.json
+++ b/docs/kb/generated/parameter-inventory.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-19T12:57:44.536Z",
+  "generatedAt": "2026-06-19T14:33:45.107Z",
   "generator": "scripts/capture/parameter-inventory.ts",
   "parameterCount": 154,
   "active": 139,

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,6 +1,6 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-19T12:57:41.855Z",
+  "generatedAt": "2026-06-19T14:33:38.813Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {


### PR DESCRIPTION
## Summary

Six KB facts went stale after PRs [#2042](https://github.com/WANDERCOLTD/HF/pull/2042) (`no-bare-behavior-target-write` ESLint rule + new `lib/ops/update-system-targets.ts`) and [#1964](https://github.com/WANDERCOLTD/HF/pull/1964) (#1953 IELTS completion gate) merged. KB Integrity CI on every PR opened off main since then has been red on `kb:fresh` — blocks #2044, #2045, #2046, #2037 (and any others).

Same shape as precedent [PR #2035](https://github.com/WANDERCOLTD/HF/pull/2035) (regen after #2033) and `c7672481` (regen after #2024).

## What changed

| File | Diff | Notes |
|---|---|---|
| `docs/kb/generated/coupling-graph.json` | +29 / -7 | 3 new edges + 1 new file from `lib/ops/update-system-targets.ts` (introduced by #2042). Affects `app/api/calls/[callId]/ops/[opId]/route.ts` outDegree 4 → 5. |
| `docs/kb/generated/demo-knobs.json` | +1 / -1 | Timestamp refresh only |
| `docs/kb/generated/model-map.json` | +1 / -1 | Timestamp refresh only |
| `docs/kb/generated/operator-surfaces.json` | +1 / -1 | Timestamp refresh only |
| `docs/kb/generated/parameter-inventory.json` | +1 / -1 | Timestamp refresh only |
| `docs/kb/generated/route-inventory.json` | +1 / -1 | Timestamp refresh only |

Net: **+29 / -12 across 6 files; substantive change in coupling-graph only.**

## How I ran it

```bash
cd apps/admin
npm run kb:model-map
npm run kb:routes
npm run kb:coupling
npm run kb:demo-knobs
npm run kb:operator-surfaces
npm run kb:parameter-inventory
```

Ran from the main tree (which carries `node_modules`); copied output into this branch's worktree at `origin/main` (3418c369). Restored main tree's working state.

## CI Docs Skip

`docs/kb/generated/*` is auto-generated; not a CI/infra surface. The kb scripts themselves at `apps/admin/scripts/capture/` weren't touched.

## Test plan

- [ ] CI: `KB Integrity` job passes (the failure I'm closing — `kb:fresh` now reports no diff).
- [ ] Once merged, #2044 / #2045 / #2046 / #2037 rebase on main and lose the KB Integrity blocker.

## Verified by

- **Live shell probe — main tree's `npm run kb:fresh` output (before regen)** [verified]:
  ```
  $ cd /Users/paulwander/projects/HF/apps/admin && npm run kb:fresh
  > admin@0.8.47 kb:fresh
  > bash scripts/capture/check-kb-fresh.sh
  ✖ KB generated facts are STALE — regenerate and commit:
       cd apps/admin && npm run kb:model-map && npm run kb:routes && npm run kb:coupling && npm run kb:demo-knobs && npm run kb:operator-surfaces && npm run kb:parameter-inventory
   docs/kb/generated/coupling-graph.json      | 31 +++++++++++++++++++++++-------
   docs/kb/generated/demo-knobs.json          |  2 +-
   docs/kb/generated/model-map.json           |  2 +-
   docs/kb/generated/operator-surfaces.json   |  2 +-
   docs/kb/generated/parameter-inventory.json |  2 +-
   docs/kb/generated/route-inventory.json     |  2 +-
   6 files changed, 29 insertions(+), 12 deletions(-)
  ```
- **CI log subject from `gh run view --log-failed --job 82365679315`** [verified] — confirmed PR #2045 hit the same `✖ KB generated facts are STALE` line with the same 6 files in the diff stat, identical insertion/deletion counts.
- **File-existence check** [verified] `ls /Users/paulwander/projects/HF-kb-regen/apps/admin/lib/ops/update-system-targets.ts` returns the path — confirms the 3 new coupling-graph edges reference a real file on origin/main (3418c369).
- **Git log probe** [verified] `git -C /Users/paulwander/projects/HF-kb-regen log --oneline 4904792f..HEAD` shows `3418c369 fix(lint): #2042 allow-list 2 legitimate bypass paths` + `392db815 feat(curriculum): #1953 four-criteria IELTS completion gate (#1964)` — the two PRs whose ungenerated edges this regen captures.
- **Substantive diff inspection** via `git diff docs/kb/generated/coupling-graph.json` (lines 1559-1562, 14399-14406, 17995-17999) — 3 new edges + 1 new node, all referencing `lib/ops/update-system-targets.ts`; outDegree update for `route.ts` mechanical.
- **Cross-reference vs. [PR #2035](https://github.com/WANDERCOLTD/HF/pull/2035) body** (`gh pr view 2035 --json body`) — same script list, same regen flow, same precedent justification.
- **Main tree restored** [verified] `git -C /Users/paulwander/projects/HF status --short` returns empty after `git checkout` of the 6 modified files.

References: [#2042](https://github.com/WANDERCOLTD/HF/pull/2042), [#1964](https://github.com/WANDERCOLTD/HF/pull/1964), [PR #2035](https://github.com/WANDERCOLTD/HF/pull/2035) (precedent), [#2044](https://github.com/WANDERCOLTD/HF/pull/2044) / [#2045](https://github.com/WANDERCOLTD/HF/pull/2045) / [#2046](https://github.com/WANDERCOLTD/HF/pull/2046) / [#2037](https://github.com/WANDERCOLTD/HF/pull/2037) (all currently red on KB Integrity, unblocked by this PR landing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)