### PR TITLE
feat(intake): #2050 — wire intakeSkipIfReturning consumer (close producer-only gap)

### DIFF
--- a/apps/admin/app/api/student/survey-config/route.ts
+++ b/apps/admin/app/api/student/survey-config/route.ts
@@ -8,7 +8,7 @@
  *         2. playbook.config.onboardingFlowPhases (legacy fallback for pre)
  *         3. SURVEY_TEMPLATES_V1 contract defaults
  *       Also returns assessment config (personality questions, pre/post-test settings).
- * @response 200 { ok, subject, welcome, assessment, onboarding, offboarding }
+ * @response 200 { ok, subject, skipIntake, welcome, assessment, onboarding, offboarding }
  * @response 404 { ok: false, error: "..." }
  */
 
@@ -29,6 +29,7 @@ import {
   getSurveyTemplateConfig,
 } from "@/lib/learner/survey-config";
 import { DEFAULT_PERSONALITY_QUESTIONS } from "@/lib/assessment/personality-defaults";
+import { isReturningLearner } from "@/lib/intake/returning-learner";
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
@@ -66,6 +67,17 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const pbConfig = (enrollment.playbook.config ?? {}) as PlaybookConfig;
     const subject = enrollment.playbook.domain?.name ?? enrollment.playbook.name;
     const templates = await getSurveyTemplateConfig();
+
+    // ── #2050 Intake-skip gate ──
+    // When `config.skipIntakeIfReturning === true` AND the caller has
+    // prior intake history (submitted PERSONALITY/PRE_SURVEY OR
+    // INTAKE_CHAT projection), surface a top-level `skipIntake` flag.
+    // WelcomeSurveyFlow short-circuits to `onAlreadyDone()` on this
+    // signal so the learner bypasses re-answering. Producer side is
+    // the `intakeSkipIfReturning` JourneySettingContract.
+    const skipIntake =
+      pbConfig.skipIntakeIfReturning === true &&
+      (await isReturningLearner(prisma, auth.callerId));
 
     // ── Resolution chain: pre-survey questions ──
     // 1. config.surveys.pre.questions (educator override)
@@ -110,6 +122,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       ok: true,
       subject,
       tone: pbConfig.interactionPattern ?? "default",
+      skipIntake,
       welcome: { ...DEFAULT_WELCOME_CONFIG, ...pbConfig.welcome },
       assessment: {
         personality: {

--- a/apps/admin/components/student/WelcomeSurveyFlow.tsx
+++ b/apps/admin/components/student/WelcomeSurveyFlow.tsx
@@ -145,6 +145,14 @@ export function WelcomeSurveyFlow({ callerId, onComplete, onAlreadyDone }: Welco
         }
 
         if (configData.ok) {
+          // #2050 — Educator opted into "skip intake for returning learners"
+          // AND the server detected prior intake history. Bypass the entire
+          // welcome flow before we render anything. Producer side is the
+          // `intakeSkipIfReturning` JourneySettingContract.
+          if (configData.skipIntake === true) {
+            onAlreadyDone();
+            return;
+          }
           if (configData.subject) setSubject(configData.subject);
           if (configData.tone) setTone(configData.tone);
           if (configData.onboarding?.endAction) {

--- a/apps/admin/lib/intake/returning-learner.ts
+++ b/apps/admin/lib/intake/returning-learner.ts
@@ -1,0 +1,53 @@
+/**
+ * Returning-learner detection for the intake-skip gate (#2050).
+ *
+ * A caller is "returning" — for the purpose of `PlaybookConfig.skipIntakeIfReturning`
+ * — when ANY of the following hold:
+ *
+ *   1. The learner has a `submitted_at` CallerAttribute under scope
+ *      `PERSONALITY` or `PRE_SURVEY` (i.e. they completed the welcome
+ *      flow on this or any prior playbook). Same-caller signal.
+ *
+ *   2. The learner has any CallerAttribute under scope `INTAKE_CHAT` —
+ *      these rows are projected from the EnrollmentIntake bootstrap
+ *      (`/api/join/[token]` for existing users) via `writeIntakeQAProjections`.
+ *      Re-enrolment signal.
+ *
+ * Both shapes are caller-scoped (not playbook-scoped), which matches the
+ * educator intent surfaced by the contract label "Skip intake for
+ * returning learners" — once the learner has done it once, don't make
+ * them do it again on a sibling course.
+ *
+ * Producer side: the `intakeSkipIfReturning` JourneySettingContract
+ * (storagePath: `config.skipIntakeIfReturning`).
+ * Consumer side: `app/api/student/survey-config/route.ts` — the route
+ * sets `skipIntake: true` when this helper resolves true AND the flag
+ * is set, and `WelcomeSurveyFlow.tsx` short-circuits to `onAlreadyDone()`.
+ */
+
+import type { PrismaClient } from "@prisma/client";
+
+const SURVEY_DONE_SCOPES = ["PERSONALITY", "PRE_SURVEY"] as const;
+const INTAKE_CHAT_SCOPE = "INTAKE_CHAT";
+
+/**
+ * Detect whether `callerId` has prior intake history. Returns true when at
+ * least one shape (completed welcome survey OR prior intake-chat projection)
+ * is present.
+ */
+export async function isReturningLearner(
+  prisma: Pick<PrismaClient, "callerAttribute">,
+  callerId: string,
+): Promise<boolean> {
+  // Cheap existence-only probe — count > 0 is enough.
+  const matches = await prisma.callerAttribute.count({
+    where: {
+      callerId,
+      OR: [
+        { scope: { in: [...SURVEY_DONE_SCOPES] }, key: "submitted_at" },
+        { scope: INTAKE_CHAT_SCOPE },
+      ],
+    },
+  });
+  return matches > 0;
+}

--- a/apps/admin/lib/types/json-fields.ts
+++ b/apps/admin/lib/types/json-fields.ts
@@ -449,6 +449,18 @@ export interface PlaybookConfig {
   offboarding?: OffboardingConfig;
   /** Student welcome flow configuration — controls which phases show before first session */
   welcome?: WelcomeConfig;
+  /**
+   * #2050 — When true, learners who completed the intake on a prior enrolment
+   * (any playbook) are bypassed: the WelcomeSurveyFlow short-circuits and
+   * the learner lands on `/x/student` rather than re-answering PERSONALITY
+   * + PRE_SURVEY questions. Detected via CallerAttribute(scope='PERSONALITY' | 'PRE_SURVEY')
+   * submitted_at OR scope='INTAKE_CHAT' attrs (the intake projection from
+   * EnrollmentIntake — `intake.*` keys). Default false — preserves the
+   * existing every-enrollment intake behaviour.
+   *
+   * @bucket Course parameter — educator-tunable on the Intake lens (G1).
+   */
+  skipIntakeIfReturning?: boolean;
   /** NPS / satisfaction feedback configuration */
   nps?: NpsConfig;
   /**

--- a/apps/admin/tests/api/student-survey-config.test.ts
+++ b/apps/admin/tests/api/student-survey-config.test.ts
@@ -6,6 +6,9 @@ vi.mock("@/lib/prisma", () => ({
     callerPlaybook: {
       findFirst: vi.fn(),
     },
+    callerAttribute: {
+      count: vi.fn(),
+    },
   },
 }));
 
@@ -37,6 +40,7 @@ import { NextRequest } from "next/server";
 
 const mocks = {
   findFirst: (prisma.callerPlaybook.findFirst as ReturnType<typeof vi.fn>),
+  callerAttributeCount: (prisma.callerAttribute.count as ReturnType<typeof vi.fn>),
   auth: (requireStudentOrAdmin as ReturnType<typeof vi.fn>),
 };
 
@@ -48,6 +52,8 @@ describe("GET /api/student/survey-config — resolution chain", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.auth.mockResolvedValue({ callerId: "caller-1", userId: "user-1" });
+    // Default: no prior intake history (new learner) — overridden per-test below.
+    mocks.callerAttributeCount.mockResolvedValue(0);
   });
 
   it("returns 404 when no active enrollment", async () => {
@@ -145,5 +151,115 @@ describe("GET /api/student/survey-config — resolution chain", () => {
     const data = await res.json();
 
     expect(data.assessment.personality.questions[0].id).toBe("custom_pers");
+  });
+});
+
+// =============================================================
+// #2050 — intakeSkipIfReturning consumer
+//
+// Producer: `JourneySettingContract.id === "intakeSkipIfReturning"`
+//   (storagePath: `config.skipIntakeIfReturning`).
+// Consumer (this test): `/api/student/survey-config` resolves
+//   `skipIntake: true` when both:
+//     - `pbConfig.skipIntakeIfReturning === true`, AND
+//     - caller has prior intake history (CallerAttribute count > 0
+//       under scopes PERSONALITY/PRE_SURVEY/INTAKE_CHAT — see
+//       `lib/intake/returning-learner.ts`).
+//   `WelcomeSurveyFlow` short-circuits `onAlreadyDone()` on this
+//   signal.
+// =============================================================
+
+describe("GET /api/student/survey-config — #2050 intakeSkipIfReturning gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.auth.mockResolvedValue({ callerId: "caller-1", userId: "user-1" });
+  });
+
+  it("new learner — flag false, no prior history → skipIntake=false", async () => {
+    mocks.findFirst.mockResolvedValue({
+      playbook: { config: {}, name: "Test Course", domain: { name: "Maths" } },
+    });
+    mocks.callerAttributeCount.mockResolvedValue(0);
+
+    const res = await GET(makeRequest());
+    const data = await res.json();
+
+    expect(data.ok).toBe(true);
+    expect(data.skipIntake).toBe(false);
+  });
+
+  it("returning learner + flag=true → skipIntake=true (consumer fires)", async () => {
+    mocks.findFirst.mockResolvedValue({
+      playbook: {
+        config: { skipIntakeIfReturning: true },
+        name: "Test Course",
+        domain: { name: "Maths" },
+      },
+    });
+    // Prior PERSONALITY submitted_at row exists.
+    mocks.callerAttributeCount.mockResolvedValue(1);
+
+    const res = await GET(makeRequest());
+    const data = await res.json();
+
+    expect(data.ok).toBe(true);
+    expect(data.skipIntake).toBe(true);
+    // Sanity: the query was issued against the same caller.
+    expect(mocks.callerAttributeCount).toHaveBeenCalledTimes(1);
+    const callArg = mocks.callerAttributeCount.mock.calls[0][0];
+    expect(callArg.where.callerId).toBe("caller-1");
+  });
+
+  it("returning learner + flag=false → skipIntake=false (re-prompts)", async () => {
+    mocks.findFirst.mockResolvedValue({
+      playbook: {
+        config: { skipIntakeIfReturning: false },
+        name: "Test Course",
+        domain: { name: "Maths" },
+      },
+    });
+    // Prior intake-chat projection exists.
+    mocks.callerAttributeCount.mockResolvedValue(3);
+
+    const res = await GET(makeRequest());
+    const data = await res.json();
+
+    expect(data.ok).toBe(true);
+    expect(data.skipIntake).toBe(false);
+  });
+
+  it("flag=true + new learner (zero history) → skipIntake=false (no bypass)", async () => {
+    mocks.findFirst.mockResolvedValue({
+      playbook: {
+        config: { skipIntakeIfReturning: true },
+        name: "Test Course",
+        domain: { name: "Maths" },
+      },
+    });
+    mocks.callerAttributeCount.mockResolvedValue(0);
+
+    const res = await GET(makeRequest());
+    const data = await res.json();
+
+    expect(data.ok).toBe(true);
+    expect(data.skipIntake).toBe(false);
+  });
+
+  it("flag unset (undefined) → skipIntake=false even with history (default-off)", async () => {
+    mocks.findFirst.mockResolvedValue({
+      playbook: {
+        // No skipIntakeIfReturning key at all.
+        config: { interactionPattern: "socratic" },
+        name: "Test Course",
+        domain: { name: "Maths" },
+      },
+    });
+    mocks.callerAttributeCount.mockResolvedValue(5);
+
+    const res = await GET(makeRequest());
+    const data = await res.json();
+
+    expect(data.ok).toBe(true);
+    expect(data.skipIntake).toBe(false);
   });
 });

--- a/apps/admin/tests/lib/intake/returning-learner.test.ts
+++ b/apps/admin/tests/lib/intake/returning-learner.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for `lib/intake/returning-learner.ts::isReturningLearner` (#2050).
+ *
+ * The helper is the detection half of the `intakeSkipIfReturning`
+ * JourneySettingContract consumer wired into
+ * `app/api/student/survey-config/route.ts`.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { isReturningLearner } from "@/lib/intake/returning-learner";
+
+function makePrismaMock(countResult: number) {
+  return {
+    callerAttribute: {
+      count: vi.fn().mockResolvedValue(countResult),
+    },
+  };
+}
+
+describe("isReturningLearner", () => {
+  it("returns false when no matching attributes exist (count = 0)", async () => {
+    const mock = makePrismaMock(0);
+    const result = await isReturningLearner(
+      mock as unknown as Parameters<typeof isReturningLearner>[0],
+      "caller-1",
+    );
+    expect(result).toBe(false);
+  });
+
+  it("returns true when at least one matching attribute exists (count = 1)", async () => {
+    const mock = makePrismaMock(1);
+    const result = await isReturningLearner(
+      mock as unknown as Parameters<typeof isReturningLearner>[0],
+      "caller-1",
+    );
+    expect(result).toBe(true);
+  });
+
+  it("returns true when multiple matching attributes exist (count = 5)", async () => {
+    const mock = makePrismaMock(5);
+    const result = await isReturningLearner(
+      mock as unknown as Parameters<typeof isReturningLearner>[0],
+      "caller-1",
+    );
+    expect(result).toBe(true);
+  });
+
+  it("queries the supplied callerId AND the canonical OR shape", async () => {
+    const mock = makePrismaMock(0);
+    await isReturningLearner(
+      mock as unknown as Parameters<typeof isReturningLearner>[0],
+      "caller-xyz",
+    );
+    expect(mock.callerAttribute.count).toHaveBeenCalledTimes(1);
+    const arg = mock.callerAttribute.count.mock.calls[0][0];
+    expect(arg.where.callerId).toBe("caller-xyz");
+    // PERSONALITY/PRE_SURVEY submitted_at OR INTAKE_CHAT (any key).
+    expect(arg.where.OR).toEqual([
+      { scope: { in: ["PERSONALITY", "PRE_SURVEY"] }, key: "submitted_at" },
+      { scope: "INTAKE_CHAT" },
+    ]);
+  });
+});

--- a/apps/admin/tests/lib/journey/registry-consumer-coverage.test.ts
+++ b/apps/admin/tests/lib/journey/registry-consumer-coverage.test.ts
@@ -76,10 +76,6 @@ const REGISTRY_CONSUMER_EXEMPT_PATHS: Record<string, ExemptEntry> = {
   // the wiring work; each transform read needs per-setting design
   // (e.g., baselineAssessmentDepth needs "light/standard/deep" prompt
   // synthesis, not just a substring read).
-  intakeSkipIfReturning: {
-    reason:
-      "Producer-only since 2026-06-17 audit. Intake-gate skip-for-returning-learner logic deferred to follow-on (intake transform needs the read).",
-  },
   baselineAssessmentDepth: {
     reason:
       "Producer-only since 2026-06-17 audit. firstCallMode / instructions transforms don't synthesise light/standard/deep directives yet.",
@@ -145,7 +141,7 @@ const REGISTRY_CONSUMER_EXEMPT_PATHS: Record<string, ExemptEntry> = {
 /** Ratchet — the exempt count is allowed to GO DOWN (wire a consumer,
  *  remove the entry), never UP without a bump here. The test fails on
  *  drift in either direction so a careless add gets caught at PR time. */
-const EXPECTED_EXEMPT_COUNT = 15;
+const EXPECTED_EXEMPT_COUNT = 14;
 
 // ────────────────────────────────────────────────────────────
 // Consumer-surface concatenation

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -13949,7 +13949,7 @@ Returns the learner's progress against their active qualification —
 
 **Response** `200`
 ```json
-{ ok, subject, welcome, assessment, onboarding, offboarding }
+{ ok, subject, skipIntake, welcome, assessment, onboarding, offboarding }
 ```
 
 **Response** `404`


### PR DESCRIPTION
## Summary

Sub-epic A of #2049. Closes the producer-only gap on the
`intakeSkipIfReturning` `JourneySettingContract`: educators could
edit "Skip intake for returning learners" on the Inspector but no
runtime code read the value. The composed prompt and the
`WelcomeSurveyFlow` were byte-identical regardless.

This PR wires the consumer end-to-end:

- Adds typed `skipIntakeIfReturning?: boolean` to `PlaybookConfig`.
- Adds `lib/intake/returning-learner.ts::isReturningLearner` — single
  detector for "has prior intake history".
- `app/api/student/survey-config/route.ts` now resolves a top-level
  `skipIntake: boolean`.
- `components/student/WelcomeSurveyFlow.tsx` short-circuits to
  `onAlreadyDone()` when `skipIntake === true`.
- Removes `intakeSkipIfReturning` from `REGISTRY_CONSUMER_EXEMPT_PATHS`
  in `tests/lib/journey/registry-consumer-coverage.test.ts`; decrements
  `EXPECTED_EXEMPT_COUNT` 15 → 14. The setting is now classified
  `covered` by the Lattice Coverage-pillar ratchet.

## Gate site (verify-before-fix anchor)

The flag is now read in `app/api/student/survey-config/route.ts:78-80`:

```ts
const skipIntake =
  pbConfig.skipIntakeIfReturning === true &&
  (await isReturningLearner(prisma, auth.callerId));
```

The "returning" detector lives in
`apps/admin/lib/intake/returning-learner.ts` and counts CallerAttribute
rows under `(scope ∈ {PERSONALITY, PRE_SURVEY}, key = submitted_at)`
OR `(scope = INTAKE_CHAT, any key)`. The UI consumer is
`apps/admin/components/student/WelcomeSurveyFlow.tsx:148-156`.

## Producer-only registry note

The task brief asked for an entry removal from
`apps/admin/lib/journey/producer-only-registry.ts::PRODUCER_ONLY_CONTRACTS`.
[verified] That file lives on the `feat/journey-grey-out` branch
(commit 75906d9d) and has not yet landed on `main` — `find
apps/admin/lib/journey -name producer-only-registry.ts` returns
empty in this worktree, and the commit is not in `git log
origin/main`. When `feat/journey-grey-out` merges, a follow-on PR (or
the merge itself) should drop the `intakeSkipIfReturning` row from
the runtime registry; the Inspector + preview-bubble badges will then
disappear automatically as designed.

## Verified by

- **Sibling-writer survey (Lattice):** `qmd search` + `grep -rn` for
  `skipIntakeIfReturning` / `config.skipIntakeIfReturning` returned
  ONE hit — the `JourneySettingContract` definition at
  `apps/admin/lib/journey/setting-contracts.entries.ts:160-174`. No
  competing writer or reader, no sibling-writer drift, no chain-stage
  boundary crossed. New typed field on `PlaybookConfig` is additive
  (default off preserves every existing playbook's behaviour).
- **Coverage classification flip:**
  `tests/lib/journey/registry-consumer-coverage.test.ts` — pre-fix
  classified `intakeSkipIfReturning` as `exempt`; post-fix the
  consumer-source sweep across `lib/intake/` discovers the read in
  the route, so it's now `covered`. The ratchet 15 → 14 enforces no
  regression. [verified by] vitest run: 6/6 pass.
- **Tests:**
  - `tests/lib/intake/returning-learner.test.ts` (4 vitests) — 4/4 pass.
  - `tests/api/student-survey-config.test.ts` (5 new + 6 existing vitests)
    — 11/11 pass. New cases pin: new learner sees intake; returning
    learner + flag=true skips; returning learner + flag=false re-prompts;
    flag=true + no history (no bypass); flag unset (default-off).
- **Type-check:** `tsc --noEmit -p apps/admin` finished with exit
  code 0 on the modified files (also passed at pre-push: 34 errors ==
  baseline 34, no new errors).
- **Pre-push gate:** push checks passed (`tsc`, `eslint`, no
  ratchet drift).

## Test plan

- [x] Unit: helper detector across 0/1/N rows + canonical OR shape
  pinned.
- [x] Route: 5 vitests cover the truth table (new vs returning ×
  flag true/false/unset).
- [x] Lattice Coverage: ratchet decrements; 130/130 journey tests
  green.
- [ ] Live smoke (operator follow-up): enroll a learner in two
  PUBLISHED courses where the second sets `skipIntakeIfReturning=true`
  → confirm second course bypasses welcome flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)