### PR TITLE
feat(content): #2132 — course-ref upload auto-triggers extraction + closes wizard I1 gap

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/course-reference/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/course-reference/route.ts
@@ -88,10 +88,14 @@ const PostBodySchema = z.object({
  * @tags courses, content-trust
  * @description Upload a course-reference markdown document for a course. Creates
  *   a `ContentSource` with `documentType: "COURSE_REFERENCE"`, links it to the
- *   playbook via `PlaybookSource`, and bumps `Playbook.composeInputsUpdatedAt`
- *   so the Preview lens (#1268) sees the staleness signal. Assertion extraction
- *   is left to the existing re-extract flow — this route only persists the raw
- *   markdown and signals staleness.
+ *   playbook via `PlaybookSource`, links to the playbook's primary subject via
+ *   `SubjectSource` (so subjectSourceId-scoped extraction can run — #2132 closes
+ *   the I1 invariant gap), bumps `Playbook.composeInputsUpdatedAt` so the
+ *   Preview lens (#1268) sees the staleness signal, and fire-and-forgets a
+ *   background extraction job so the Content tab populates without an operator
+ *   click. Auto-trigger respects the extract route's cache gate — re-uploads
+ *   of identical content skip with `skipped: true` (no LLM cost). Manual
+ *   "Re-extract" still works as before (passes `replace: true`).
  *
  *   Idempotent on the same content hash: re-uploading the same markdown reuses
  *   the existing source and only re-links if necessary.
@@ -99,7 +103,7 @@ const PostBodySchema = z.object({
  * @pathParam courseId string - Playbook UUID
  * @bodyParam markdown string - Course-reference markdown body
  * @bodyParam name string (optional) - Display name (defaults to "Course Reference — <playbook.name>")
- * @response 200 { ok, contentSourceId, name, isNew }
+ * @response 200 { ok, contentSourceId, name, isNew, extraction: { jobId, skipped, reason } | null }
  * @response 400 { ok: false, error, issues? }
  * @response 404 { ok: false, error: "Course not found" }
  */
@@ -192,6 +196,37 @@ export async function POST(
       },
     });
 
+    // #2132 — link the ContentSource to the playbook's primary subject so the
+    // background extraction can pass subjectSourceId on every ContentAssertion
+    // write (closes ENTITIES.md §6 I1 — without this, assertions would land
+    // with subjectSourceId=null and leak cross-course through SectionDataLoader's
+    // strict-FK filter). Best-effort: if the playbook has no subject linked yet,
+    // skip the SubjectSource creation; extraction can still run but won't be
+    // subject-scoped until a subject is attached.
+    const playbookSubject = await prisma.playbookSubject.findFirst({
+      where: { playbookId: courseId },
+      select: { subjectId: true },
+    });
+    let subjectSourceId: string | undefined;
+    if (playbookSubject) {
+      const subjectSource = await prisma.subjectSource.upsert({
+        where: {
+          subjectId_sourceId: {
+            subjectId: playbookSubject.subjectId,
+            sourceId: contentSourceId,
+          },
+        },
+        update: {},
+        create: {
+          subjectId: playbookSubject.subjectId,
+          sourceId: contentSourceId,
+          tags: ["course-reference", "upload-route"],
+        },
+        select: { id: true },
+      });
+      subjectSourceId = subjectSource.id;
+    }
+
     // #1268 staleness gap — a fresh course-reference changes what AI teaches
     // (assertions, instructions, session_overrides) once re-extract runs.
     // Bump the playbook's staleness signal so Preview flips immediately,
@@ -199,11 +234,59 @@ export async function POST(
     // assertions on the next call. Best-effort.
     await bumpPlaybookComposeTimestamp(courseId);
 
+    // #2132 — auto-trigger background extraction so the Content tab populates
+    // without an operator click. Internal HTTP call to the extract route
+    // (rather than calling runBackgroundExtraction directly) preserves the
+    // cache gate, the 409 concurrent-extraction guard, the cap enforcement,
+    // and the LO-link reconciliation — all in one tested place. Auto-trigger
+    // does NOT pass replace=true; the cache gate skips already-extracted
+    // sources with zero LLM cost. See `flow-wizard-upload.md` for the chain.
+    let extraction:
+      | { jobId: string | null; skipped: boolean; reason?: string }
+      | null = null;
+    try {
+      const baseUrl = req.nextUrl.origin;
+      const cookie = req.headers.get("cookie") || "";
+      const extractRes = await fetch(
+        `${baseUrl}/api/content-sources/${contentSourceId}/extract`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json", cookie },
+          body: JSON.stringify(
+            playbookSubject ? { subjectId: playbookSubject.subjectId } : {},
+          ),
+        },
+      );
+      const extractData = await extractRes.json().catch(() => null);
+      if (extractData?.ok) {
+        extraction = {
+          jobId: extractData.jobId ?? null,
+          skipped: extractData.skipped === true,
+          reason: extractData.skipped ? (extractData.reason as string) : undefined,
+        };
+      } else if (extractData?.error) {
+        console.warn(
+          `[course-reference] extract trigger returned error for ${contentSourceId}:`,
+          extractData.error,
+        );
+      }
+    } catch (extractErr) {
+      // Non-fatal: upload succeeded, extraction can be retried via the Re-extract
+      // button. Surface in logs only — the response still carries 200 because
+      // the source is saved + the staleness bump fired.
+      console.warn(
+        `[course-reference] extract trigger failed for ${contentSourceId}:`,
+        extractErr,
+      );
+    }
+
     return NextResponse.json({
       ok: true,
       contentSourceId,
       name: displayName,
       isNew,
+      subjectSourceId: subjectSourceId ?? null,
+      extraction,
     });
   } catch (err) {
     console.error("[course-reference] POST error:", err);

--- a/apps/admin/lib/chat/wizard-tool-executor/tools/_pedagogy-assertions.ts
+++ b/apps/admin/lib/chat/wizard-tool-executor/tools/_pedagogy-assertions.ts
@@ -14,10 +14,15 @@
  * `app/api/courses/[courseId]/course-reference/route.ts:145-177` so the
  * two pedagogy-write surfaces stay in lockstep.
  *
+ * #2132 (2026-06-20) — closed the `subjectSourceId` I1 gap on this
+ * surface. Every `ContentAssertion.create` now passes the SubjectSource
+ * id captured from `prisma.subjectSource.create` above, so
+ * SectionDataLoader's strict-FK filter on `curriculumAssertions` does
+ * not leak rows cross-course inside the shared Subject (ENTITIES.md §6
+ * I1). Sibling gaps on `app/api/content-sources/route.ts` and the
+ * course-pack ingest path are still open — separate concern.
+ *
  * Out of scope for #1545:
- *   - `subjectSourceId` is NOT set here. Same pre-existing gap as
- *     `app/api/content-sources/route.ts` and the course-pack ingest
- *     path; tracked separately, not introduced by this fix.
  *   - Backfill of historical wizard-created courses that never received
  *     pedagogy assertions — a separate ops concern (see PR body for
  *     the live count probe).
@@ -89,8 +94,9 @@ export async function createPedagogyAssertionsFromCourseRef(
     select: { id: true },
   });
 
-  await prisma.subjectSource.create({
+  const subjectSource = await prisma.subjectSource.create({
     data: { subjectId, sourceId: refSource.id },
+    select: { id: true },
   });
 
   await upsertPlaybookSource(playbookId, refSource.id, {
@@ -102,6 +108,12 @@ export async function createPedagogyAssertionsFromCourseRef(
       data: {
         ...row,
         sourceId: refSource.id,
+        // #2132 — ENTITIES.md §6 I1: every ContentAssertion write MUST
+        // pass subjectSourceId so SectionDataLoader's strict-FK filter
+        // on `curriculumAssertions` scopes correctly. Pre-#2132 this
+        // field was null and assertions leaked cross-course inside the
+        // shared Subject.
+        subjectSourceId: subjectSource.id,
         // Course-reference assertions are teacher-authored — bias the
         // LO-link confidence to 1.0 so the linker treats them as
         // high-confidence anchors (per `reconcile-lo-linkage.ts`

--- a/apps/admin/tests/api/staleness-bumps-1268.test.ts
+++ b/apps/admin/tests/api/staleness-bumps-1268.test.ts
@@ -61,6 +61,15 @@ const {
     },
     playbookSubject: {
       upsert: vi.fn(),
+      // #2132 — course-reference POST now looks up the primary subject to
+      // create a SubjectSource link before triggering extraction (closes
+      // I1 invariant). Tests default to "no primary subject linked" so
+      // the upload path skips the SubjectSource upsert; tests that care
+      // can override per-case.
+      findFirst: vi.fn().mockResolvedValue(null),
+    },
+    subjectSource: {
+      upsert: vi.fn().mockResolvedValue({ id: "ss-1" }),
     },
     $transaction: vi.fn(async (fn: unknown) => {
       // Two transaction shapes are exercised here:

--- a/apps/admin/tests/lib/chat/wizard-tool-executor/pedagogy-assertions.test.ts
+++ b/apps/admin/tests/lib/chat/wizard-tool-executor/pedagogy-assertions.test.ts
@@ -54,7 +54,10 @@ function row(overrides: Partial<AssertionCreateData> = {}): AssertionCreateData 
 beforeEach(() => {
   vi.clearAllMocks();
   mockContentSourceCreate.mockResolvedValue({ id: "src-1" });
-  mockSubjectSourceCreate.mockResolvedValue({});
+  // #2132 — subjectSource.create now requests `select: { id: true }` so
+  // the helper can pass subjectSourceId on every ContentAssertion write
+  // (closes ENTITIES.md §6 I1). Mock must return a row with an id.
+  mockSubjectSourceCreate.mockResolvedValue({ id: "ss-1" });
   mockContentAssertionCreate.mockResolvedValue({});
   mockUpsertPlaybookSource.mockResolvedValue({});
 });
@@ -90,15 +93,18 @@ describe("createPedagogyAssertionsFromCourseRef — canonical write shape (#1545
       assertionRows: [row()],
     });
 
+    // #2132 — `select: { id: true }` added so the helper can pass
+    // subjectSourceId on each ContentAssertion write (I1 invariant).
     expect(mockSubjectSourceCreate).toHaveBeenCalledWith({
       data: { subjectId: "sub-1", sourceId: "src-1" },
+      select: { id: true },
     });
     expect(mockUpsertPlaybookSource).toHaveBeenCalledWith("pb-1", "src-1", {
       tags: ["course-reference"],
     });
   });
 
-  it("writes ContentAssertion rows with linkConfidence=1.0 + depth=0 (NOT confidence, NOT isActive)", async () => {
+  it("writes ContentAssertion rows with linkConfidence=1.0 + depth=0 + subjectSourceId (NOT confidence, NOT isActive)", async () => {
     await createPedagogyAssertionsFromCourseRef({
       courseName: "Course",
       playbookId: "pb-1",
@@ -110,6 +116,10 @@ describe("createPedagogyAssertionsFromCourseRef — canonical write shape (#1545
     expect(mockContentAssertionCreate).toHaveBeenCalledTimes(2);
     const args0 = mockContentAssertionCreate.mock.calls[0][0];
     expect(args0.data.sourceId).toBe("src-1");
+    // #2132 — every ContentAssertion write MUST set subjectSourceId so
+    // SectionDataLoader's strict-FK filter scopes correctly (ENTITIES.md
+    // §6 I1). Without this, assertions leak cross-course in shared Subjects.
+    expect(args0.data.subjectSourceId).toBe("ss-1");
     expect(args0.data.linkConfidence).toBe(1.0);
     expect(args0.data.depth).toBe(0);
     expect(args0.data.assertion).toBe("First fact");

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -5664,7 +5664,7 @@ Upload a course-reference markdown document for a course. Creates
 
 **Response** `200`
 ```json
-{ ok, contentSourceId, name, isNew }
+{ ok, contentSourceId, name, isNew, extraction: { jobId, skipped, reason } | null }
 ```
 
 **Response** `400`


### PR DESCRIPTION
## Summary

Closes the user-facing gap on **course-tab upload** (the `/x/courses/[id]` Reference upload form): operator uploads a course-ref MD → Content tab populates without a "Re-extract" click.

Also closes the **I1 invariant** gap on `lib/chat/wizard-tool-executor/tools/_pedagogy-assertions.ts:101` (documented gap at line 18-20 since #1545).

The wizard's actual file-upload path (`SourcesPanel → /api/course-pack/ingest` with `nonBlocking:true`) ALREADY auto-triggers extraction end-to-end — that's a separate surface and was never broken. Memory updated at `flow-wizard-upload.md` so the next session/agent finds this in 30 seconds.

## Two commits, one concern each

### Commit 1 — Auto-trigger on course-tab upload + create SubjectSource

After the PlaybookSource upsert:
1. Look up the playbook's primary subject via `playbookSubject.findFirst`
2. If found, upsert `SubjectSource` linking the new ContentSource (so background extraction can pass `subjectSourceId` correctly)
3. Fire-and-forget internal POST to `/api/content-sources/<id>/extract` (no `replace`, so the cache gate skips already-extracted sources)
4. Return `extraction: { jobId, skipped, reason }` in the response

### Commit 2 — Close I1 on `_pedagogy-assertions.ts`

Capture the SubjectSource id via `select: { id: true }`; pass `subjectSourceId` on every `ContentAssertion.create` in the loop. Same shape as the fix landed in PR #2130 for `course-ref-tool-handlers.ts`.

## Your specific concerns — already handled

**"ensure this doesn't run unnecessarily"** — auto-trigger sends NO `replace: true`. Extract route's cache gate at `app/api/content-sources/[sourceId]/extract/route.ts:122-138` skips when `source._count.assertions > 0 && !isExtractionOutdated(extractorVersion)`. Returns `{ skipped: true, reason: "extraction-current" }` with zero LLM cost.

**"if user runs manually after auto-run...what happens?"** — manual "Re-extract" button sends `replace: true`, deletes old assertions, forces re-run. Auto-trigger sees zero collisions because manual + auto take different cache-gate paths.

**Concurrent re-uploads** — 409 guard at `extract/route.ts:256-268` blocks a second extraction on the same source while one is in flight.

**Same MD uploaded twice** — `ContentSource` dedups by `contentHash` at `course-reference/route.ts:145-157`; reuses existing source row.

## Test plan

- [x] `npx vitest run tests/api/staleness-bumps-1268.test.ts tests/lib/chat/wizard-tool-executor/pedagogy-assertions.test.ts` → 20/20 green
- [x] `npx tsc --noEmit` → 38 errors (baseline 39, -1) — none in changed files
- [x] `npx eslint` on changed files → 0 errors
- [ ] Post-merge: upload a course-ref MD via the course-tab Reference form → Content tab populates without Re-extract click
- [ ] Post-merge: re-upload the same MD → response returns `extraction: { skipped: true, reason: "extraction-current" }`
- [ ] Post-merge: click "Re-extract" → still works as before (force-replaces)

## Verified by

* `npx vitest run tests/api/staleness-bumps-1268.test.ts tests/lib/chat/wizard-tool-executor/pedagogy-assertions.test.ts` → 20/20 passed
* `npx tsc --noEmit` → 38 errors total, none in `app/api/courses/[courseId]/course-reference/route.ts` or `lib/chat/wizard-tool-executor/tools/_pedagogy-assertions.ts`
* `npx eslint apps/admin/app/api/courses/[courseId]/course-reference/route.ts apps/admin/lib/chat/wizard-tool-executor/tools/_pedagogy-assertions.ts` → 0 errors
* Code-traced cache gate at `extract/route.ts:122-138` — confirmed skip path for already-current sources
* Code-traced 409 guard at `extract/route.ts:256-268` — confirmed concurrent extraction block
* Confirmed against PR #2130's sibling fix on `course-ref-tool-handlers.ts:248,387` — same shape (capture SubjectSource id via select, pass subjectSourceId on assertion writes)

## Lattice survey

- **Chain Contracts** — no cross-stage boundary touched (this sits BEFORE the extract pipeline; just connects upload to it)
- **Guards** — `ai-to-db-guard.md` honoured (extract route routes through `saveAssertions` chokepoint; we don't bypass)
- **Cascade** — no cascadable knob touched
- **Rules** — `ai-to-db-guard.md` cap+dedup intact via reused route; new `memory/flow-wizard-upload.md` documents the two upload surfaces
- **Coverage** — no Coverage-pillar gate affected

## What this PR does NOT do

- Does NOT add UI polling on the Content tab (PR2 / follow-on — would use `useSourceStatus` to show "Extracting..." + retry-on-failure button)
- Does NOT touch the wizard's `SourcesPanel` upload path (already works)
- Does NOT close I1 on `app/api/content-sources/route.ts` or `course-pack/ingest/route.ts` (sibling gaps; separate concern)

Refs #2132. Closes the course-tab side of the user's wizard-parity ask. UI polling follow-on tracked separately.

## CI Docs Skip

operator-runbook impact: none — wires existing routes together, no new deploy surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)