### PR TITLE
chore(lattice): epic #2049 closeout — ratchet to 0

### DIFF
--- a/apps/admin/lib/journey/producer-only-registry.ts
+++ b/apps/admin/lib/journey/producer-only-registry.ts
@@ -47,21 +47,7 @@ export interface ProducerOnlyEntry {
 /** Active producer-only contracts. Edits land in the playbook config
  *  but nothing downstream uses the value. */
 export const PRODUCER_ONLY_CONTRACTS: Record<string, ProducerOnlyEntry> = {
-  // ── intake gate
-  intakeSkipIfReturning: {
-    destinedFor: "intake",
-    note: "Intake flow doesn't skip returning learners yet.",
-  },
-
-  // ── compose-prompt transforms (educator-tunable but no transform reads it)
-  // ── voice provider knobs
-  interruptSensitivity: {
-    destinedFor: "voice-provider",
-    note: "Voice-stack consumer pending — should gate VAPI barge-in threshold + voicemail-detection.",
-  },
-
-  // ── runtime gates (composeImpact=[] hides them from the Coverage test,
-  // but they're runtime-effect settings hiding behind that flag)
+  // All 18 producer-only contracts wired by epic #2049 (2026-06-19).
 };
 
 /** Type-narrowing helper for the UI. */

--- a/apps/admin/tests/lib/journey/registry-consumer-coverage.test.ts
+++ b/apps/admin/tests/lib/journey/registry-consumer-coverage.test.ts
@@ -80,16 +80,12 @@ const REGISTRY_CONSUMER_EXEMPT_PATHS: Record<string, ExemptEntry> = {
   // (settings the agent's manual audit missed). All confirmed
   // producer-only via wide `grep -rln <id> lib/` returning 0 hits
   // outside `setting-contracts.entries.ts`.
-  interruptSensitivity: {
-    reason:
-      "Producer-only since 2026-06-17 audit. Voice-stack consumer pending — interrupt sensitivity should gate the VAPI assistant's `voicemailDetectionEnabled` + barge-in threshold but no transform reads it today.",
-  },
 };
 
 /** Ratchet — the exempt count is allowed to GO DOWN (wire a consumer,
  *  remove the entry), never UP without a bump here. The test fails on
  *  drift in either direction so a careless add gets caught at PR time. */
-const EXPECTED_EXEMPT_COUNT = 4;
+const EXPECTED_EXEMPT_COUNT = 0;
 
 // ────────────────────────────────────────────────────────────
 // Consumer-surface concatenation


### PR DESCRIPTION
Closes the cascade-merge drift on EXPECTED_EXEMPT_COUNT. All 18 producer-only contracts wired via #2049 sub-epics. Inspector badge auto-clears.