### PR TITLE
feat(content): #2125 PR2 — IELTS seed writes ContentAssertion rows + close I1 on wizard

### DIFF
--- a/apps/admin/lib/chat/course-ref-tool-handlers.ts
+++ b/apps/admin/lib/chat/course-ref-tool-handlers.ts
@@ -229,7 +229,7 @@ async function attachToExistingCourse(
       },
     });
 
-    await tx.subjectSource.create({
+    const subjectSource = await tx.subjectSource.create({
       data: {
         subjectId: subjectId!,
         sourceId: source.id,
@@ -245,10 +245,13 @@ async function attachToExistingCourse(
     });
 
     if (assertions.length > 0) {
+      // #2125 PR2 — pass subjectSourceId so assertions don't leak cross-course
+      // through SectionDataLoader's strict-FK filter (ENTITIES.md §6 I1).
       await tx.contentAssertion.createMany({
         data: assertions.map((a) => ({
           ...a,
           sourceId: source.id,
+          subjectSourceId: subjectSource.id,
         })),
       });
     }
@@ -364,7 +367,7 @@ async function createCourseFromRef(
     });
 
     // 7. Link to subject
-    await tx.subjectSource.create({
+    const subjectSource = await tx.subjectSource.create({
       data: {
         subjectId: subject.id,
         sourceId: source.id,
@@ -381,10 +384,13 @@ async function createCourseFromRef(
 
     // 8. Create assertions
     if (assertions.length > 0) {
+      // #2125 PR2 — pass subjectSourceId so assertions don't leak cross-course
+      // through SectionDataLoader's strict-FK filter (ENTITIES.md §6 I1).
       await tx.contentAssertion.createMany({
         data: assertions.map((a) => ({
           ...a,
           sourceId: source.id,
+          subjectSourceId: subjectSource.id,
         })),
       });
     }

--- a/apps/admin/prisma/seed-ielts-course.ts
+++ b/apps/admin/prisma/seed-ielts-course.ts
@@ -50,9 +50,13 @@ import { PrismaClient } from "@prisma/client";
 import * as fs from "fs";
 import * as path from "path";
 
+import * as crypto from "crypto";
+
 import { projectCourseReference } from "../lib/wizard/project-course-reference";
 import { applyProjection } from "../lib/wizard/apply-projection";
 import { findOrCreateSeedPlaybook } from "../lib/seed/find-or-create-seed-playbook";
+import { saveAssertions } from "../lib/content-trust/save-assertions";
+import type { ExtractedAssertion } from "../lib/content-trust/extract-assertions";
 
 const DOMAIN_SLUG = "abacus-academy";
 const SUBJECT_SLUG = "ielts-speaking";
@@ -115,7 +119,7 @@ export async function main(prisma: PrismaClient): Promise<void> {
     });
   }
 
-  await prisma.subjectSource.upsert({
+  const subjectSource = await prisma.subjectSource.upsert({
     where: { subjectId_sourceId: { subjectId: subject.id, sourceId: source.id } },
     update: {},
     create: { subjectId: subject.id, sourceId: source.id },
@@ -208,6 +212,71 @@ export async function main(prisma: PrismaClient): Promise<void> {
       console.warn(`  ⚠ ${w.severity}: [${w.code}] ${w.message}`);
     }
   }
+
+  // ── 4a. Derived ContentAssertion rows (#2125 PR2) ──
+  // Without these the Content tab on /x/courses/<id> shows "No categories
+  // yet" + the Course Map / Teaching Points panels are empty. Derive a
+  // small set of assertions from the projection output we already have in
+  // memory — skills (skill_framework), modules (session_flow), and the
+  // course's directive teaching approach (teaching_rule). This is
+  // intentionally narrower than wizard AI extraction would produce on
+  // the same doc — the operator can upgrade with richer assertions via a
+  // CourseRefData fixture or AI re-extract once this is in place.
+  //
+  // Writes route through `saveAssertions(sourceId, assertions,
+  // subjectSourceId)` — the canonical chokepoint. This (a) honours the
+  // ai-to-db-guard `maxAssertionsPerDocument` cap, (b) dedups by
+  // contentHash so re-seed is idempotent, and (c) passes subjectSourceId
+  // to close the ENTITIES.md §6 I1 invariant (without it, assertions
+  // leak cross-course in SectionDataLoader's curriculumAssertions filter).
+  const derivedAssertions: ExtractedAssertion[] = [];
+
+  for (const skill of projection.skills) {
+    const tierText =
+      skill.tiers?.secure || skill.tiers?.developing || skill.tiers?.emerging || skill.name;
+    const text = `${skill.name} (${skill.ref}). Secure tier: ${tierText}`;
+    derivedAssertions.push({
+      assertion: text,
+      category: "skill_framework",
+      chapter: "Skills Framework",
+      section: skill.ref,
+      tags: ["ielts", "skill", skill.ref.toLowerCase()],
+      examRelevance: 1.0,
+      contentHash: crypto.createHash("sha256").update(text).digest("hex"),
+    });
+  }
+
+  for (const mod of projection.curriculumModules) {
+    const loRefs = mod.learningObjectives.map((lo) => lo.ref).join(", ");
+    const text = `${mod.title}${mod.description ? `. ${mod.description}` : ""}${loRefs ? ` Primary outcomes: ${loRefs}.` : ""}`;
+    derivedAssertions.push({
+      assertion: text,
+      category: "session_flow",
+      chapter: "Modules",
+      section: mod.slug,
+      tags: ["ielts", "module", mod.slug],
+      examRelevance: 1.0,
+      contentHash: crypto.createHash("sha256").update(text).digest("hex"),
+    });
+  }
+
+  const teachingText =
+    "IELTS Speaking tutor uses a directive correction-retry cycle. Names the single most score-limiting issue after each answer, provides the correction, and asks for an immediate retry. Theory is embedded in practice — never standalone lectures. Target speech ratio ~80% student / ~20% tutor.";
+  derivedAssertions.push({
+    assertion: teachingText,
+    category: "teaching_rule",
+    chapter: "Teaching Approach",
+    tags: ["ielts", "pedagogy", "directive", "correction-retry"],
+    examRelevance: 0.5,
+    contentHash: crypto.createHash("sha256").update(teachingText).digest("hex"),
+  });
+
+  const saveResult = await saveAssertions(source.id, derivedAssertions, subjectSource.id);
+  console.log(
+    `  Assertions: +${saveResult.created} written, ` +
+      `dedup ${saveResult.duplicatesSkipped}` +
+      (saveResult.truncatedByCap ? `, truncated ${saveResult.truncatedByCap} by cap` : ""),
+  );
 
   // ── 4b. Post-projection coversModules upsert for the Mock module (#550) ──
   // The fixture parser (`detectAuthoredModules`) does not yet handle a


### PR DESCRIPTION
## Summary

PR 2 of 3 for issue #2125 (seed↔wizard parity for IELTS Speaking Practice). Closes the **"Content Mix: No categories yet"** gap on the Content tab + closes the **ENTITIES.md §6 I1 invariant** leak on both seed AND wizard course-ref write paths.

Builds on PR1 #2128 (canonical-doc alignment), which is merged.

## Two commits — one concern each

### Commit 1: `fix(content-trust)` — wizard side I1 fix

Both `tx.contentAssertion.createMany` sites in `lib/chat/course-ref-tool-handlers.ts` (`attachToExistingCourse` line 248 + `createCourseFromRef` line 387) now pass `subjectSourceId` (captured from the existing `tx.subjectSource.create` one line above each). Pre-fix the wizard wrote `subjectSourceId: null` on every wizard-built course-ref → SectionDataLoader's strict-FK filter (`SectionDataLoader.ts:840`) fans null rows across every course in the shared Subject.

### Commit 2: `feat(content)` — seed side, ~10 derived assertions

After `applyProjection()` completes in `prisma/seed-ielts-course.ts`, derive ContentAssertion rows from projection output already in memory:

| Category | Count | Source |
|---|---|---|
| `skill_framework` | 4 | One per IELTS criterion (SKILL-01..04), Secure tier descriptor |
| `session_flow` | 5 | One per module (baseline/part1/part2/part3/mock), title + description + primary outcomes |
| `teaching_rule` | 1 | Directive correction-retry approach summary |

Writes route through `lib/content-trust/save-assertions.ts::saveAssertions(sourceId, assertions, subjectSourceId)` — the canonical chokepoint:
- Dedups by `contentHash` → re-seed is idempotent
- Enforces `maxAssertionsPerDocument` cap → `ai-to-db-guard.md`
- Passes `subjectSourceId` → closes I1 on the seed side

## What this PR does NOT do

- Does NOT use AI extraction (non-deterministic + costly per re-seed)
- Does NOT hand-author a `CourseRefData` JSON sidecar (potential PR3+; would unlock the full ~50+ assertion shape `convertCourseRefToAssertions` produces)
- Does NOT add a parity vitest (PR3 per Tech Lead split — structural-only, no LLM in test)
- Does NOT backfill existing hf_sandbox IELTS rows — operator re-runs `npm run db:seed` after deploy

## Test plan

- [x] `npx vitest run tests/lib/seed-ielts-fixture.test.ts` — 11/11 green (projection shape unchanged)
- [x] `npx tsc --noEmit` — 38 errors (baseline 39, -1) — none in changed files
- [x] `npx eslint` on changed files — 0 errors
- [ ] Post-merge: operator runs `npm run db:seed` on hf-dev VM
- [ ] Post-merge: `curl /api/courses/<id>/content-sources` returns `assertionCount > 0` on hf_sandbox
- [ ] Post-merge: Content tab on /x/courses/&lt;id&gt; shows Content Mix categories (skill_framework / session_flow / teaching_rule), no longer "No categories yet"

## Verified by

- `npx vitest run tests/lib/seed-ielts-fixture.test.ts` → 11 passed
- `npx tsc --noEmit` → 38 errors, none introduced
- `npx eslint apps/admin/prisma/seed-ielts-course.ts apps/admin/lib/chat/course-ref-tool-handlers.ts` → 0 errors, only pre-existing warnings
- Code-traced `lib/content-trust/save-assertions.ts:32` → confirmed it accepts `subjectSourceId` 3rd arg; dedup query at 39-44 scopes by it; cap enforcement at 60+ uses `resolveExtractionConfig`
- Live-verified pre-fix gap on hf_sandbox: `curl http://localhost:3000/api/courses/20b21160-0516-49c9-a8da-105772f41e64/content-sources` → `assertionCount: 0`
- Code-traced ENTITIES.md §6 I1 invariant via `SectionDataLoader.ts:840` strict `subjectSourceId: { in: [...] }` filter on curriculumAssertions

## Sibling-writer survey on ContentAssertion

11 writers total (per Tech Lead review). After this PR, the wizard course-ref writers (`course-ref-tool-handlers.ts:248,387`) AND the seed-ielts path BOTH pass `subjectSourceId` correctly. Three writers still bypass: `admin-tool-handlers.ts:742`, `_pedagogy-assertions.ts:101`, and the other seed scripts (`seed-educator-demo.ts`, `seed-demo-course.ts`, `seed-holographic-demo.ts`). Those are separate concerns not in scope.

## Lattice survey

- **Chain Contracts** — no cross-stage boundary
- **Guards** — `ai-to-db-guard.md` honoured (route through `saveAssertions`)
- **Cascade** — no cascadable knob touched
- **Rules** — `ai-to-db-guard.md` newly compliant on seed side
- **Coverage** — no Coverage-pillar gate affected

## CI Docs Skip

operator-runbook impact: none — seed input change + wizard internal FK fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)