### PR TITLE
fix(wizard): relax MODULE_ID_PATTERN for CIO/CTO unit-doc IDs

### DIFF
--- a/apps/admin/lib/wizard/__tests__/detect-authored-modules.test.ts
+++ b/apps/admin/lib/wizard/__tests__/detect-authored-modules.test.ts
@@ -75,9 +75,11 @@ describe("detectAuthoredModules — IELTS v2.2 fixture", () => {
   });
 
   it("enforces ID regex on every parsed module", () => {
+    // Pattern relaxed to include hyphens + length cap raised to 80
+    // (CIO/CTO unit-doc IDs). Updated 2026-06-20 for the trio-import fix.
     for (const m of result.modules) {
-      expect(m.id).toMatch(/^[a-z][a-z0-9_]*$/);
-      expect(m.id.length).toBeLessThanOrEqual(32);
+      expect(m.id).toMatch(/^[a-z][a-z0-9_-]*$/);
+      expect(m.id.length).toBeLessThanOrEqual(80);
     }
   });
 

--- a/apps/admin/lib/wizard/detect-authored-modules.ts
+++ b/apps/admin/lib/wizard/detect-authored-modules.ts
@@ -87,8 +87,15 @@ export function extractOutcomeStatements(bodyText: string): Record<string, strin
 
 // ── Module ID validation ──────────────────────────────────────────────
 
-const MODULE_ID_PATTERN = /^[a-z][a-z0-9_]*$/;
-const MAX_MODULE_ID_LENGTH = 32;
+// Pattern: lowercase letter prefix, then lowercase/digits/underscores/hyphens.
+// Hyphens added to support unit-doc-derived IDs (CIO/CTO trio: filenames
+// like `standard-unit-04-it-operations-infrastructure`). Length cap bumped
+// from 32 → 80 for the same reason — unit doc filenames carry semantic
+// segments and run longer than the original 32-char IELTS budget. The
+// regex still excludes uppercase, spaces, and special chars that would
+// break JSON keys / URL slugs.
+const MODULE_ID_PATTERN = /^[a-z][a-z0-9_-]*$/;
+const MAX_MODULE_ID_LENGTH = 80;
 
 // ── Header declaration patterns ───────────────────────────────────────
 
@@ -322,7 +329,7 @@ function rowToModule(
   if (!MODULE_ID_PATTERN.test(rawId) || rawId.length > MAX_MODULE_ID_LENGTH) {
     warnings.push({
       code: "MODULE_ID_INVALID",
-      message: `Module ID "${rawId}" does not match required pattern /^[a-z][a-z0-9_]*$/ (max ${MAX_MODULE_ID_LENGTH} chars).`,
+      message: `Module ID "${rawId}" does not match required pattern /^[a-z][a-z0-9_-]*$/ (max ${MAX_MODULE_ID_LENGTH} chars).`,
       path: `modules.${rawId}.id`,
       severity: "error",
     });


### PR DESCRIPTION
## Summary

CIO/CTO trio (epic #2009) re-projection landed 0 modules — unit-doc IDs like \`standard-unit-04-it-operations-infrastructure\` (47 chars, hyphenated) failed the original \`/^[a-z][a-z0-9_]*$/\` 32-char cap.

Relaxed to \`/^[a-z][a-z0-9_-]*$/\` (hyphens OK) + max 80 chars. Still excludes uppercase / spaces / specials.

## Verified by

- Live import retry showed: \`hasErrors: true\`, \`validationWarnings\` for all 5 modules with \`MODULE_ID_INVALID\`, \`parsed 0 module(s) from catalogue\`.
- 34/34 \`detect-authored-modules\` vitests green after relaxation.
- Existing IELTS fixture (which uses underscore IDs) still parses identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)