### PR TITLE
feat(picker): #2104 per-module prerequisiteStrict override

### DIFF
--- a/a-sample-docs/course-reference-template.md
+++ b/a-sample-docs/course-reference-template.md
@@ -195,6 +195,18 @@ If any row has `Learner-selectable: Yes`, `Playbook.config.progressionMode`
 becomes `learner-picks`; otherwise it stays `ai-led`.
 - Voice band readout: Yes | No (defaults to No)
 
+OPTIONAL PER-MODULE OVERRIDE (#2104): `AuthoredModule.prerequisiteStrict`
+(boolean, optional) overrides the course-level
+`PlaybookConfig.strictPrerequisites` flag for a single module. The picker
+resolves `mod.prerequisiteStrict ?? strictPrerequisites ?? false`. Use this
+when one module should hard-lock while the rest stay soft-warn — e.g. IELTS
+Speaking keeps the course-level flag `false` (free-pick ethos for Parts
+1/2/3) while setting `prerequisiteStrict: true` on the Mock Exam module so
+it locks until the practice modules are mastered. The Module Catalogue
+table below does not yet have a column for this field — set it via the
+operator UI / direct `Playbook.config.modules[]` edit. Absent → falls back
+to the course-level flag (zero regression).
+
 REPLACE the two `[example — replace]` rows below with your real modules.
 -->
 

--- a/apps/admin/app/x/courses/[courseId]/_components/LearnerModulePicker.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/LearnerModulePicker.tsx
@@ -139,16 +139,20 @@ export function LearnerModulePicker({
   const inProgress = useMemo(() => new Set(inProgressModuleIds), [inProgressModuleIds]);
 
   // Pre-compute the set of locked module ids — modules whose prereqs
-  // aren't all MASTERED while the course runs in strict mode. Drives
+  // aren't all MASTERED AND whose effective-strict flag is true. Drives
   // the tile-level lock badge + desaturate (Slice 4.6) AND suppresses
   // the recommended-next badge on the same tile so the two affordances
-  // never contradict each other. Empty set when `strictPrerequisites`
-  // is false → tiles stay un-decorated and Slice 4.5's soft-warning
-  // path is untouched.
+  // never contradict each other. A module is locked only when ITS OWN
+  // effective-strict resolves to true:
+  //   `mod.prerequisiteStrict ?? strictPrerequisites ?? false`
+  // (#2104 — per-module override so IELTS Mock Exam can hard-lock
+  // while Parts 1/2/3 stay soft-warn even though the course-level
+  // flag is `false`.)
   const lockedModuleIds = useMemo(() => {
-    if (!strictPrerequisites) return new Set<string>();
     const locked = new Set<string>();
     for (const m of modules) {
+      const effectiveStrict = m.prerequisiteStrict ?? strictPrerequisites ?? false;
+      if (!effectiveStrict) continue;
       const unmet = computeUnmetPrereqs(m, modulesById);
       if (unmet.length > 0) locked.add(m.id);
     }
@@ -175,7 +179,10 @@ export function LearnerModulePicker({
         onSelect(moduleId);
         return;
       }
-      if (strictPrerequisites) {
+      // #2104 — per-module override of course-level `strictPrerequisites`.
+      // Resolution: `mod.prerequisiteStrict ?? strictPrerequisites ?? false`.
+      const effectiveStrict = mod.prerequisiteStrict ?? strictPrerequisites ?? false;
+      if (effectiveStrict) {
         setPendingHardLock({ module: mod, unmetPrereqs: unmet });
         return;
       }

--- a/apps/admin/lib/types/json-fields.ts
+++ b/apps/admin/lib/types/json-fields.ts
@@ -1234,6 +1234,28 @@ export interface AuthoredModule {
   masteryThreshold?: number;
 
   /**
+   * #2104 (epic #2102 S2) — per-module override of the course-level
+   * `PlaybookConfig.strictPrerequisites` flag.
+   *
+   * Resolution at picker time:
+   *   `mod.prerequisiteStrict ?? PlaybookConfig.strictPrerequisites ?? false`
+   *
+   * Use case: IELTS Speaking Practice keeps the course-level flag at
+   * `false` (soft-warn for Parts 1/2/3 — free-pick ethos) while
+   * setting `prerequisiteStrict: true` on the Mock Exam module to
+   * hard-lock it until the practice prereqs are mastered. Without
+   * this per-module knob the course-level flag forces all-or-nothing.
+   *
+   * Read by `LearnerModulePicker.tsx` (`lockedModuleIds` useMemo +
+   * `handlePick`). The Soft-Warn / Hard-Lock modal pair is unchanged
+   * — the override just selects which one fires for this module.
+   *
+   * Absent (default) → falls back to course-level flag = zero
+   * regression for every existing course-ref.
+   */
+  prerequisiteStrict?: boolean;
+
+  /**
    * #1701 (epic #1700 Theme 1) — module-scoped settings layer (G8).
    *
    * All keys optional. Each maps to a G8 entry in

--- a/apps/admin/tests/components/courses/LearnerModulePicker-prerequisiteStrict.test.tsx
+++ b/apps/admin/tests/components/courses/LearnerModulePicker-prerequisiteStrict.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * LearnerModulePicker — per-module `prerequisiteStrict` override.
+ *
+ * Story: #2104 (S2 of epic #2102). Pins the resolution rule
+ *   `mod.prerequisiteStrict ?? strictPrerequisites ?? false`
+ * across the picker's two consumers:
+ *   - `lockedModuleIds` useMemo (drives the lock badge + desaturate)
+ *   - `handlePick` (drives hard-lock vs soft-warn modal selection)
+ *
+ * AC coverage:
+ *   1. `prerequisiteStrict: true` hard-locks regardless of course flag
+ *   2. `prerequisiteStrict: false` forces soft-warn even when course flag is true
+ *   3. `prerequisiteStrict` absent → falls back to course-level flag
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { LearnerModulePicker } from "@/app/x/courses/[courseId]/_components/LearnerModulePicker";
+import type { AuthoredModule } from "@/lib/types/json-fields";
+
+function baseMod(overrides: Partial<AuthoredModule> = {}): AuthoredModule {
+  return {
+    id: "part1",
+    label: "Part 1",
+    learnerSelectable: true,
+    mode: "tutor",
+    duration: "Student-led",
+    scoringFired: "LR + GRA only",
+    voiceBandReadout: false,
+    sessionTerminal: false,
+    frequency: "repeatable",
+    outcomesPrimary: ["OUT-01"],
+    prerequisites: [],
+    ...overrides,
+  };
+}
+
+describe("LearnerModulePicker — per-module prerequisiteStrict override (#2104)", () => {
+  it("AC1: prerequisiteStrict=true hard-locks the module even when course-level strictPrerequisites=false", () => {
+    // Setup: Part 1 not mastered; Mock Exam declares prerequisiteStrict=true with Part 1 as prereq.
+    // Course-level flag is false (soft-warn default).
+    const part1 = baseMod({
+      id: "part1",
+      label: "Part 1",
+      progress: { status: "NOT_STARTED", callCount: 0 },
+    });
+    const mock = baseMod({
+      id: "mock",
+      label: "Mock Exam",
+      prerequisites: ["part1"],
+      prerequisiteStrict: true,
+    });
+
+    const onSelect = vi.fn();
+    render(
+      <LearnerModulePicker
+        modules={[part1, mock]}
+        lessonPlanMode="continuous"
+        strictPrerequisites={false}
+        onSelect={onSelect}
+      />,
+    );
+
+    // Lock badge present on the Mock Exam tile (lockedModuleIds includes "mock").
+    const lockBadges = screen.getAllByLabelText(
+      "Locked — complete the prereqs first",
+    );
+    expect(lockBadges.length).toBe(1);
+
+    // Clicking the Mock Exam tile opens the HARD-LOCK modal, not the soft-warn.
+    const mockTile = screen.getByRole("button", { name: /Mock Exam/i });
+    fireEvent.click(mockTile);
+
+    expect(screen.getByText("Complete these first")).toBeTruthy();
+    expect(screen.queryByText(/Heads up/i)).toBeNull();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("AC2: prerequisiteStrict=false forces soft-warn even when course-level strictPrerequisites=true", () => {
+    // Setup: Part 1 not mastered; Part 2 declares prerequisiteStrict=false override
+    // against the otherwise-strict course flag.
+    const part1 = baseMod({
+      id: "part1",
+      label: "Part 1",
+      progress: { status: "NOT_STARTED", callCount: 0 },
+    });
+    const part2 = baseMod({
+      id: "part2",
+      label: "Part 2",
+      prerequisites: ["part1"],
+      prerequisiteStrict: false,
+    });
+
+    const onSelect = vi.fn();
+    render(
+      <LearnerModulePicker
+        modules={[part1, part2]}
+        lessonPlanMode="continuous"
+        strictPrerequisites={true}
+        onSelect={onSelect}
+      />,
+    );
+
+    // No lock badge on Part 2 — per-module override won, lockedModuleIds is empty.
+    expect(
+      screen.queryByLabelText("Locked — complete the prereqs first"),
+    ).toBeNull();
+
+    // Clicking Part 2 opens the SOFT-WARN modal, not the hard-lock.
+    const part2Tile = screen.getByRole("button", { name: /Part 2/i });
+    fireEvent.click(part2Tile);
+
+    expect(screen.getByText(/Heads up/i)).toBeTruthy();
+    expect(screen.queryByText("Complete these first")).toBeNull();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("AC3: prerequisiteStrict absent → falls back to course-level strictPrerequisites flag", () => {
+    // Setup: Part 1 not mastered; Part 2 does NOT declare prerequisiteStrict.
+    // Course-level flag is true → should hard-lock (course flag wins via fallback).
+    const part1 = baseMod({
+      id: "part1",
+      label: "Part 1",
+      progress: { status: "NOT_STARTED", callCount: 0 },
+    });
+    const part2 = baseMod({
+      id: "part2",
+      label: "Part 2",
+      prerequisites: ["part1"],
+      // prerequisiteStrict: undefined (omitted)
+    });
+
+    const onSelect = vi.fn();
+    render(
+      <LearnerModulePicker
+        modules={[part1, part2]}
+        lessonPlanMode="continuous"
+        strictPrerequisites={true}
+        onSelect={onSelect}
+      />,
+    );
+
+    // Lock badge IS present on Part 2 — fallback to course-level true.
+    const lockBadges = screen.getAllByLabelText(
+      "Locked — complete the prereqs first",
+    );
+    expect(lockBadges.length).toBe(1);
+
+    // Clicking Part 2 opens the HARD-LOCK modal (course-level flag drives via fallback).
+    const part2Tile = screen.getByRole("button", { name: /Part 2/i });
+    fireEvent.click(part2Tile);
+
+    expect(screen.getByText("Complete these first")).toBeTruthy();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #2104 (S2 of epic #2102).

## Summary

Adds optional `AuthoredModule.prerequisiteStrict?: boolean` so a single module can hard-lock while the rest of the course stays soft-warn (or vice-versa). Picker resolves at click time:

```
mod.prerequisiteStrict ?? PlaybookConfig.strictPrerequisites ?? false
```

IELTS Speaking can now declare `prerequisiteStrict: true` on Mock Exam while the course-level flag stays `false` for Parts 1/2/3 (free-pick ethos). Absent → falls back to course-level flag = zero regression for every existing course-ref.

## What changed

- `lib/types/json-fields.ts` — `AuthoredModule.prerequisiteStrict?: boolean` (optional, JSDoc with use case)
- `app/x/courses/[courseId]/_components/LearnerModulePicker.tsx` — `lockedModuleIds` useMemo + `handlePick` both resolve per-module via the rule above. Soft-warn / hard-lock modal pair unchanged.
- `a-sample-docs/course-reference-template.md` — documents the new optional field. Template is exempt from `courses-template-version-coverage`, no version bump.
- `tests/components/courses/LearnerModulePicker-prerequisiteStrict.test.tsx` — 3 vitests pinning the three resolution branches.

## Verified by

- `tests/components/courses/LearnerModulePicker-prerequisiteStrict.test.tsx` — 3/3 pass [verified]:
  - AC1: `prerequisiteStrict: true` + course `false` → hard-lock fires (lock badge present, hard-lock modal opens on click)
  - AC2: `prerequisiteStrict: false` + course `true` → soft-warn fires (no lock badge, soft-warn modal opens on click)
  - AC3: `prerequisiteStrict` absent + course `true` → falls back to course-level (hard-lock fires)
- `tests/lib/wizard/fixture-type-coverage.test.ts` — 12/12 pass [verified]: field is on `AuthoredModule` (not `AuthoredModuleSettings`), no fixture YAML walk change required.
- `tests/lib/courses/courses-template-version-coverage.test.ts` — 6/6 pass [verified]: template path exempt, no version bump.
- `npx tsc --noEmit` — 39 errors == baseline (no new errors in touched files) [verified].
- `npx eslint` on touched files — 0 errors, 1 pre-existing warning unrelated to changes [verified].
- **Lattice survey** [verified]: AuthoredModule sibling-writers mapped — `detect-authored-modules.ts` (wizard parser, doesn't set the new field — fine, optional), `apply-projection.ts` (wholesale pass-through at `merged.modules = patch.modules`, preserves new field), `app/api/courses/[courseId]/import-modules/route.ts` defensive normalisation at line 146 spreads `...m` then adds `prerequisites` — new field preserved through pass-through. No DB column mutation, no chain-stage boundary, no convention conflict. Decision: ship.

## Coordination

S1 (#2103) is in parallel; it touches `RailLayout` in the same file. This PR modifies `lockedModuleIds` useMemo + `handlePick` (different regions). Whichever merges first, the other rebases.

Ready for `/vm-cp`.