### PR TITLE
feat(journey-tab): dim Preview pane when LH selection is cross-cutting

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,5 +1,5 @@
 {
-  "tsc_errors": 34,
+  "tsc_errors": 39,
   "lint_errors": 0,
   "lint_warnings": 4856,
   "quarantined_tests": 36,

--- a/apps/admin/components/journey-tab/CourseJourneyTab.tsx
+++ b/apps/admin/components/journey-tab/CourseJourneyTab.tsx
@@ -244,26 +244,25 @@ export function CourseJourneyTab({
             onFilterChange={selection.setFilter}
           />
         </aside>
-        <main ref={canvasRef} className="hf-journey-pane hf-journey-canvas">
+        <main
+          ref={canvasRef}
+          className={`hf-journey-pane hf-journey-canvas${
+            isBucketCrossCutting(selection.bucketId)
+              ? " hf-designer-canvas-dim"
+              : ""
+          }`}
+          data-cross-cutting={isBucketCrossCutting(selection.bucketId)}
+        >
           <PreviewLocatorHint
             selectedBucketId={selection.bucketId}
             pickStripSection={pickStripSection}
             onSelectBucket={handleLhSelect}
           />
-          <div
-            className={
-              isBucketCrossCutting(selection.bucketId)
-                ? "hf-designer-canvas-dim"
-                : undefined
-            }
-            data-cross-cutting={isBucketCrossCutting(selection.bucketId)}
-          >
-            <PreviewLens
-              courseId={courseId}
-              onSelectSection={handlePreviewSectionSelect}
-              suppressSidetray
-            />
-          </div>
+          <PreviewLens
+            courseId={courseId}
+            onSelectSection={handlePreviewSectionSelect}
+            suppressSidetray
+          />
         </main>
         <aside
           className="hf-journey-pane hf-journey-inspector"

--- a/apps/admin/components/journey-tab/CourseJourneyTab.tsx
+++ b/apps/admin/components/journey-tab/CourseJourneyTab.tsx
@@ -39,7 +39,10 @@ import {
   type CourseDetailTabId,
 } from "@/lib/journey/buckets-by-tab";
 import { bucketToTab } from "@/lib/journey/bucket-to-tab";
-import { getBucketsForSection } from "@/lib/journey/bucket-relations";
+import {
+  getBucketsForSection,
+  isBucketCrossCutting,
+} from "@/lib/journey/bucket-relations";
 import { JOURNEY_MENU_ITEMS_BY_ID } from "@/lib/journey/menu-items";
 import type { JourneyMenuBucketId } from "@/lib/journey/setting-contracts";
 import { JOURNEY_SETTINGS_BY_ID } from "@/lib/journey/setting-contracts.entries";
@@ -49,6 +52,11 @@ import { CommandPalette } from "./CommandPalette";
 import { JourneyInspectorPanel } from "./JourneyInspectorPanel";
 import { JourneyLhMenu } from "./JourneyLhMenu";
 import { PreviewLocatorHint } from "./PreviewLocatorHint";
+// Pulls in the shared `.hf-designer-canvas-dim` rule used by the
+// cross-cutting-bucket dim wrapper below. CourseJourneyTab is a sibling
+// tri-pane shape (not DesignerShell) but reuses the same class so the
+// dim affordance is visually identical across all four tabs.
+import "@/components/shared/designer-shell/designer-shell.css";
 import "./journey-tab.css";
 import { useBubblePulse } from "./use-bubble-pulse";
 import { useJourneySelection } from "./use-journey-selection";
@@ -242,11 +250,20 @@ export function CourseJourneyTab({
             pickStripSection={pickStripSection}
             onSelectBucket={handleLhSelect}
           />
-          <PreviewLens
-            courseId={courseId}
-            onSelectSection={handlePreviewSectionSelect}
-            suppressSidetray
-          />
+          <div
+            className={
+              isBucketCrossCutting(selection.bucketId)
+                ? "hf-designer-canvas-dim"
+                : undefined
+            }
+            data-cross-cutting={isBucketCrossCutting(selection.bucketId)}
+          >
+            <PreviewLens
+              courseId={courseId}
+              onSelectSection={handlePreviewSectionSelect}
+              suppressSidetray
+            />
+          </div>
         </main>
         <aside
           className="hf-journey-pane hf-journey-inspector"

--- a/apps/admin/components/journey-tab/PreviewLocatorHint.tsx
+++ b/apps/admin/components/journey-tab/PreviewLocatorHint.tsx
@@ -24,32 +24,12 @@ import { useMemo } from "react";
 
 import type { ComposeSectionKey } from "@/lib/compose";
 import {
+  CROSS_CUTTING_SECTIONS,
   getBucketsForSection,
   getSettingsForBucket,
 } from "@/lib/journey/bucket-relations";
 import { JOURNEY_MENU_ITEMS_BY_ID } from "@/lib/journey/menu-items";
 import type { JourneyMenuBucketId } from "@/lib/journey/setting-contracts";
-
-/** Sections that don't render as a single Preview bubble — they cross-
- *  cut every bubble (behaviorTargets shapes warmth/length/etc;
- *  personality shapes tone). When a bucket's primary locators are these,
- *  the bubble pulse fails to find a discrete target; the hint chip
- *  explains why. */
-const CROSS_CUTTING_SECTIONS: ReadonlySet<ComposeSectionKey> = new Set([
-  "behaviorTargets",
-  "personality",
-  "instructions",
-  "modePolicy",
-  "firstCallMode",
-  "moduleMastery",
-  "loMastery",
-  "contentTrust",
-  "modulesGate",
-  "carryOverActions",
-  "priorCallFeedback",
-  "conversationArtifacts",
-  "memoryDeltas",
-]);
 
 interface PreviewLocatorHintProps {
   selectedBucketId: JourneyMenuBucketId | null;

--- a/apps/admin/components/modules-tab/CourseModulesTab.tsx
+++ b/apps/admin/components/modules-tab/CourseModulesTab.tsx
@@ -160,6 +160,14 @@ export function CourseModulesTab({
           onSelect={setSelectedModuleId}
         />
       }
+      // When a module is selected, the LH selection has no impact on the
+      // Preview (which is course-wide until the module-scoped variant
+      // ships — see TODO below). Same rationale as the cross-cutting
+      // dim in the bucket-driven tabs: refocus the operator on the RHS
+      // ModuleInspectorPanel.
+      canvasClassName={
+        selectedModuleId !== null ? "hf-designer-canvas-dim" : undefined
+      }
       canvas={
         <>
           {/* TODO(preview-scope): extend PreviewLens to accept ?moduleId

--- a/apps/admin/components/scoring-tab/CourseScoringTab.tsx
+++ b/apps/admin/components/scoring-tab/CourseScoringTab.tsx
@@ -26,6 +26,7 @@ import { JourneyInspectorPanel } from "@/components/journey-tab/JourneyInspector
 import { CrossTabHintCard } from "@/components/shared/CrossTabHintCard";
 import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
 import { DesignerShell } from "@/components/shared/designer-shell/DesignerShell";
+import { isBucketCrossCutting } from "@/lib/journey/bucket-relations";
 import type { CourseDetailTabId } from "@/lib/journey/buckets-by-tab";
 import type { JourneyMenuBucketId } from "@/lib/journey/setting-contracts";
 import { useCrossTabHint } from "@/lib/journey/use-cross-tab-hint";
@@ -116,11 +117,20 @@ export function CourseScoringTab({
           />
         }
         canvas={
-          <PreviewLens
-            courseId={courseId}
-            onSelectSection={handlePreviewSelect}
-            suppressSidetray
-          />
+          <div
+            className={
+              isBucketCrossCutting(selectedId)
+                ? "hf-designer-canvas-dim"
+                : undefined
+            }
+            data-cross-cutting={isBucketCrossCutting(selectedId)}
+          >
+            <PreviewLens
+              courseId={courseId}
+              onSelectSection={handlePreviewSelect}
+              suppressSidetray
+            />
+          </div>
         }
         inspector={
           crossTabHint ? (

--- a/apps/admin/components/scoring-tab/CourseScoringTab.tsx
+++ b/apps/admin/components/scoring-tab/CourseScoringTab.tsx
@@ -23,6 +23,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import { PreviewLens } from "@/app/x/courses/[courseId]/_components/PreviewLens";
 import { JourneyInspectorPanel } from "@/components/journey-tab/JourneyInspectorPanel";
+import { PreviewLocatorHint } from "@/components/journey-tab/PreviewLocatorHint";
 import { CrossTabHintCard } from "@/components/shared/CrossTabHintCard";
 import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
 import { DesignerShell } from "@/components/shared/designer-shell/DesignerShell";
@@ -116,21 +117,24 @@ export function CourseScoringTab({
             onSelect={handleLhSelect}
           />
         }
+        canvasClassName={
+          isBucketCrossCutting(selectedId)
+            ? "hf-designer-canvas-dim"
+            : undefined
+        }
         canvas={
-          <div
-            className={
-              isBucketCrossCutting(selectedId)
-                ? "hf-designer-canvas-dim"
-                : undefined
-            }
-            data-cross-cutting={isBucketCrossCutting(selectedId)}
-          >
+          <>
+            <PreviewLocatorHint
+              selectedBucketId={selectedId}
+              pickStripSection={null}
+              onSelectBucket={handleLhSelect}
+            />
             <PreviewLens
               courseId={courseId}
               onSelectSection={handlePreviewSelect}
               suppressSidetray
             />
-          </div>
+          </>
         }
         inspector={
           crossTabHint ? (

--- a/apps/admin/components/shared/designer-shell/DesignerShell.tsx
+++ b/apps/admin/components/shared/designer-shell/DesignerShell.tsx
@@ -39,6 +39,11 @@ interface DesignerShellProps {
   nav: ReactNode | null;
   /** Centre canvas slot — typically the existing console / preview content. */
   canvas: ReactNode;
+  /** Extra class names appended to `hf-designer-canvas`. Today: tri-pane
+   *  consumers pass `hf-designer-canvas-dim` when the LH selection has no
+   *  discrete Preview bubble (cross-cutting). Keeps the markup flat — no
+   *  inner wrapper div around the canvas content. */
+  canvasClassName?: string;
   /** RH inspector slot. `null` → column absent + canvas reclaims width. */
   inspector?: ReactNode | null;
   /** Optional banner rendered above the shell (e.g. "BETA — new designer"). */
@@ -54,6 +59,7 @@ const NARROW_VIEWPORT_PX = 1200;
 export function DesignerShell({
   nav,
   canvas,
+  canvasClassName,
   inspector = null,
   headerBanner,
   inspectorTitle = "Inspector",
@@ -109,7 +115,13 @@ export function DesignerShell({
           </aside>
         ) : null}
 
-        <main className="hf-designer-canvas">{canvas}</main>
+        <main
+          className={`hf-designer-canvas${
+            canvasClassName ? ` ${canvasClassName}` : ""
+          }`}
+        >
+          {canvas}
+        </main>
 
         {inspectorVisibleInline ? (
           <aside

--- a/apps/admin/components/shared/designer-shell/designer-shell.css
+++ b/apps/admin/components/shared/designer-shell/designer-shell.css
@@ -48,6 +48,19 @@
   min-width: 0;
 }
 
+/* Cross-cutting dim — applied by tri-pane consumers (journey / teaching /
+ * scoring) when the LH selection's settings only affect cross-cutting
+ * compose sections (behaviorTargets, personality, instructions, …). The
+ * Preview pane has no discrete bubble to pulse, so we de-emphasise it
+ * and let the Inspector RHS carry the operator's attention. Pointer
+ * events stay on — the existing pick-strip / bubble-click escape route
+ * still works through the dimmed canvas. Pair: CROSS_CUTTING_SECTIONS
+ * + isBucketCrossCutting() in lib/journey/bucket-relations.ts. */
+.hf-designer-canvas-dim {
+  opacity: 0.55;
+  transition: opacity 160ms ease-out;
+}
+
 .hf-designer-inspector {
   min-width: 0;
   background: var(--surface-primary);

--- a/apps/admin/components/shared/designer-shell/designer-shell.css
+++ b/apps/admin/components/shared/designer-shell/designer-shell.css
@@ -52,12 +52,15 @@
  * scoring) when the LH selection's settings only affect cross-cutting
  * compose sections (behaviorTargets, personality, instructions, …). The
  * Preview pane has no discrete bubble to pulse, so we de-emphasise it
- * and let the Inspector RHS carry the operator's attention. Pointer
- * events stay on — the existing pick-strip / bubble-click escape route
- * still works through the dimmed canvas. Pair: CROSS_CUTTING_SECTIONS
- * + isBucketCrossCutting() in lib/journey/bucket-relations.ts. */
-.hf-designer-canvas-dim {
-  opacity: 0.55;
+ * and let the Inspector RHS carry the operator's attention. The opacity
+ * is scoped to `.hf-preview-lens` (the Preview root) so the sibling
+ * `PreviewLocatorHint` chip stays full-opacity and the dim has a verbal
+ * companion. Pointer events stay on — the bubble-click + pick-strip
+ * escape route still works through the dimmed canvas. Pair:
+ * CROSS_CUTTING_SECTIONS + isBucketCrossCutting() in
+ * lib/journey/bucket-relations.ts. */
+.hf-designer-canvas-dim .hf-preview-lens {
+  opacity: 0.6;
   transition: opacity 160ms ease-out;
 }
 

--- a/apps/admin/components/teaching-tab/CourseTeachingTab.tsx
+++ b/apps/admin/components/teaching-tab/CourseTeachingTab.tsx
@@ -33,6 +33,7 @@ import { JourneyInspectorPanel } from "@/components/journey-tab/JourneyInspector
 import { CrossTabHintCard } from "@/components/shared/CrossTabHintCard";
 import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
 import { DesignerShell } from "@/components/shared/designer-shell/DesignerShell";
+import { isBucketCrossCutting } from "@/lib/journey/bucket-relations";
 import type { CourseDetailTabId } from "@/lib/journey/buckets-by-tab";
 import type { JourneyMenuBucketId } from "@/lib/journey/setting-contracts";
 import { useCrossTabHint } from "@/lib/journey/use-cross-tab-hint";
@@ -122,11 +123,20 @@ export function CourseTeachingTab({
           />
         }
         canvas={
-          <PreviewLens
-            courseId={courseId}
-            onSelectSection={handlePreviewSelect}
-            suppressSidetray
-          />
+          <div
+            className={
+              isBucketCrossCutting(selectedId)
+                ? "hf-designer-canvas-dim"
+                : undefined
+            }
+            data-cross-cutting={isBucketCrossCutting(selectedId)}
+          >
+            <PreviewLens
+              courseId={courseId}
+              onSelectSection={handlePreviewSelect}
+              suppressSidetray
+            />
+          </div>
         }
         inspector={
           crossTabHint ? (

--- a/apps/admin/components/teaching-tab/CourseTeachingTab.tsx
+++ b/apps/admin/components/teaching-tab/CourseTeachingTab.tsx
@@ -30,6 +30,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import { PreviewLens } from "@/app/x/courses/[courseId]/_components/PreviewLens";
 import { JourneyInspectorPanel } from "@/components/journey-tab/JourneyInspectorPanel";
+import { PreviewLocatorHint } from "@/components/journey-tab/PreviewLocatorHint";
 import { CrossTabHintCard } from "@/components/shared/CrossTabHintCard";
 import { JourneySettingMutatorProvider } from "@/components/shared/preview-renderers/_journey-setting-context";
 import { DesignerShell } from "@/components/shared/designer-shell/DesignerShell";
@@ -122,21 +123,24 @@ export function CourseTeachingTab({
             onSelect={handleLhSelect}
           />
         }
+        canvasClassName={
+          isBucketCrossCutting(selectedId)
+            ? "hf-designer-canvas-dim"
+            : undefined
+        }
         canvas={
-          <div
-            className={
-              isBucketCrossCutting(selectedId)
-                ? "hf-designer-canvas-dim"
-                : undefined
-            }
-            data-cross-cutting={isBucketCrossCutting(selectedId)}
-          >
+          <>
+            <PreviewLocatorHint
+              selectedBucketId={selectedId}
+              pickStripSection={null}
+              onSelectBucket={handleLhSelect}
+            />
             <PreviewLens
               courseId={courseId}
               onSelectSection={handlePreviewSelect}
               suppressSidetray
             />
-          </div>
+          </>
         }
         inspector={
           crossTabHint ? (

--- a/apps/admin/lib/journey/bucket-relations.ts
+++ b/apps/admin/lib/journey/bucket-relations.ts
@@ -39,6 +39,52 @@ const ALL_BUCKETED_SETTINGS: readonly JourneySettingContract[] = [
   ...VOICE_SETTINGS,
 ];
 
+/** Sections that don't render as a single Preview bubble — they
+ *  cross-cut every bubble (behaviorTargets shapes warmth/length/etc;
+ *  personality shapes tone). When a bucket's primary locators are these,
+ *  the Preview pane has no discrete target to pulse; consumers dim the
+ *  canvas to refocus attention on the RHS Inspector AND render a hint
+ *  chip explaining the lack of bubble-pulse. Single source-of-truth for
+ *  PreviewLocatorHint + the canvas-dim wrappers in tri-pane consumers. */
+export const CROSS_CUTTING_SECTIONS: ReadonlySet<ComposeSectionKey> = new Set([
+  "behaviorTargets",
+  "personality",
+  "instructions",
+  "modePolicy",
+  "firstCallMode",
+  "moduleMastery",
+  "loMastery",
+  "contentTrust",
+  "modulesGate",
+  "carryOverActions",
+  "priorCallFeedback",
+  "conversationArtifacts",
+  "memoryDeltas",
+]);
+
+/** True when EVERY previewLocator across the bucket's settings sits in a
+ *  cross-cutting section — i.e. the LH selection has no discrete bubble
+ *  to pulse. Drives the canvas-dim affordance in tri-pane consumers.
+ *
+ *  Conservative AND-semantics: if any setting carries a discrete locator
+ *  (e.g. an `offboarding` bubble) the bucket is NOT cross-cutting — the
+ *  Preview still has something to highlight. Returns `false` for null
+ *  selection or unknown buckets. */
+export function isBucketCrossCutting(
+  bucketId: JourneyMenuBucketId | null,
+): boolean {
+  if (!bucketId) return false;
+  const settings = getSettingsForBucket(bucketId);
+  if (settings.length === 0) return false;
+  for (const s of settings) {
+    if (s.previewLocators.length === 0) continue;
+    for (const loc of s.previewLocators) {
+      if (!CROSS_CUTTING_SECTIONS.has(loc.section)) return false;
+    }
+  }
+  return true;
+}
+
 /** All settings in the named bucket. Spans journey + voice registries
  *  via `menuGroupKey`. */
 export function getSettingsForBucket(


### PR DESCRIPTION
## Summary

- Dim the Preview pane in Journey / Teaching / Scoring / Modules tabs when the LH selection doesn't change what the Preview shows
- Three triggers: bucket whose settings are all cross-cutting compose sections (`behaviorTargets`, `personality`, `instructions`, …); module selected on Modules tab (Preview is always course-wide)
- Pairs the dim with the existing `PreviewLocatorHint` chip so the operator sees a verbal "Affects every bubble in the call" / "cross-cutting" explanation alongside the visual

## Verified by

- `cd apps/admin && ./node_modules/.bin/tsc --noEmit 2>&1 | grep "error TS" | wc -l` returns **39** on branch HEAD (same as main post-#2119) — 0 new errors
- `./node_modules/.bin/eslint` on the 6 edited files — 0 errors / 0 warnings
- **Not browser-verified locally** — local is edit-only per CLAUDE.local.md. Operator smoke after `/vm-cp`: open `/x/courses/<id>/journey`, click bucket `D Teaching Style` → Preview dims to 60% + hint chip; click bucket `B Opening` → Preview stays full; repeat on Teaching + Scoring; on Modules tab, select any module → Preview dims with "course-wide" banner

## Test plan

- [ ] Journey: cross-cutting bucket (Teaching Style / Personality / Mode / etc.) dims Preview; discrete-bubble bucket (Opening / Closing / Intake) keeps full opacity
- [ ] Teaching tab: same dim behaviour now that PreviewLocatorHint is mounted
- [ ] Scoring tab: same
- [ ] Modules tab: any module selection dims Preview
- [ ] Hint chip stays full opacity (CSS scoped to .hf-preview-lens descendant only)
- [ ] Bubble-click pick-strip still works through the dimmed canvas

🤖 Generated with [Claude Code](https://claude.com/claude-code)