### PR TITLE
chore(voice): restore interrupt-sensitivity.ts lost during cascade merge

### DIFF
--- a/apps/admin/lib/voice/interrupt-sensitivity.ts
+++ b/apps/admin/lib/voice/interrupt-sensitivity.ts
@@ -1,0 +1,92 @@
+/**
+ * Interrupt-sensitivity → VAPI barge-in mapper (#2053 / sub-epic D of #2049).
+ *
+ * The journey/voice contract `interruptSensitivity` (`Playbook.config.interruptSensitivity`)
+ * controls how readily the AI yields when the learner starts speaking.
+ * Storage is a slider (numeric) with optional tier-string fallback for
+ * forward-compat with operator UI experiments. Pre-#2053 the value was
+ * persisted but no runtime path consumed it — the Inspector lied (badge:
+ * "🚫 Not yet active — voice-stack consumer pending").
+ *
+ * This module is the consumer. Pure function, no IO. Callers (the VAPI
+ * adapter today, future Retell sibling) translate the resolved value into
+ * the provider's wire-format barge-in knob.
+ *
+ * VAPI mapping — `stopSpeakingPlan.numWords`
+ * -----------------------------------------
+ * VAPI's barge-in control lives on `assistant.stopSpeakingPlan.numWords`
+ * (https://docs.vapi.ai/api-reference/assistants/create-assistant —
+ * `stopSpeakingPlan`): the count of consecutive learner words that must
+ * be detected before the assistant stops talking. Lower = more sensitive
+ * (interrupts sooner). VAPI's default is 0 (any detected speech yields).
+ *
+ *   Sensitivity (educator setting) → numWords (VAPI):
+ *     1.0 / "high"   → 0  (most sensitive — yields on any speech)
+ *     0.5 / "medium" → 1  (yields after 1 detected word)
+ *     0.0 / "low"    → 3  (only yields after 3 words; assistant talks through brief noises)
+ *
+ * Numeric values between buckets are linearly interpolated then rounded.
+ * Out-of-range / unparseable values resolve to "medium" — the safer
+ * mid-band default — and the caller can log a warn.
+ *
+ * Companion test: `tests/lib/voice/interrupt-sensitivity.test.ts` pins
+ * every tier + the numeric interpolation.
+ */
+
+/** Tier strings the educator UI MAY emit (forward-compat — today's
+ *  slider stores a number). Accepted by the resolver so a future
+ *  `control: "select"` swap doesn't break the consumer. */
+export type InterruptSensitivityTier = "low" | "medium" | "high";
+
+/** Wire-shape fragment the adapter spreads onto the VAPI assistant
+ *  payload. Never overwrites unrelated keys. */
+export interface VapiBargeInConfig {
+  stopSpeakingPlan: {
+    numWords: number;
+  };
+}
+
+const TIER_TO_NUM_WORDS: Record<InterruptSensitivityTier, number> = {
+  low: 3,
+  medium: 1,
+  high: 0,
+};
+
+/**
+ * Resolve a stored sensitivity value into a VAPI barge-in fragment, or
+ * `null` when the operator hasn't set anything (caller should omit the
+ * key and let VAPI's own default ride).
+ *
+ * Accepts:
+ *   - `number` in [0, 1] (slider — default control type for the contract)
+ *   - tier string `"low" | "medium" | "high"` (forward-compat for a
+ *     possible select-control swap)
+ *   - `null` / `undefined` / unrecognised value → returns `null`
+ */
+export function mapInterruptSensitivityToVapi(
+  value: unknown,
+): VapiBargeInConfig | null {
+  if (value === null || value === undefined) return null;
+
+  if (typeof value === "string") {
+    const tier = value.toLowerCase() as InterruptSensitivityTier;
+    if (tier in TIER_TO_NUM_WORDS) {
+      return { stopSpeakingPlan: { numWords: TIER_TO_NUM_WORDS[tier] } };
+    }
+    return null;
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    // Clamp to [0, 1]. The contract is a `slider`; if a future UI bug
+    // ships an out-of-range write, we'd rather clamp than crash the
+    // assistant payload.
+    const clamped = Math.max(0, Math.min(1, value));
+    // Linear interpolation: 0.0 → 3 words, 0.5 → 1.5 → rounded 2 (sensible
+    // between low + medium), 1.0 → 0 words. Round to nearest integer to
+    // satisfy VAPI's int type.
+    const numWords = Math.round(3 - 3 * clamped);
+    return { stopSpeakingPlan: { numWords } };
+  }
+
+  return null;
+}

--- a/apps/admin/tests/lib/voice/interrupt-sensitivity.test.ts
+++ b/apps/admin/tests/lib/voice/interrupt-sensitivity.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for the interruptSensitivity → VAPI barge-in mapper
+ * (#2053 / sub-epic D of #2049).
+ *
+ * Pins:
+ *  1. Tier string mapping (low/medium/high) → numWords
+ *  2. Numeric slider [0..1] interpolation → numWords
+ *  3. Clamping for out-of-range numeric values
+ *  4. Null / undefined / unrecognised → null (caller omits the knob)
+ *  5. End-to-end via `VapiProvider.buildAssistantConfig`: the resolved
+ *     `voiceConfig.interruptSensitivity` produces the expected
+ *     `assistant.stopSpeakingPlan` block.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { mapInterruptSensitivityToVapi } from "@/lib/voice/interrupt-sensitivity";
+import { VapiProvider } from "@/lib/voice/providers/vapi";
+import type { AssistantRequestContext } from "@/lib/voice/types";
+
+describe("mapInterruptSensitivityToVapi — tier strings", () => {
+  it("low → 3 words (least sensitive)", () => {
+    expect(mapInterruptSensitivityToVapi("low")).toEqual({
+      stopSpeakingPlan: { numWords: 3 },
+    });
+  });
+
+  it("medium → 1 word (mid)", () => {
+    expect(mapInterruptSensitivityToVapi("medium")).toEqual({
+      stopSpeakingPlan: { numWords: 1 },
+    });
+  });
+
+  it("high → 0 words (most sensitive — yields on any speech)", () => {
+    expect(mapInterruptSensitivityToVapi("high")).toEqual({
+      stopSpeakingPlan: { numWords: 0 },
+    });
+  });
+
+  it("accepts case-insensitive tier strings", () => {
+    expect(mapInterruptSensitivityToVapi("HIGH")).toEqual({
+      stopSpeakingPlan: { numWords: 0 },
+    });
+    expect(mapInterruptSensitivityToVapi("Medium")).toEqual({
+      stopSpeakingPlan: { numWords: 1 },
+    });
+  });
+});
+
+describe("mapInterruptSensitivityToVapi — numeric slider", () => {
+  it("0.0 → 3 words (slider floor)", () => {
+    expect(mapInterruptSensitivityToVapi(0)).toEqual({
+      stopSpeakingPlan: { numWords: 3 },
+    });
+  });
+
+  it("0.5 → 2 words (mid-band — rounded)", () => {
+    // Linear: 3 - 3*0.5 = 1.5 → Math.round → 2
+    expect(mapInterruptSensitivityToVapi(0.5)).toEqual({
+      stopSpeakingPlan: { numWords: 2 },
+    });
+  });
+
+  it("1.0 → 0 words (slider ceiling, most sensitive)", () => {
+    expect(mapInterruptSensitivityToVapi(1)).toEqual({
+      stopSpeakingPlan: { numWords: 0 },
+    });
+  });
+
+  it("0.7 → 1 word (between medium and high)", () => {
+    // Linear: 3 - 3*0.7 = 0.9 → Math.round → 1
+    expect(mapInterruptSensitivityToVapi(0.7)).toEqual({
+      stopSpeakingPlan: { numWords: 1 },
+    });
+  });
+
+  it("clamps negative values to 0 → 3 words", () => {
+    expect(mapInterruptSensitivityToVapi(-0.5)).toEqual({
+      stopSpeakingPlan: { numWords: 3 },
+    });
+  });
+
+  it("clamps >1 values to 1 → 0 words", () => {
+    expect(mapInterruptSensitivityToVapi(2.5)).toEqual({
+      stopSpeakingPlan: { numWords: 0 },
+    });
+  });
+});
+
+describe("mapInterruptSensitivityToVapi — null / unrecognised", () => {
+  it("null → null (omit the knob, keep VAPI default)", () => {
+    expect(mapInterruptSensitivityToVapi(null)).toBeNull();
+  });
+
+  it("undefined → null", () => {
+    expect(mapInterruptSensitivityToVapi(undefined)).toBeNull();
+  });
+
+  it("unknown tier string → null", () => {
+    expect(mapInterruptSensitivityToVapi("aggressive")).toBeNull();
+  });
+
+  it("non-finite number → null", () => {
+    expect(mapInterruptSensitivityToVapi(Number.NaN)).toBeNull();
+    expect(mapInterruptSensitivityToVapi(Number.POSITIVE_INFINITY)).toBeNull();
+  });
+
+  it("object / array → null", () => {
+    expect(mapInterruptSensitivityToVapi({ tier: "high" })).toBeNull();
+    expect(mapInterruptSensitivityToVapi([1])).toBeNull();
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Integration through VapiProvider.buildAssistantConfig
+// ────────────────────────────────────────────────────────────
+
+function baseCtx(
+  overrides: Partial<AssistantRequestContext> = {},
+): AssistantRequestContext {
+  return {
+    callerId: "caller-1",
+    callerName: "Alice",
+    customerPhone: "+441234567890",
+    voicePrompt: "You are a friendly tutor.",
+    firstLine: "Hi Alice!",
+    toolDefinitions: [],
+    knowledgePlanEnabled: false,
+    serverUrlBase: "https://hf.example.com/api/voice/vapi",
+    modelConfig: { provider: "openai", model: "gpt-4o" },
+    unknownCallerPrompt: "Hello caller!",
+    noActivePromptFallback: "No prompt fallback.",
+    ...overrides,
+  };
+}
+
+describe("VapiProvider.buildAssistantConfig — interruptSensitivity wiring", () => {
+  it("omits stopSpeakingPlan when voiceConfig.interruptSensitivity is undefined", () => {
+    const p = new VapiProvider({}, {});
+    const out = p.buildAssistantConfig(
+      baseCtx({ voiceConfig: { voiceId: "asteria" } }),
+    ) as { assistant: Record<string, unknown> };
+    expect(out.assistant.stopSpeakingPlan).toBeUndefined();
+  });
+
+  it("low tier sets stopSpeakingPlan.numWords = 3", () => {
+    const p = new VapiProvider({}, {});
+    const out = p.buildAssistantConfig(
+      baseCtx({ voiceConfig: { interruptSensitivity: "low" } }),
+    ) as { assistant: Record<string, unknown> };
+    expect(out.assistant.stopSpeakingPlan).toEqual({ numWords: 3 });
+  });
+
+  it("high tier sets stopSpeakingPlan.numWords = 0", () => {
+    const p = new VapiProvider({}, {});
+    const out = p.buildAssistantConfig(
+      baseCtx({ voiceConfig: { interruptSensitivity: "high" } }),
+    ) as { assistant: Record<string, unknown> };
+    expect(out.assistant.stopSpeakingPlan).toEqual({ numWords: 0 });
+  });
+
+  it("numeric slider 0.5 sets stopSpeakingPlan.numWords = 2", () => {
+    const p = new VapiProvider({}, {});
+    const out = p.buildAssistantConfig(
+      baseCtx({ voiceConfig: { interruptSensitivity: 0.5 } }),
+    ) as { assistant: Record<string, unknown> };
+    expect(out.assistant.stopSpeakingPlan).toEqual({ numWords: 2 });
+  });
+
+  it("unrecognised value leaves stopSpeakingPlan unset", () => {
+    const p = new VapiProvider({}, {});
+    const out = p.buildAssistantConfig(
+      baseCtx({ voiceConfig: { interruptSensitivity: "aggressive" } }),
+    ) as { assistant: Record<string, unknown> };
+    expect(out.assistant.stopSpeakingPlan).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Restoring file from #2059's commit 7f643612b that didn't survive epic #2049's cascade merges. Closes the post-epic registry-consumer-coverage failure for interruptSensitivity.