### PR TITLE
fix(content): #2125 — stamp teachMethod on IELTS seed assertions + backfill legacy null rows

### DIFF
--- a/apps/admin/prisma/seed-ielts-course.ts
+++ b/apps/admin/prisma/seed-ielts-course.ts
@@ -57,6 +57,7 @@ import { applyProjection } from "../lib/wizard/apply-projection";
 import { findOrCreateSeedPlaybook } from "../lib/seed/find-or-create-seed-playbook";
 import { saveAssertions } from "../lib/content-trust/save-assertions";
 import type { ExtractedAssertion } from "../lib/content-trust/extract-assertions";
+import { categoryToTeachMethod } from "../lib/content-trust/resolve-config";
 
 const DOMAIN_SLUG = "abacus-academy";
 const SUBJECT_SLUG = "ielts-speaking";
@@ -231,6 +232,11 @@ export async function main(prisma: PrismaClient): Promise<void> {
   // leak cross-course in SectionDataLoader's curriculumAssertions filter).
   const derivedAssertions: ExtractedAssertion[] = [];
 
+  // All three categories below are INSTRUCTION_CATEGORIES → categoryToTeachMethod
+  // returns "tutor_instruction" (short-circuited per #605 so tutor-facing
+  // directives never inherit a learner-facing method). Stamped here so the
+  // per-subject methods breakdown shows them grouped correctly instead of
+  // bucketing under "unassigned".
   for (const skill of projection.skills) {
     const tierText =
       skill.tiers?.secure || skill.tiers?.developing || skill.tiers?.emerging || skill.name;
@@ -243,6 +249,7 @@ export async function main(prisma: PrismaClient): Promise<void> {
       tags: ["ielts", "skill", skill.ref.toLowerCase()],
       examRelevance: 1.0,
       contentHash: crypto.createHash("sha256").update(text).digest("hex"),
+      teachMethod: categoryToTeachMethod("skill_framework", "practice"),
     });
   }
 
@@ -257,6 +264,7 @@ export async function main(prisma: PrismaClient): Promise<void> {
       tags: ["ielts", "module", mod.slug],
       examRelevance: 1.0,
       contentHash: crypto.createHash("sha256").update(text).digest("hex"),
+      teachMethod: categoryToTeachMethod("session_flow", "practice"),
     });
   }
 
@@ -269,6 +277,7 @@ export async function main(prisma: PrismaClient): Promise<void> {
     tags: ["ielts", "pedagogy", "directive", "correction-retry"],
     examRelevance: 0.5,
     contentHash: crypto.createHash("sha256").update(teachingText).digest("hex"),
+    teachMethod: categoryToTeachMethod("teaching_rule", "practice"),
   });
 
   const saveResult = await saveAssertions(source.id, derivedAssertions, subjectSource.id);
@@ -277,6 +286,24 @@ export async function main(prisma: PrismaClient): Promise<void> {
       `dedup ${saveResult.duplicatesSkipped}` +
       (saveResult.truncatedByCap ? `, truncated ${saveResult.truncatedByCap} by cap` : ""),
   );
+
+  // Self-heal teachMethod on already-existing rows from the previous seed
+  // run that wrote them with teachMethod=null (PR #2130 shipped without
+  // the categoryToTeachMethod call — assertions dedup on contentHash so
+  // saveAssertions above won't rewrite them; this fills the column in
+  // place). Idempotent: WHERE teachMethod IS NULL means subsequent runs
+  // touch zero rows.
+  const teachMethodBackfill = await prisma.contentAssertion.updateMany({
+    where: {
+      sourceId: source.id,
+      teachMethod: null,
+      category: { in: ["skill_framework", "session_flow", "teaching_rule"] },
+    },
+    data: { teachMethod: "tutor_instruction" },
+  });
+  if (teachMethodBackfill.count > 0) {
+    console.log(`  teachMethod backfilled on ${teachMethodBackfill.count} legacy row(s)`);
+  }
 
   // ── 4b. Post-projection coversModules upsert for the Mock module (#550) ──
   // The fixture parser (`detectAuthoredModules`) does not yet handle a


### PR DESCRIPTION
## Summary

Tiny polish on top of #2130. The seed wrote 10 ContentAssertion rows but didn't pass `teachMethod` — the per-subject methods breakdown then bucketed all 10 under "unassigned" (visible on hf_sandbox post-#2130: `bySubject[0].methods[0]: { teachMethod: "unassigned", count: 10 }`).

All three categories the seed emits (`skill_framework`, `session_flow`, `teaching_rule`) are members of `INSTRUCTION_CATEGORIES`, so `categoryToTeachMethod()` short-circuits to `"tutor_instruction"` per the #605 guard. Stamped at create-time on every new row.

## Self-heal for existing hf_sandbox rows

`saveAssertions` dedups by `contentHash`, so the 10 existing rows (written by #2130 with `teachMethod: null`) would never be rewritten by future seed runs. Added a one-line `updateMany` step:

```ts
WHERE sourceId = <ielts-source>
  AND teachMethod IS NULL
  AND category IN (skill_framework, session_flow, teaching_rule)
SET teachMethod = "tutor_instruction"
```

Idempotent (next runs touch zero rows). No manual cleanup needed.

## Verified by

- `npx vitest run tests/lib/seed-ielts-fixture.test.ts` → 11/11 green
- `npx tsc --noEmit` → 38 errors (baseline 39, -1) — zero in changed file
- `npx eslint apps/admin/prisma/seed-ielts-course.ts` → 0 errors; 2 pre-existing `any` warnings on lines 382+384, untouched
- Pre-fix live state on hf_sandbox: `curl /api/courses/20b21160-…/content-breakdown` → `bySubject[0].methods[0]: { teachMethod: "unassigned", count: 10 }`
- `categoryToTeachMethod` short-circuit verified at `lib/content-trust/resolve-config.ts:1647-1654` (INSTRUCTION_CATEGORIES → "tutor_instruction" regardless of intent arg)

## Test plan

- [x] Vitest green locally
- [x] tsc + eslint clean
- [ ] Post-merge: re-run IELTS seed on hf-dev VM (`npm run seed:ielts`)
- [ ] Post-merge: `curl /api/courses/<id>/content-breakdown` → `bySubject[0].methods[0].teachMethod === "tutor_instruction"`, no longer "unassigned"

Refs #2125 (post-PR2 polish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)