### PR TITLE
fix(ui): portal JsonEditorModal — restore {} JSON modal on tri-pane tabs

### DIFF
--- a/apps/admin/components/settings/JsonEditorModal.tsx
+++ b/apps/admin/components/settings/JsonEditorModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { X, Save } from "lucide-react";
 
 interface JsonEditorModalProps {
@@ -64,8 +65,9 @@ export function JsonEditorModal({
   }, [isOpen, requestClose]);
 
   if (!isOpen) return null;
+  if (typeof document === "undefined") return null;
 
-  return (
+  return createPortal(
     <div
       style={{
         position: "fixed",
@@ -210,6 +212,7 @@ export function JsonEditorModal({
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }


### PR DESCRIPTION
## Summary

- `JsonEditorModal` previously rendered inline. On the tri-pane tabs (Journey / Teaching / Scoring) the mount point sits inside `.hf-designer-inspector` (`position: sticky; overflow: auto; max-height: 80vh`). Safari clips `position: fixed` descendants of a sticky+overflow ancestor — backdrop appears as a grey rectangle over the inspector column only, and the dialog itself can land off-stage.
- Fix: `createPortal(..., document.body)` so the modal escapes any ancestor stacking/clipping context. SSR-guarded with `if (typeof document === "undefined") return null;`.
- Single chokepoint — `JsonEditorModal` is the shared modal mounted from `EditAsJsonButton` (journey/teaching/scoring) AND `FallbacksPanel`. All consumers fixed transitively.
- Modules tab has no `{} JSON` affordance — not affected.

## Verified by

- Source trace: `apps/admin/components/shared/designer-shell/designer-shell.css:51` (`.hf-designer-inspector` containing-block trap), `apps/admin/components/settings/JsonEditorModal.tsx:67-217` (modal mount point).
- Pre-push tsc: 0 errors (baseline 34, -34).
- Pre-push eslint: 0 errors in changed files.
- [unverified] Browser smoke test on Safari Scoring tab. Mechanical 5-line portal change; requires manual confirmation that clicking `{} JSON` opens the modal centred on the viewport.

## Test plan

- [ ] Open Scoring tab on a course in Safari. Click `{} JSON` on a setting card. Modal opens centred on viewport, not clipped to inspector column.
- [ ] Repeat on Teaching tab.
- [ ] Repeat on Journey tab.
- [ ] Esc closes; backdrop click closes (with dirty-warn if textarea edited).
- [ ] `FallbacksPanel` settings page: `{} JSON` still works (sibling reuse site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)