### PR TITLE
fix(modules-tab): coloured left-edge stripes on bipane cards

### DIFF
--- a/apps/admin/components/modules-tab/ModuleEditor.tsx
+++ b/apps/admin/components/modules-tab/ModuleEditor.tsx
@@ -154,7 +154,7 @@ function ModuleHowCard({
 }) {
   return (
     <section
-      className="hf-card hf-module-editor-card"
+      className="hf-card hf-module-editor-card hf-module-editor-card-how"
       data-testid="hf-module-editor-how"
       aria-labelledby="hf-module-editor-how-title"
     >
@@ -186,7 +186,7 @@ function ModuleWhenCard({ module: m }: { module: ModuleEditorRow }) {
     typeof m.position === "number" ? `Position #${m.position + 1}` : "Unset";
   return (
     <section
-      className="hf-card hf-module-editor-card"
+      className="hf-card hf-module-editor-card hf-module-editor-card-when"
       data-testid="hf-module-editor-when"
       aria-labelledby="hf-module-editor-when-title"
     >

--- a/apps/admin/components/modules-tab/modules-tab.css
+++ b/apps/admin/components/modules-tab/modules-tab.css
@@ -18,6 +18,28 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+  /* Coloured left stripe — each card variant overrides --hf-card-accent
+   * (token-only per ui-design-system.md). Default falls back to the
+   * border-default value so the variant overrides bite cleanly. */
+  border-left: 4px solid var(--hf-card-accent, var(--border-default));
+}
+
+/* Per-card accent — left stripe + soft tinted background.
+   Tokens only: accent-primary / accent-secondary / status-warning-text. */
+.hf-module-editor-header {
+  --hf-card-accent: var(--accent-primary);
+  border-left: 4px solid var(--hf-card-accent);
+  background: color-mix(in srgb, var(--accent-primary) 4%, var(--surface-primary));
+}
+
+.hf-module-editor-card-how {
+  --hf-card-accent: var(--accent-secondary);
+  background: color-mix(in srgb, var(--accent-secondary) 4%, var(--surface-primary));
+}
+
+.hf-module-editor-card-when {
+  --hf-card-accent: var(--status-warning-text);
+  background: color-mix(in srgb, var(--status-warning-text) 4%, var(--surface-primary));
 }
 
 .hf-module-editor-card-header {


### PR DESCRIPTION
## Summary

The 4 cards in the Modules-tab bipane editor (Header / How / When / Allowances) were undifferentiated — same surface, same border, same visual weight. Operator wanted coloured edges to distinguish them.

Per-card accent (tokens only):

| Card | Accent | Intent |
|---|---|---|
| Header | \`--accent-primary\` (blue) | Identity |
| HOW | \`--accent-secondary\` (purple) | Behavioural settings |
| WHEN | \`--status-warning-text\` (amber) | Sequencing / time |
| Allowances | unchanged dashed | Coming-soon honest signal |

Each variant: 4px solid left border + 4% color-mix tint on background.

## Verified by

- Per \`.claude/rules/ui-design-system.md\`: tokens only (no hex), color-mix() for alpha (not hex opacity), \`hf-\` prefix discipline maintained.
- 2 files touched: \`components/modules-tab/modules-tab.css\` (variant classes) + \`components/modules-tab/ModuleEditor.tsx\` (added variant class on HOW + WHEN sections).
- Will verify visually after VM pull — same hot-reload pattern as PR #2124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)