### PR TITLE
chore(ratchet): correct tsc_errors baseline 34 → 39 (truth-up)

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,5 +1,5 @@
 {
-  "tsc_errors": 34,
+  "tsc_errors": 39,
   "lint_errors": 0,
   "lint_warnings": 4856,
   "quarantined_tests": 36,


### PR DESCRIPTION
## Summary

- `tsc_errors: 34` in `.ratchet.json` was wrong — the real count at PR #2018 (commit `6d90a383`) was already 39.
- 5 errors weren't drift since #2018 — they were already there at #2018's merge.
- `#2027` ("ratchet step runs always") landed AFTER #2018, so the silent-drift hole let the bad baseline through unchecked.
- This bumps the baseline to match reality so the pre-push hook stops blocking honest PRs.

No tsc errors are introduced or resolved by this commit.

## Verified by

- `cd apps/admin && ./node_modules/.bin/tsc --noEmit 2>&1 | grep "error TS" | wc -l` returns **39** on current `main` HEAD `90f46572` (2026-06-20 11:09 BST)
- Same count (39) reproduced at the #2018 SHA `6d90a383` via temp worktree (`git worktree add --detach ~/temp 6d90a383`)
- Diff between #2018 and current main: field-order noise inside `app/api/callers/[callerId]/insights/route.ts(120,39)` only — no change in the error set

## Test plan

- [ ] CI ratchet step on this PR confirms tsc_errors == 39 (no warnings)
- [ ] After merge, subsequent feature PRs (`feat/preview-dim-cross-cutting`, `feat/modules-tab-bipane-editor`) push without the pre-push hook blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)