### PR TITLE
fix(css): hf-page-container responsive width cap

### DIFF
--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -3975,10 +3975,17 @@ html.light {
 
 /* Modal/Overlay defined in full below (search .hf-modal-overlay) */
 
-/* ── Page container (max-width centered) ── */
+/* ── Page container (max-width centered) ──
+   Responsive cap: 1400px on wide screens, but never wider than the
+   viewport minus the left nav (~240px) minus a 40px breathing margin.
+   Pre-fix `max-width: 1400px` was a hard cap that ignored viewport
+   size — on a ~1440px laptop with the LH nav rendered, content
+   extended ~250px past the right edge and clipped horizontally.
+   The min() expression caps growth at the smaller of (1400, available).
+*/
 .hf-page-container {
   padding: 24px;
-  max-width: 1400px;
+  max-width: min(1400px, calc(100vw - 280px));
   margin: 0 auto;
 }
 .hf-page-container.hf-page-wide {


### PR DESCRIPTION
## Summary

\`.hf-page-container\` had \`max-width: 1400px\` as a hard cap that ignored viewport size. On a ~1440px CSS-px laptop viewport with the LH nav rendered (~240px), content pushed ~250px past the right edge. The Teaching tab's Inspector pane (rendered to the right of main) compounded the overflow — operator screenshot showed heading clipped on the left (\"TS Speaking Practice\") and Inspector tabs clipped on the right.

Fix: \`max-width: min(1400px, calc(100vw - 280px))\`. On wide displays unchanged. On constrained viewports the container shrinks to fit available area.

## Verified by

- Operator screenshot (2026-06-20 13:13 UTC) showed horizontal overflow on the IELTS Speaking Practice / Teaching tab. Root cause traced to globals.css:3981.
- One-line CSS change. No tests touched, no behavior change beyond the cap calculation.
- Will verify visually after VM pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)