### PR TITLE
test(lattice): Coverage gates for AuthoredModuleMode + SessionKindString + learner-UI leak (#2135 S4 prep)

### DIFF
--- a/.claude/rules/learner-ui-leak-coverage.md
+++ b/.claude/rules/learner-ui-leak-coverage.md
@@ -1,0 +1,153 @@
+# Learner-UI leak coverage — internal labels must not leak
+
+> Internal-only labels (parameter IDs, criterion names, OUT-NN outcome
+> codes, spec slugs, raw mastery scores) MUST NOT appear as quoted
+> string literals in learner-UI source files. The static-literal
+> Coverage test catches one class of the leak; the runtime SUPERVISE-
+> spec scan (proposed in epic [#2135](https://github.com/WANDERCOLTD/HF/issues/2135) S4 / #2139) catches the
+> complementary runtime-data-flow class.
+>
+> Sibling Coverage-pillar gates:
+> [`mode-ui-coverage.md`](./mode-ui-coverage.md) (type-union ↔ UI
+> consumer presence),
+> [`sessionkind-reader-coverage.md`](./sessionkind-reader-coverage.md)
+> (SessionKind writer + reader),
+> [`registry-consumer-coverage.md`](./registry-consumer-coverage.md)
+> (journey settings storagePath ↔ transform reader),
+> [`parameter-measurement-coverage.md`](./parameter-measurement-coverage.md)
+> (Parameter ↔ measurement spec, link 7),
+> [`parameter-loop-closure.md`](./parameter-loop-closure.md) (measured
+> Parameter ↔ AGGREGATE/ADAPT consumer, link 8).
+>
+> Born of the 2026-06-21 audit + PR #2134 / #1955 live incident: Part 3
+> focus pin shipped showing the IELTS CRITERION label ("Lexical
+> Resource", "Pronunciation", etc.) instead of the technique focus
+> label ("giving reasons" / "structuring an argument" / "handling a
+> challenge" / "expanding an answer") required by the BDD spec
+> (US-P3-01 + HF-IELTS-Pre-Voice-Testing-Checklist.md Unit 4). The
+> criterion is INTERNAL — it's the dimension the adaptive engine
+> measures via Skill scores; the technique is EXTERNAL — what the
+> learner sees and what the tutor frames the session around. The
+> BIG LATTICE MISS: no structural gate separated the two.
+
+## Rule
+
+When you author code that flows data into a learner-UI render dir
+(`components/sim/**`, `app/x/student/**`, `apps/foh/app/**`,
+`apps/foh/components/**`):
+
+1. **Do not hardcode internal-only labels as string literals** in those
+   dirs. If a learner-facing string is needed, source it from a
+   typed union of learner-safe labels (e.g. a `Part3TechniqueFocus`
+   union with values like `"giving reasons"`), NOT from internal
+   identifiers.
+2. **Do not pass values typed as "internal-only" through to render
+   props** without a projection step that maps internal → learner-safe.
+3. **The projection happens at the boundary** — typically in a
+   pipeline stage (REWARD / SUPERVISE / COMPOSE) that reads internal
+   state and writes a learner-safe label to `CallerAttribute` /
+   `PinnedCardContent.focusArea` / similar. The render path reads ONLY
+   the projected value.
+
+## Why the static-literal gate is necessary but not sufficient
+
+This Coverage test catches: **hardcoded internal-only string literals
+in learner-UI source files**. That covers cases like a developer
+hardcoding `label: "Lexical Resource"` directly in a SimChat component.
+
+It does NOT catch: **values flowing through props from internal
+sources at runtime**. E.g., `select-pinned-card.ts` reads
+`IELTS_SKILL_LABELS[parameterId]` and stamps it on
+`PinnedCardContent.focusArea` → the SimChat render then reads the
+stored value. The literal "Lexical Resource" never appears in the
+SimChat source — it flows through.
+
+The runtime side is owned by epic [#2135](https://github.com/WANDERCOLTD/HF/issues/2135) S4 (#2139) — a
+SUPERVISE-stage spec that scans the composed prompt and learner-facing
+projection at compose-time for the same leak patterns. The two gates
+together close the loop:
+
+| Layer | Catches | Gate |
+|---|---|---|
+| Build-time | Hardcoded internal-only literals in learner-UI source | This Coverage test |
+| Runtime | Internal values flowing through props or composed-prompt content | SUPERVISE-spec (#2139) |
+| Type-system (future) | Internal-only typed values passed where learner-safe expected | Branded types / `@internalOnly` JSDoc + ESLint |
+
+## How matching works
+
+For each label in every set in `INTERNAL_LABEL_REGISTRY`:
+- Concatenate source from `LEARNER_UI_DIRS` (excluding `.test.ts` files).
+- Regex check: does `"<label>"` or `'<label>'` appear in the source?
+- Match → leak. Listed in exempt → exempt. Else → clean.
+
+Ratchet pins both the leak count AND the exempt count. Either
+direction of drift fails CI.
+
+## Course-agnostic by design
+
+`INTERNAL_LABEL_REGISTRY` is a Record where each key is a course or
+category name and each value is `{ description, labels[] }`. Add a new
+course → add a key. The test auto-walks the union. No course-specific
+test edits beyond the registry entry.
+
+Today's registry at the test's birth (2026-06-21):
+
+| Set key | Description | Labels |
+|---|---|---|
+| `IELTS_CRITERIA` | Scoring criteria — internal axes the adaptive engine measures; learner sees technique focus (Part 3) or overall band (Mock Results), never these directly during normal session UI | "Fluency and Coherence", "Lexical Resource", "Grammatical Range and Accuracy", "Pronunciation" |
+| `IELTS_CRITERION_SLUGS` | Internal parameter IDs / slug forms — engine-side addressing | `skill_*` slugs for the same 4 criteria |
+
+Future: `CIO_CTO_COMPETENCIES`, `KS2_SATS_STRANDS`, `OCEAN_TRAITS`, etc.
+
+## Today's exemptions
+
+| Key | Reason |
+|---|---|
+| `IELTS_CRITERIA:Lexical Resource` | Mock Results screen sanctioned per BDD US-Mock-05 — per-criterion bands shown only on Results screen, not in pin/session UI |
+| `IELTS_CRITERIA:Pronunciation` | Same — Mock Results screen sanctioned |
+
+The Mock Results screen is explicitly defined in
+HF-IELTS-Pre-Voice-Testing-Checklist Unit 5 + BDD US-Mock-05 as the
+ONE learner-facing surface that displays per-criterion scores. Both
+exempt entries point at the same FOH stub
+(`apps/foh/app/api/scores/route.ts`) that serves that screen.
+
+## When NOT to apply
+
+- The Mock Results screen surface — sanctioned, exempt-with-reason.
+- Operator-only diagnostic panels embedded inside a `components/sim/`
+  file but gated by role — exempt with reason explaining the gate.
+- Test fixtures — `.test.ts` / `.test.tsx` files are excluded by the
+  walker.
+
+## When adding a new course
+
+Author checklist (same PR):
+
+1. Open `tests/lib/sim-chat/learner-ui-leak-coverage.test.ts`.
+2. Add a new key to `INTERNAL_LABEL_REGISTRY` with `description`
+   (>30 chars) and `labels[]` (the literal strings that should never
+   leak from this course's internal dimensions).
+3. Run the test. If new leaks appear, either:
+   - Move the offending label out of learner-UI dirs (preferred), OR
+   - Add to `LEARNER_UI_LEAK_EXEMPT` with a substantive reason +
+     bump `EXPECTED_EXEMPT_COUNT`.
+4. If sanctioned learner-surface (e.g., a Results screen for the new
+   course), exempt with reason citing the BDD spec that sanctions it.
+
+## When deleting a label
+
+1. Remove from the registry (or the exempt list).
+2. Drop `EXPECTED_EXEMPT_COUNT` if needed.
+3. Run the test — the non-stale-exempt assertion catches drift.
+
+## Related
+
+- [`tests/lib/sim-chat/learner-ui-leak-coverage.test.ts`](../../apps/admin/tests/lib/sim-chat/learner-ui-leak-coverage.test.ts) — this test
+- [`apps/admin/lib/curriculum/derive-focus-area.ts`](../../apps/admin/lib/curriculum/derive-focus-area.ts) — `IELTS_SKILL_LABELS` source (the labels this gate keeps OUT of learner-UI dirs)
+- [`apps/foh/app/api/scores/route.ts`](../../apps/foh/app/api/scores/route.ts) — Mock Results screen FOH stub (the 2 exemptions point here)
+- Epic [#2135](https://github.com/WANDERCOLTD/HF/issues/2135) — IELTS scoring as canonical MEASURE specs (the architectural substrate; #2139 lands the runtime SUPERVISE-spec gate)
+- Story #1955 (PR #2134, merged 2026-06-20) — the live incident showing the criterion-leaking-to-pin failure mode this Coverage gate exists to prevent recurring
+- [`.claude/rules/mode-ui-coverage.md`](./mode-ui-coverage.md) — sibling Coverage gate (UI consumer presence)
+- [`.claude/rules/sessionkind-reader-coverage.md`](./sessionkind-reader-coverage.md) — sibling Coverage gate (SessionKind writer/reader)
+- BDD source: HF-IELTS-Pre-Voice-Testing-Checklist.md (Unit 4 US-P3-01 + Unit 5 US-Mock-05) + HF IELTS — BDD Stories (US-P3 + US-Mock)

--- a/.claude/rules/mode-ui-coverage.md
+++ b/.claude/rules/mode-ui-coverage.md
@@ -1,0 +1,148 @@
+# Mode UI coverage — type-union value ↔ UI consumer pairing
+
+> Every `AuthoredModuleMode` value in
+> `apps/admin/lib/types/json-fields.ts` MUST have a consumer on each
+> of three axes: **teaching** (compose-side directive or default),
+> **adminUI** (badge / icon / inspector / pill), and **learnerUI**
+> (SIM shell, FOH pre-call card, ExamModeShell mount, or chat-feed
+> reskin). Modes that legitimately don't need a per-axis consumer
+> (because they ARE the default — `tutor` baseline conversational,
+> `mixed` = tutor + assessment touches) live in `MODE_AXIS_EXEMPT`
+> with a >20-char reason.
+>
+> Sibling Coverage-pillar gates:
+> [`registry-consumer-coverage.md`](./registry-consumer-coverage.md)
+> (`JOURNEY_SETTINGS` storagePath → transform reader),
+> [`sessionkind-reader-coverage.md`](./sessionkind-reader-coverage.md)
+> (`SessionKindString` value → writer + reader),
+> [`parameter-coverage.md`](./parameter-coverage.md) (Parameter row →
+> runtime consumer),
+> [`tier-visibility-coverage.md`](./tier-visibility-coverage.md)
+> (route response → tier-redactor).
+>
+> Born of the 2026-06-21 audit which surfaced the producer-only
+> failure mode: PRs #2077 / #2081 / #2090 closed stories #2010 / #2011
+> / #2013 with COMPLETED state after wiring the type union extension
+> + compose directives + admin badge icons. The audit confirmed all
+> three were on `origin/main`. But for `quiz` and `mock-exam`, NO
+> learner-facing UI consumer ever shipped — the learner experienced
+> an identical SimChat session whether the module's mode was `tutor`,
+> `mixed`, `quiz`, or `mock-exam`. The Coverage matrix was incomplete
+> at the consumer surface that mattered most.
+
+## Rule
+
+When you add or modify a value in the `AuthoredModuleMode` type union
+at `apps/admin/lib/types/json-fields.ts`:
+
+1. **Add coverage rows for the new value** in
+   `apps/admin/tests/lib/sim-chat/mode-ui-coverage.test.ts` —
+   specifically add the literal to `AUTHORED_MODULE_MODE_VALUES`. The
+   source-vs-matrix sanity test fires immediately if you don't.
+2. **Decide the consumer plan for each of the three axes:**
+   - **teaching** (compose-side): does this mode need a compose-time
+     directive (like `resolveModuleQuizDirective` /
+     `resolveModuleMockExamDirective`)? OR is it covered by the
+     baseline tutor stack (like `tutor` and `mixed`)? OR via a
+     spec-slug template runner (like `examiner`)? Wire the
+     consumer OR add to `MODE_AXIS_EXEMPT` with reason.
+   - **adminUI**: at least one `app/x/**` or `components/**` file
+     should branch on `.mode === "<value>"` to render a distinct
+     badge / icon / inspector. Tutor today is the implicit fallback
+     in `ModePill` / `ModeIcon` ternary chains; if your mode is
+     similarly implicit, exempt with reason.
+   - **learnerUI**: does the learner experience anything different?
+     A SimChat reskin? A specialised shell (like `ExamModeShell` for
+     `examiner`)? A pre-call context card? Wire OR exempt.
+3. **If you can't ship a consumer in the same PR**, add to
+   `MODE_AXIS_EXEMPT` with a reason describing WHY the cell is
+   intentionally producer-only AND bump `EXPECTED_EXEMPT_COUNT`. The
+   ratchet test catches the bump as a conscious decision.
+
+## How matching works
+
+For each (mode, axis) cell, the test walks the axis's consumer
+directories and looks for the mode literal in a comparison against
+`mode` / `.mode`:
+
+```
+mode === "<value>"
+mode !== "<value>"
+.mode === "<value>"
+.mode !== "<value>"
+```
+
+Switch-case branches (`case "<value>":`) are **deliberately NOT
+matched** — they may legitimately exist for unrelated string literals
+(e.g. `AudienceId = "mixed"` in
+`lib/prompt/composition/transforms/audience.ts` is NOT a mode
+consumer). If your mode is consumed via a switch, rewrite the branch
+to use an explicit `=== ` check OR list the cell in `MODE_AXIS_EXEMPT`
+with a one-line reason.
+
+## Axis consumer-directory map
+
+| Axis | Directories |
+|---|---|
+| teaching | `lib/prompt/composition/transforms`, `lib/prompt/composition/loaders`, `lib/prompt/composition`, `lib/curriculum` |
+| adminUI | `app/x`, `components/modules-tab`, `components/journey-tab` |
+| learnerUI | `components/sim`, `app/x/student`, `apps/foh/app`, `apps/foh/components` |
+
+## Today's incumbent matrix (2026-06-21 baseline)
+
+| Mode | teaching | adminUI | learnerUI |
+|---|---|---|---|
+| `tutor` | exempt-default | exempt-fallback | exempt-default |
+| `mixed` | exempt-default | covered | exempt-default |
+| `examiner` | exempt-template | covered | covered (`ExamModeShell`) |
+| `quiz` | covered (`resolveModuleQuizDirective`) | covered (ModePill icon) | **gap** |
+| `mock-exam` | covered (`resolveModuleMockExamDirective`) | covered (ModePill icon) | **gap** |
+
+Ratchet baseline: `EXPECTED_EXEMPT_COUNT = 6`, `EXPECTED_GAP_COUNT = 2`.
+
+## Shell reuse pattern (operator-preferred)
+
+When a new mode shares behaviour with an existing one (e.g.
+`mock-exam` is conceptually examiner-mode with a different persona +
+visual aesthetic), the preferred shape is:
+
+1. Extend the existing shell's mount-gate to accept both modes:
+   ```ts
+   // components/sim/ExamModeShell.tsx
+   export function shouldMountExamModeShell(
+     module: Pick<AuthoredModule, "mode">,
+     sessionTerminal: boolean,
+   ): boolean {
+     return (
+       (module.mode === "examiner" || module.mode === "mock-exam") &&
+       sessionTerminal === true
+     );
+   }
+   ```
+2. Drive the colour theme + mode-pill copy from the mode literal
+   inside the shell — same JSX, themed differently per mode.
+3. Both `examiner` and `mock-exam` cells become `covered`; no new
+   shell file required.
+
+This counts as `covered` (real `.mode === "X"` reader in the
+learnerUI dir). The Coverage test doesn't distinguish "covered-own"
+from "covered-shared" today — that's metadata for the operator to
+track in the rule file's matrix.
+
+## When NOT to apply
+
+This rule covers `AuthoredModuleMode`. The same generic shape applies
+to other type unions where producer-only failure would surprise
+learners — e.g. `SessionKindString` (covered by
+[`sessionkind-reader-coverage.md`](./sessionkind-reader-coverage.md)).
+Each surface gets its own paired test + rule.
+
+## Related
+
+- [`tests/lib/sim-chat/mode-ui-coverage.test.ts`](../../apps/admin/tests/lib/sim-chat/mode-ui-coverage.test.ts) — the test
+- [`apps/admin/lib/types/json-fields.ts`](../../apps/admin/lib/types/json-fields.ts) — `AuthoredModuleMode` source-of-truth
+- [`apps/admin/lib/prompt/composition/transforms/instructions.ts`](../../apps/admin/lib/prompt/composition/transforms/instructions.ts) — `resolveModuleQuizDirective` + `resolveModuleMockExamDirective`
+- [`apps/admin/components/sim/ExamModeShell.tsx`](../../apps/admin/components/sim/ExamModeShell.tsx) — `shouldMountExamModeShell` (examiner-only today; mock-exam shell-reuse pending)
+- [`.claude/rules/sessionkind-reader-coverage.md`](./sessionkind-reader-coverage.md) — sibling Coverage-pillar test
+- [`.claude/rules/registry-consumer-coverage.md`](./registry-consumer-coverage.md) — sibling Coverage-pillar test (storagePath surface)
+- Epic [#2009](https://github.com/WANDERCOLTD/HF/issues/2009) — CIO/CTO trio variant mechanics (closing PRs #2077 / #2081 / #2090 exposed this gap)

--- a/.claude/rules/sessionkind-reader-coverage.md
+++ b/.claude/rules/sessionkind-reader-coverage.md
@@ -1,0 +1,131 @@
+# SessionKind reader coverage — writer + reader pairing
+
+> Every `SessionKindString` value in
+> `apps/admin/lib/voice/session-rules.ts` MUST have BOTH a writer
+> (at least one code path creates a `Session` with that kind) AND a
+> reader (at least one business-logic surface branches on the kind).
+> Type-only ghosts — values declared in the union with no writer and
+> no business-logic reader, only the type-exhaustiveness switch case
+> — must either be implemented OR removed from the union.
+>
+> Sibling Coverage-pillar gates:
+> [`mode-ui-coverage.md`](./mode-ui-coverage.md)
+> (`AuthoredModuleMode` value → 3-axis UI consumer),
+> [`registry-consumer-coverage.md`](./registry-consumer-coverage.md)
+> (`JOURNEY_SETTINGS` storagePath → transform reader),
+> [`parameter-coverage.md`](./parameter-coverage.md) (Parameter row →
+> runtime consumer).
+>
+> Born of the 2026-06-21 audit which found `ASSESSMENT` and
+> `TEXT_CHAT` declared on epic #1338's unified Session model alongside
+> `ENROLLMENT` / `VOICE_CALL` / `SIM_CALL`, with full counterFlags
+> branches in `session-rules.ts::initialCounterFlags`. But no code
+> path ever calls `createSession({ kind: "ASSESSMENT" })` or
+> `createSession({ kind: "TEXT_CHAT" })`. Both are type-only ghosts.
+> The convention "if it's in the union it must be reachable" was not
+> structurally enforced — this gate closes that.
+
+## Rule
+
+When you add a value to `SessionKindString`:
+
+1. **Add the value to `SESSION_KIND_VALUES`** in
+   `apps/admin/tests/lib/voice/sessionkind-reader-coverage.test.ts`.
+   The source-vs-matrix sanity test fires if the union diverges from
+   the test data.
+2. **Implement the writer** — at least one code path must
+   `createSession({ kind: "<value>", ... })` (or equivalent
+   data/where shape on `prisma.session`). If you can't ship the
+   writer in the same PR, list the cell in `SESSIONKIND_AXIS_EXEMPT`
+   with a reason describing what's pending (e.g., "reserved for
+   epic #X").
+3. **Implement the reader** — at least one business-logic surface
+   must branch on the kind value via `=== "<value>"` or
+   `kind: "<value>"` (Prisma where/data field). The
+   type-exhaustiveness switch at
+   `session-rules.ts::initialCounterFlags` does NOT count — it's type
+   plumbing, not consumption.
+4. **Bump ratchets** if you legitimately add an exemption. The test
+   fails on ratchet drift.
+
+When you REMOVE a value, also remove its rows from the test
+matrix and the exempt list, plus drop the ratchet counts accordingly.
+
+## How matching works
+
+For each (kind, axis) cell:
+
+**Writer match** — kind appears as the value of a `kind:` field:
+```
+kind: "<value>"
+kind = "<value>"
+kind:"<value>"
+kind="<value>"
+```
+
+**Reader match** — kind appears in any of:
+```
+kind === "<value>"
+kind !== "<value>"
+.kind === "<value>"
+.kind !== "<value>"
+kind: "<value>"   (Prisma where { kind: "X" })
+```
+
+Switch-case branches (`case "<value>":`) are **deliberately NOT
+matched** — every union member appears as a case label in the
+type-exhaustiveness switch at `lib/voice/session-rules.ts`, which is
+not a business-logic consumer. Ghost kinds will pass type-checking
+but fail this Coverage test.
+
+## Axis source-directory map
+
+| Axis | Directories |
+|---|---|
+| writer | `lib/voice`, `lib/intake`, `lib/test-harness`, `app/api`, `lib/curriculum` |
+| reader | `lib/voice`, `lib/pipeline`, `lib/curriculum`, `lib/prompt`, `app/api`, `app/x`, `components` |
+
+## Today's incumbent matrix (2026-06-21 baseline)
+
+| Kind | writer | reader |
+|---|---|---|
+| `ENROLLMENT` | covered | covered (`resolve-used-prompt.ts`, `stamp-enrollment-session-prompt.ts`) |
+| `VOICE_CALL` | covered (voice webhooks) | covered (`poll-stale-calls.ts`, pipeline runners) |
+| `SIM_CALL` | covered (`sim-runner.ts`, `/api/callers/[id]/calls`) | covered |
+| `ASSESSMENT` | **exempt-ghost** | **exempt-ghost** |
+| `TEXT_CHAT` | **exempt-ghost** | **exempt-ghost** |
+
+Ratchet baseline: `EXPECTED_EXEMPT_COUNT = 4`, `EXPECTED_GAP_COUNT = 0`.
+
+## Ghost-kind resolution paths
+
+For each ghost (ASSESSMENT, TEXT_CHAT), one of these must happen:
+
+1. **Implement** — wire a writer in the appropriate intake / harness
+   route, wire a reader in the appropriate consumer dir. Drop the
+   exempt entries; drop the ratchet by 2 each.
+2. **Remove from the union** — if no use case materialises, delete
+   the value from `SessionKindString`, remove its case branch from
+   `initialCounterFlags` (the exhaustive switch enforces this — the
+   `const exhaustive: never = kind` line will fire on the next member
+   added). Drop the exempt entries; drop the ratchet by 2 each.
+
+The decision is operator-level, not coder-level. The exempt entries
+carry the reason so the decision is auditable; the ratchet pins the
+count so the question can't be silently deferred forever.
+
+## When NOT to apply
+
+This rule covers `SessionKindString` specifically. Other Session-
+level enums (e.g. `Session.status`, `Session.outcome`) have their own
+type-exhaustiveness consumers in `session-rules.ts` and don't carry
+the ghost risk because every status/outcome has a business-logic
+path (status flips drive UI rendering; outcomes feed counter flags).
+
+## Related
+
+- [`tests/lib/voice/sessionkind-reader-coverage.test.ts`](../../apps/admin/tests/lib/voice/sessionkind-reader-coverage.test.ts) — the test
+- [`apps/admin/lib/voice/session-rules.ts`](../../apps/admin/lib/voice/session-rules.ts) — `SessionKindString` source-of-truth + exhaustive switch
+- [`apps/admin/lib/voice/create-session.ts`](../../apps/admin/lib/voice/create-session.ts) — canonical Session writer (epic #1338)
+- [`.claude/rules/mode-ui-coverage.md`](./mode-ui-coverage.md) — sibling Coverage-pillar test
+- Epic [#1338](https://github.com/WANDERCOLTD/HF/issues/1338) — unified Session model (origin of the 5-value union)

--- a/apps/admin/tests/lib/sim-chat/learner-ui-leak-coverage.test.ts
+++ b/apps/admin/tests/lib/sim-chat/learner-ui-leak-coverage.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Learner-UI leak coverage — Lattice 5th-pillar Coverage test.
+ *
+ * **What this test pins:**
+ *  Internal-only labels and identifiers (parameter IDs, criterion
+ *  labels, OUT-NN outcome codes, spec slugs, raw mastery scores) MUST
+ *  NOT appear as literal strings in any source file under the
+ *  **learner-UI render dirs**: `components/sim/**`, `app/x/student/**`,
+ *  `apps/foh/**`.
+ *
+ *  This catches the "internal label leaked to learner-visible surface"
+ *  failure mode. Live incident: PR #2134 (#1955) — merged 2026-06-20 —
+ *  passes `IELTS_SKILL_LABELS["skill_lexical_resource_lr"] = "Lexical
+ *  Resource"` as the value of `PinnedCardContent.focusArea` AND
+ *  references "criterion" in the tutor directive. The BDD spec
+ *  (HF-IELTS-Pre-Voice-Testing-Checklist.md, US-P3-01) requires the
+ *  learner pin show only ONE of the 4 technique labels (`giving
+ *  reasons` / `structuring an argument` / `handling a challenge` /
+ *  `expanding an answer`) — never the criterion name, never the
+ *  parameter ID, never the score.
+ *
+ *  This test is the structural backstop. The runtime backstop is a
+ *  SUPERVISE-stage spec (proposed in ADR
+ *  `docs/decisions/2026-06-21-session-focus-rewardspec-substrate.md`)
+ *  that scans the composed prompt at compose-time for the same leak
+ *  patterns. The two layers together close the loop.
+ *
+ * **Course-agnostic by design:**
+ *  Each course registers its internal-only label set via
+ *  `INTERNAL_LABEL_REGISTRY`. The test walks the union of all sets
+ *  and fails on any literal occurrence in learner-UI dirs. New course
+ *  → add its set to the registry. No course-specific test edits
+ *  beyond the registry entry.
+ *
+ * **How matching works:**
+ *  - Concatenate source from `LEARNER_UI_DIRS` (excluding `.test.ts`).
+ *  - For each label in every internal set, check if it appears as a
+ *    quoted string literal (`"X"` or `'X'`) anywhere in the source.
+ *  - Match → leak. Listed in exempt → exempt. Else → gap (test fails).
+ *
+ *  Exempt entries carry a substantive reason + are pinned by a ratchet.
+ *  The incumbent leak count at this test's birth (2026-06-21) is
+ *  recorded in `EXPECTED_LEAK_COUNT`. The leak count can only DROP.
+ *
+ * **How to fix a failure:**
+ *  - "New leak appeared": the label was added to a learner-UI render
+ *    path. Either move the label assignment to a server-side projection
+ *    that maps internal → learner-safe BEFORE the data reaches the
+ *    learner-UI dir, OR add to `LEARNER_UI_LEAK_EXEMPT` with a >20-char
+ *    reason describing the structural constraint.
+ *  - "Incumbent leak cleared": drop `EXPECTED_LEAK_COUNT`.
+ *
+ *  See `.claude/rules/learner-ui-leak-coverage.md` for the durable rule
+ *  + ADR `docs/decisions/2026-06-21-session-focus-rewardspec-substrate.md`
+ *  for the architectural framing.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const REPO_ADMIN = resolve(__dirname, "..", "..", "..");
+const REPO_ROOT = resolve(REPO_ADMIN, "..", "..");
+
+// ────────────────────────────────────────────────────────────
+// Internal-label registry — course-agnostic, extensible.
+//
+// Each course registers a named set of labels that are internal-only:
+// they describe assessment dimensions, parameter axes, or scoring
+// shapes that the learner is NOT supposed to see directly. The
+// adaptive engine reads them; the composed prompt + UI render
+// PROJECTIONS of them (mode pills, technique labels, band names) —
+// never the raw label.
+//
+// To extend: add a new key to INTERNAL_LABEL_REGISTRY. The walk
+// auto-picks it up. No further test edits needed.
+// ────────────────────────────────────────────────────────────
+
+interface InternalLabelSet {
+  /** Why these labels are internal-only. */
+  description: string;
+  /** The labels (as they appear in source — exact case + spacing). */
+  labels: readonly string[];
+}
+
+const INTERNAL_LABEL_REGISTRY: Record<string, InternalLabelSet> = {
+  IELTS_CRITERIA: {
+    description:
+      "IELTS scoring criteria — internal scoring axes. The learner sees the technique focus label (Part 3) or the overall band (Mock Results), never these criterion names directly during normal session UI. Source: lib/curriculum/derive-focus-area.ts::IELTS_SKILL_LABELS.",
+    labels: [
+      "Fluency and Coherence",
+      "Lexical Resource",
+      "Grammatical Range and Accuracy",
+      "Pronunciation",
+    ],
+  },
+  IELTS_CRITERION_SLUGS: {
+    description:
+      "IELTS criterion slug form — these are internal parameter IDs / slugs the engine uses to address skill scores. Never appear in learner-rendered text.",
+    labels: [
+      "skill_fluency_and_coherence_fc",
+      "skill_lexical_resource_lr",
+      "skill_grammatical_range_and_accuracy_gra",
+      "skill_pronunciation_p",
+    ],
+  },
+  // Future course registrations slot in here. E.g.:
+  // CIO_CTO_COMPETENCIES: { description: "...", labels: [...] }
+  // KS2_SATS_STRANDS: { description: "...", labels: [...] }
+};
+
+// ────────────────────────────────────────────────────────────
+// Learner-UI dirs — where leaks become user-visible.
+// ────────────────────────────────────────────────────────────
+
+const LEARNER_UI_DIRS: string[] = [
+  // SIM / Chat surface mounted in admin app today (the actual learner
+  // experience is the same SimChat surface admin testers exercise).
+  join(REPO_ADMIN, "components", "sim"),
+  // Per-learner views surfaced under the admin /x/student namespace.
+  join(REPO_ADMIN, "app", "x", "student"),
+  // FOH (front-of-house) learner app — separate workspace.
+  join(REPO_ROOT, "apps", "foh", "app"),
+  join(REPO_ROOT, "apps", "foh", "components"),
+];
+
+// ────────────────────────────────────────────────────────────
+// Exempt list — leaks the test consciously accepts (e.g. labels in
+// admin-tester-only diagnostic surfaces that share files with learner
+// UI, or labels in operator-only debug panels embedded in SimChat).
+// Required: >20-char reason. Each entry is keyed `<setKey>:<label>`
+// and pinned by ratchet — count cannot grow.
+// ────────────────────────────────────────────────────────────
+
+interface LeakExemptEntry {
+  reason: string;
+}
+
+type LeakKey = `${keyof typeof INTERNAL_LABEL_REGISTRY}:${string}`;
+
+const LEARNER_UI_LEAK_EXEMPT: Partial<Record<LeakKey, LeakExemptEntry>> = {
+  // BDD US-Mock-05 (HF-IELTS-Pre-Voice-Testing-Checklist.md) explicitly
+  // sanctions the Mock Results screen to display per-criterion scores
+  // (Overall band + FC / LR / GRA / P bands + one strength + one
+  // area-to-work-on). This is the ONLY learner-facing surface where
+  // IELTS criterion labels are allowed; the labels here serve that
+  // screen via apps/foh/app/api/scores/route.ts (FOH stub today,
+  // proxies HF backend in prod). Pin context (Part 3 "Today's focus")
+  // MUST NOT use criterion labels — that's the #1955 leak class
+  // tracked by the runtime SUPERVISE-spec gate (epic #2135 S4) AND
+  // the proposed Part3TechniqueFocus union (separate story).
+  "IELTS_CRITERIA:Lexical Resource": {
+    reason:
+      "Mock Results screen sanctioned per BDD US-Mock-05 — per-criterion bands shown only on Results screen; not in pin/session UI",
+  },
+  "IELTS_CRITERIA:Pronunciation": {
+    reason:
+      "Mock Results screen sanctioned per BDD US-Mock-05 — per-criterion bands shown only on Results screen; not in pin/session UI",
+  },
+};
+
+/** Ratchet — total incumbent leaks beyond exempt. The #1955-class
+ *  runtime leak (values flowing through props from internal sources
+ *  like `derive-focus-area.ts::IELTS_SKILL_LABELS` into
+ *  `PinnedCardContent.focusArea`) does NOT fire this static-literal
+ *  gate — it requires the runtime SUPERVISE-spec scan filed under
+ *  epic #2135 S4 (#2139). This gate catches the complementary class:
+ *  internal-only labels hardcoded as string literals in learner-UI
+ *  source files. */
+const EXPECTED_LEAK_COUNT = 0;
+
+/** Ratchet — exempt list size. 2 incumbents at launch (both Mock
+ *  Results screen labels). */
+const EXPECTED_EXEMPT_COUNT = 2;
+
+// ────────────────────────────────────────────────────────────
+// Source-walk
+// ────────────────────────────────────────────────────────────
+
+function walkSource(dir: string): string[] {
+  const out: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    const full = join(dir, e);
+    let st;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      if (e === "node_modules" || e === "__tests__" || e === ".next") continue;
+      out.push(...walkSource(full));
+    } else if (
+      (e.endsWith(".ts") || e.endsWith(".tsx")) &&
+      !e.endsWith(".test.ts") &&
+      !e.endsWith(".test.tsx")
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const LEARNER_UI_SOURCE: string = (() => {
+  const files: string[] = [];
+  for (const dir of LEARNER_UI_DIRS) {
+    files.push(...walkSource(dir));
+  }
+  return files
+    .map((f) => {
+      try {
+        return readFileSync(f, "utf8");
+      } catch {
+        return "";
+      }
+    })
+    .join("\n");
+})();
+
+/** Detect if a label appears as a quoted string literal in source.
+ *  Matches `"<label>"` or `'<label>'` — bare unquoted occurrences
+ *  (e.g. in comments) do NOT count as leaks. */
+function labelIsLeaked(label: string, source: string): boolean {
+  const esc = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`["']${esc}["']`);
+  return re.test(source);
+}
+
+// ────────────────────────────────────────────────────────────
+// Classification
+// ────────────────────────────────────────────────────────────
+
+type Classification = "clean" | "exempt" | "leak";
+
+interface LeakResult {
+  setKey: string;
+  label: string;
+  key: LeakKey;
+  classification: Classification;
+}
+
+function classifyLabel(setKey: string, label: string): LeakResult {
+  const key = `${setKey}:${label}` as LeakKey;
+  if (LEARNER_UI_LEAK_EXEMPT[key]) {
+    return { setKey, label, key, classification: "exempt" };
+  }
+  if (labelIsLeaked(label, LEARNER_UI_SOURCE)) {
+    return { setKey, label, key, classification: "leak" };
+  }
+  return { setKey, label, key, classification: "clean" };
+}
+
+// ────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────
+
+describe("Learner-UI leak coverage (Lattice Coverage)", () => {
+  const allResults: LeakResult[] = [];
+  for (const [setKey, set] of Object.entries(INTERNAL_LABEL_REGISTRY)) {
+    for (const label of set.labels) {
+      allResults.push(classifyLabel(setKey, label));
+    }
+  }
+
+  it("registry has at least one internal-label set", () => {
+    expect(
+      Object.keys(INTERNAL_LABEL_REGISTRY).length,
+      "INTERNAL_LABEL_REGISTRY is empty — at least one course must register an internal label set",
+    ).toBeGreaterThan(0);
+  });
+
+  it("every registry entry has a substantive description (>30 chars)", () => {
+    for (const [k, v] of Object.entries(INTERNAL_LABEL_REGISTRY)) {
+      expect(
+        v.description.trim().length,
+        `${k}: description too short — write why these labels are internal-only`,
+      ).toBeGreaterThan(30);
+    }
+  });
+
+  it("every registry entry has at least one label", () => {
+    for (const [k, v] of Object.entries(INTERNAL_LABEL_REGISTRY)) {
+      expect(
+        v.labels.length,
+        `${k}: no labels declared`,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it("no internal-only label leaks into learner-UI source beyond the ratchet", () => {
+    const leaks = allResults.filter((r) => r.classification === "leak");
+    expect(
+      leaks.length,
+      `Internal-only labels found as string literals in learner-UI source:\n  ${leaks
+        .map((l) => l.key)
+        .join("\n  ")}\n\nFix: move the label assignment to a server-side projection (e.g. a REWARD-stage spec) that maps internal → learner-safe BEFORE the data reaches the learner-UI dir. See ADR docs/decisions/2026-06-21-session-focus-rewardspec-substrate.md.`,
+    ).toBeLessThanOrEqual(EXPECTED_LEAK_COUNT);
+  });
+
+  it("ratchet — leak count matches EXPECTED_LEAK_COUNT exactly", () => {
+    const leaks = allResults.filter((r) => r.classification === "leak");
+    expect(
+      leaks.length,
+      `Leak count drifted from ${EXPECTED_LEAK_COUNT}. ` +
+        `Current leaks: ${leaks.map((l) => l.key).join(", ")}. ` +
+        `If you cleared an incumbent, drop EXPECTED_LEAK_COUNT. ` +
+        `If you introduced one, pause: fix the projection instead.`,
+    ).toBe(EXPECTED_LEAK_COUNT);
+  });
+
+  it("ratchet — exempt count matches EXPECTED_EXEMPT_COUNT exactly", () => {
+    const exemptIds = Object.keys(LEARNER_UI_LEAK_EXEMPT);
+    expect(
+      exemptIds.length,
+      `Exempt-list size drifted from ${EXPECTED_EXEMPT_COUNT}. Current: ${exemptIds.join(", ")}`,
+    ).toBe(EXPECTED_EXEMPT_COUNT);
+  });
+
+  it("every exempt entry has a substantive reason (>20 chars)", () => {
+    for (const [k, entry] of Object.entries(LEARNER_UI_LEAK_EXEMPT)) {
+      expect(
+        entry!.reason.trim().length,
+        `${k}: reason too short`,
+      ).toBeGreaterThan(20);
+    }
+  });
+
+  it("no exempt entry references an unknown label (stale row)", () => {
+    const stale: string[] = [];
+    for (const k of Object.keys(LEARNER_UI_LEAK_EXEMPT)) {
+      const [setKey, label] = k.split(":");
+      const set = INTERNAL_LABEL_REGISTRY[setKey];
+      if (!set || !set.labels.includes(label)) stale.push(k);
+    }
+    expect(stale, `Stale exempt entries: ${stale.join(", ")}`).toEqual([]);
+  });
+
+  it("classification distribution sanity (operator-facing log)", () => {
+    const counts: Record<Classification, number> = {
+      clean: 0,
+      exempt: 0,
+      leak: 0,
+    };
+    for (const r of allResults) counts[r.classification]++;
+    const totalLabels = Object.values(INTERNAL_LABEL_REGISTRY).reduce(
+      (s, set) => s + set.labels.length,
+      0,
+    );
+    expect(counts.clean + counts.exempt + counts.leak).toBe(totalLabels);
+  });
+});

--- a/apps/admin/tests/lib/sim-chat/mode-ui-coverage.test.ts
+++ b/apps/admin/tests/lib/sim-chat/mode-ui-coverage.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Mode UI coverage — Lattice 5th-pillar Coverage test.
+ *
+ * **What this test pins:**
+ *  Every `AuthoredModuleMode` value in
+ *  `apps/admin/lib/types/json-fields.ts` MUST have a consumer on each
+ *  of three axes:
+ *    1. **teaching** — composition transform branches on the mode
+ *       (compose-side teaching directive), OR the mode is the default
+ *       (tutor / mixed) so the baseline tutor stack handles it.
+ *    2. **adminUI** — at least one admin UI component (`app/x/**`,
+ *       `components/**`) branches on the mode (badge, icon, inspector,
+ *       pill).
+ *    3. **learnerUI** — at least one learner-facing render path branches
+ *       on the mode (SIM shell, FOH pre-call card, ExamModeShell mount,
+ *       or chat-feed reskin), OR the mode is the default chat-feed
+ *       behaviour.
+ *
+ *  Catches the producer-only failure mode where a mode literal is added
+ *  to the type union (and possibly the compose-side directive), but the
+ *  UI surfaces silently ignore the value. The 2026-06-20 audit found
+ *  `quiz` and `mock-exam` shipped with compose directives + admin badges
+ *  but no learner-facing UI consumer — operators saw distinct icons but
+ *  the learner experienced an identical chat session regardless of mode.
+ *
+ * **How matching works:**
+ *  For each (mode, axis) cell, the test walks the axis's consumer
+ *  directories and looks for one of these patterns referencing the mode
+ *  literal:
+ *    - `mode === "<value>"` (or `mode !== "<value>"`)
+ *    - `case "<value>":`
+ *    - `=== "<value>"` followed by `.mode` reference nearby
+ *  A match counts as `covered`. Exempt cells are listed in
+ *  `MODE_AXIS_EXEMPT` with a documented reason. Anything else is `gap`.
+ *
+ * **How to fix a failure:**
+ *  - "Cell X.Y is a gap": wire the consumer (shell, transform, inspector)
+ *    OR add to `MODE_AXIS_EXEMPT` with a one-line reason describing the
+ *    intentional choice (e.g., "tutor is the default — no specific UI
+ *    needed").
+ *  - "Ratchet drifted up": you added an exempt entry without bumping
+ *    `EXPECTED_EXEMPT_COUNT`. Decide consciously.
+ *  - "Stale exempt entry": the cell now has a real consumer; remove the
+ *    exempt row.
+ *
+ *  See `.claude/rules/mode-ui-coverage.md` for the durable rule.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+// ────────────────────────────────────────────────────────────
+// Canonical mode set — verified against the source type union
+// at test runtime so a new union value forces a matrix update.
+// ────────────────────────────────────────────────────────────
+
+const AUTHORED_MODULE_MODE_VALUES = [
+  "examiner",
+  "tutor",
+  "mixed",
+  "quiz",
+  "mock-exam",
+] as const;
+
+type AuthoredModuleMode = (typeof AUTHORED_MODULE_MODE_VALUES)[number];
+
+const REPO_ADMIN = resolve(__dirname, "..", "..", "..");
+
+const TYPE_SOURCE_PATH = join(
+  REPO_ADMIN,
+  "lib",
+  "types",
+  "json-fields.ts",
+);
+
+// ────────────────────────────────────────────────────────────
+// Three axes the matrix pins
+// ────────────────────────────────────────────────────────────
+
+type ModeAxis = "teaching" | "adminUI" | "learnerUI";
+const AXES: readonly ModeAxis[] = ["teaching", "adminUI", "learnerUI"] as const;
+
+const AXIS_DIRS: Record<ModeAxis, string[]> = {
+  teaching: [
+    "lib/prompt/composition/transforms",
+    "lib/prompt/composition/loaders",
+    "lib/prompt/composition",
+    "lib/curriculum",
+  ],
+  adminUI: [
+    "app/x",
+    "components/modules-tab",
+    "components/journey-tab",
+  ],
+  learnerUI: [
+    "components/sim",
+    "app/x/student",
+    // FOH learner app — separate workspace
+    "../foh/app",
+    "../foh/components",
+  ],
+};
+
+// ────────────────────────────────────────────────────────────
+// Exempt list — (mode, axis) cells where the mode is the implicit
+// default and a specific consumer is intentionally not required.
+// Required: one-line reason >20 chars.
+// ────────────────────────────────────────────────────────────
+
+interface ExemptEntry {
+  reason: string;
+}
+
+type CellKey = `${AuthoredModuleMode}.${ModeAxis}`;
+
+const MODE_AXIS_EXEMPT: Partial<Record<CellKey, ExemptEntry>> = {
+  // Tutor is the default conversational mode — the baseline tutor
+  // stack at lib/prompt/composition handles it without a mode-specific
+  // directive. No teaching consumer required.
+  "tutor.teaching": {
+    reason:
+      "tutor is the default mode; baseline tutor stack handles it without a mode-specific compose directive",
+  },
+  // ModePill / ModeIcon in AuthoredModulesPanel + LearnerModulePicker
+  // use a ternary chain where tutor is the fallback (no explicit
+  // `mode === "tutor"`). The badge IS rendered; the consumer is just
+  // implicit via the fallback branch.
+  "tutor.adminUI": {
+    reason:
+      "tutor is the fallback in ModePill/ModeIcon ternary chains; admin renders the badge implicitly without an explicit mode equality check",
+  },
+  // Tutor uses the default chat-feed shell (SimChat) for learner UI —
+  // no exam-shell, no MCQ overlay, no banner override.
+  "tutor.learnerUI": {
+    reason:
+      "tutor uses the default SimChat shell; no mode-specific learner UI needed",
+  },
+  // Mixed = tutor + occasional assessment touches. Uses tutor baseline
+  // at compose time + per-question scoring activation when the spec
+  // fires. No mode-literal-specific directive.
+  "mixed.teaching": {
+    reason:
+      "mixed = tutor baseline + assessment activation; no mode-literal-specific compose directive",
+  },
+  // Mixed uses the default chat-feed shell — same as tutor for the
+  // learner UI even though pacing differs.
+  "mixed.learnerUI": {
+    reason:
+      "mixed uses the default SimChat shell; same learner-facing aesthetic as tutor",
+  },
+  // Examiner mode is wired through the spec runner at
+  // lib/curriculum/build-per-segment-measure-prompt.ts via a string
+  // template keyed off the spec slug ("examiner-mode" scoring prompt),
+  // NOT via a literal `.mode === "examiner"` comparator. The
+  // ExamModeShell mount-gate at components/sim/ExamModeShell.tsx:62
+  // IS the literal reader, but that's on the learnerUI axis.
+  "examiner.teaching": {
+    reason:
+      "examiner is wired via spec-slug template ('examiner-mode' scoring prompt), not via literal .mode comparator in teaching dirs",
+  },
+};
+
+/** Ratchet — only goes DOWN as gaps close, never UP without a bump. */
+const EXPECTED_EXEMPT_COUNT = 6;
+
+/** Ratchet — UI consumer gaps frozen at incumbent count. Drops as
+ *  gaps close. Today's incumbents: quiz.learnerUI + mock-exam.learnerUI
+ *  — both flagged in the 2026-06-21 audit. Operators see distinct
+ *  badges in the admin Modules tab; learners experience an identical
+ *  chat session regardless of mode. */
+const EXPECTED_GAP_COUNT = 2;
+
+// ────────────────────────────────────────────────────────────
+// Source-walk + classification
+// ────────────────────────────────────────────────────────────
+
+function walkSource(dir: string): string[] {
+  const out: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    const full = join(dir, e);
+    let st;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      if (e === "node_modules" || e === "__tests__" || e === ".next") continue;
+      out.push(...walkSource(full));
+    } else if (
+      (e.endsWith(".ts") || e.endsWith(".tsx")) &&
+      !e.endsWith(".test.ts") &&
+      !e.endsWith(".test.tsx")
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function concatSourceForAxis(axis: ModeAxis): string {
+  const files: string[] = [];
+  for (const rel of AXIS_DIRS[axis]) {
+    files.push(...walkSource(resolve(REPO_ADMIN, rel)));
+  }
+  return files
+    .map((f) => {
+      try {
+        return readFileSync(f, "utf8");
+      } catch {
+        return "";
+      }
+    })
+    .join("\n");
+}
+
+// Pre-compute once per test run.
+const AXIS_SOURCE: Record<ModeAxis, string> = {
+  teaching: concatSourceForAxis("teaching"),
+  adminUI: concatSourceForAxis("adminUI"),
+  learnerUI: concatSourceForAxis("learnerUI"),
+};
+
+/** Mode-literal consumer patterns. The mode value must appear in a
+ *  comparison against a variable literally named `mode` or accessed
+ *  as `.mode` — this discriminates real consumers from incidental
+ *  string-literal collisions (e.g. AudienceId `"mixed"` lives in
+ *  lib/prompt/composition/transforms/audience.ts but isn't a mode
+ *  consumer). Switch-case branches are NOT matched here; they may
+ *  legitimately exist for unrelated string literals or pure type-
+ *  exhaustiveness plumbing. Cases that ARE valid (mode-keyed switches)
+ *  should rewrite to `===` checks or list the cell in exempt with a
+ *  one-line reason. */
+function modeIsConsumed(mode: AuthoredModuleMode, source: string): boolean {
+  const esc = mode.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // Match shapes:
+  //   mode === "X"          mode !== "X"
+  //   .mode === "X"         .mode !== "X"
+  //   .mode==='X'           etc.
+  const re = new RegExp(
+    `(?:\\.\\s*mode\\s*[!=]==\\s*["']${esc}["'])|(?:\\bmode\\s*[!=]==\\s*["']${esc}["'])`,
+    "m",
+  );
+  return re.test(source);
+}
+
+type Classification = "covered" | "exempt" | "gap";
+
+interface CellResult {
+  mode: AuthoredModuleMode;
+  axis: ModeAxis;
+  key: CellKey;
+  classification: Classification;
+  reason?: string;
+}
+
+function classifyCell(mode: AuthoredModuleMode, axis: ModeAxis): CellResult {
+  const key: CellKey = `${mode}.${axis}`;
+  const exempt = MODE_AXIS_EXEMPT[key];
+  if (exempt) {
+    return { mode, axis, key, classification: "exempt", reason: exempt.reason };
+  }
+  if (modeIsConsumed(mode, AXIS_SOURCE[axis])) {
+    return { mode, axis, key, classification: "covered" };
+  }
+  return { mode, axis, key, classification: "gap" };
+}
+
+// ────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────
+
+describe("AuthoredModuleMode UI/teaching coverage (Lattice Coverage)", () => {
+  const results: CellResult[] = AUTHORED_MODULE_MODE_VALUES.flatMap((m) =>
+    AXES.map((a) => classifyCell(m, a)),
+  );
+
+  it("test matrix matches the source-of-truth type union", () => {
+    const src = readFileSync(TYPE_SOURCE_PATH, "utf8");
+    const m = src.match(
+      /export\s+type\s+AuthoredModuleMode\s*=\s*([^;]+);/m,
+    );
+    expect(m, "AuthoredModuleMode export not found in json-fields.ts").toBeTruthy();
+    const sourceValues = (m![1].match(/["']([^"']+)["']/g) ?? []).map((s) =>
+      s.replace(/["']/g, ""),
+    );
+    const sorted = [...sourceValues].sort();
+    const local = [...AUTHORED_MODULE_MODE_VALUES].sort();
+    expect(
+      sorted,
+      `Source type union diverged from test matrix. Source: ${sorted.join(", ")}; matrix: ${local.join(", ")}. Update AUTHORED_MODULE_MODE_VALUES in this file and add coverage rows.`,
+    ).toEqual(local);
+  });
+
+  it("no (mode, axis) cell is an uncovered gap beyond the ratchet", () => {
+    const gaps = results.filter((r) => r.classification === "gap");
+    expect(
+      gaps.length,
+      `Producer-only mode cells (no consumer found, no exemption):\n  ${gaps
+        .map((g) => g.key)
+        .join("\n  ")}\n\nFix: wire the consumer OR add to MODE_AXIS_EXEMPT with a >20-char reason.`,
+    ).toBeLessThanOrEqual(EXPECTED_GAP_COUNT);
+  });
+
+  it("ratchet — gap count matches EXPECTED_GAP_COUNT exactly", () => {
+    const gaps = results.filter((r) => r.classification === "gap");
+    expect(
+      gaps.length,
+      `Gap count drifted from ${EXPECTED_GAP_COUNT}. ` +
+        `Current gaps: ${gaps.map((g) => g.key).join(", ")}. ` +
+        `If you closed a gap, drop EXPECTED_GAP_COUNT. ` +
+        `If you opened one, pause: wire the consumer instead.`,
+    ).toBe(EXPECTED_GAP_COUNT);
+  });
+
+  it("ratchet — exempt count matches EXPECTED_EXEMPT_COUNT exactly", () => {
+    const ex = Object.keys(MODE_AXIS_EXEMPT);
+    expect(
+      ex.length,
+      `Exempt-list size drifted from ${EXPECTED_EXEMPT_COUNT}. ` +
+        `Current: ${ex.join(", ")}. ` +
+        `If you removed an exemption (wired the consumer), drop the constant. ` +
+        `If you added one, was that intentional?`,
+    ).toBe(EXPECTED_EXEMPT_COUNT);
+  });
+
+  it("every exempt entry has a substantive reason (>20 chars)", () => {
+    for (const [k, entry] of Object.entries(MODE_AXIS_EXEMPT)) {
+      expect(
+        entry!.reason.trim().length,
+        `${k}: reason too short (${entry!.reason.length} chars) — write what makes this cell intentionally exempt`,
+      ).toBeGreaterThan(20);
+    }
+  });
+
+  it("no exempt entry is contradicted by an actual consumer match", () => {
+    const contradicted: string[] = [];
+    for (const [k, _] of Object.entries(MODE_AXIS_EXEMPT)) {
+      const [mode, axis] = k.split(".") as [AuthoredModuleMode, ModeAxis];
+      if (modeIsConsumed(mode, AXIS_SOURCE[axis])) {
+        contradicted.push(k);
+      }
+    }
+    expect(
+      contradicted,
+      `Exempt entries that now have real consumer matches — remove from MODE_AXIS_EXEMPT:\n  ${contradicted.join("\n  ")}`,
+    ).toEqual([]);
+  });
+
+  it("no exempt entry references an unknown mode (stale row)", () => {
+    const known = new Set<string>(AUTHORED_MODULE_MODE_VALUES);
+    const stale: string[] = [];
+    for (const k of Object.keys(MODE_AXIS_EXEMPT)) {
+      const [mode] = k.split(".");
+      if (!known.has(mode)) stale.push(k);
+    }
+    expect(stale, `Stale exempt entries: ${stale.join(", ")}`).toEqual([]);
+  });
+
+  it("classification distribution sanity (operator-facing log)", () => {
+    const counts: Record<Classification, number> = {
+      covered: 0,
+      exempt: 0,
+      gap: 0,
+    };
+    for (const r of results) counts[r.classification]++;
+    const sum = counts.covered + counts.exempt + counts.gap;
+    expect(sum).toBe(AUTHORED_MODULE_MODE_VALUES.length * AXES.length);
+  });
+});

--- a/apps/admin/tests/lib/voice/sessionkind-reader-coverage.test.ts
+++ b/apps/admin/tests/lib/voice/sessionkind-reader-coverage.test.ts
@@ -1,0 +1,346 @@
+/**
+ * SessionKind reader coverage — Lattice 5th-pillar Coverage test.
+ *
+ * **What this test pins:**
+ *  Every `SessionKindString` value in
+ *  `apps/admin/lib/voice/session-rules.ts` MUST have BOTH a writer
+ *  (at least one code path creates a Session with that kind) AND a
+ *  reader (at least one runtime / UI surface branches on that kind).
+ *
+ *  A kind with no writer is a `type-only ghost`: declared in the type
+ *  union but unreachable from any runtime path. ASSESSMENT and
+ *  TEXT_CHAT were both ghosts at this test's birth (2026-06-21) —
+ *  declared on epic #1338 alongside ENROLLMENT / VOICE_CALL / SIM_CALL,
+ *  but no `createSession({ kind: ... })` call ever passes them.
+ *
+ *  A kind with a writer but no reader is a producer-only kind: the
+ *  pipeline writes it but no admin surface badge, no learner-facing
+ *  copy, no analysis-spec branch ever consumes it. SIM_CALL was at
+ *  this boundary in the 2026-06-21 audit (read by pipeline runners,
+ *  but no admin list view distinguished it from VOICE_CALL).
+ *
+ * **How matching works:**
+ *  For each kind, the test walks two source sets:
+ *    - **Writers**: `lib/voice`, `lib/intake`, `lib/test-harness`,
+ *      `app/api`, `lib/curriculum`. Match shape:
+ *      `kind:\s*["']<value>["']` or `kind\s*=\s*["']<value>["']`.
+ *    - **Readers**: `lib/voice`, `lib/pipeline`, `lib/curriculum`,
+ *      `app/api`, `app/x`, `components`. Match shape:
+ *      `kind ===|case ['"X'"]:|kind !==` against the value, OR a
+ *      type-narrowing check via SessionKindString.
+ *
+ *  Each value gets a (writer, reader) classification. Exempt cells live
+ *  in `SESSIONKIND_AXIS_EXEMPT` with a >20-char reason. Ratchet pins
+ *  the incumbent count.
+ *
+ * **How to fix a failure:**
+ *  - "Kind X has no writer / reader": either implement the missing side,
+ *    OR remove the value from the SessionKindString union (the right
+ *    move for ASSESSMENT / TEXT_CHAT if they remain unused).
+ *  - "Ratchet drifted": consciously bump or close.
+ *
+ *  See `.claude/rules/sessionkind-reader-coverage.md` for the durable
+ *  rule.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+// ────────────────────────────────────────────────────────────
+// Canonical kind set — verified at runtime against source union
+// ────────────────────────────────────────────────────────────
+
+const SESSION_KIND_VALUES = [
+  "ENROLLMENT",
+  "ASSESSMENT",
+  "VOICE_CALL",
+  "SIM_CALL",
+  "TEXT_CHAT",
+] as const;
+
+type SessionKind = (typeof SESSION_KIND_VALUES)[number];
+
+const REPO_ADMIN = resolve(__dirname, "..", "..", "..");
+
+const UNION_SOURCE_PATH = join(
+  REPO_ADMIN,
+  "lib",
+  "voice",
+  "session-rules.ts",
+);
+
+// ────────────────────────────────────────────────────────────
+// Two axes the matrix pins
+// ────────────────────────────────────────────────────────────
+
+type KindAxis = "writer" | "reader";
+const AXES: readonly KindAxis[] = ["writer", "reader"] as const;
+
+const AXIS_DIRS: Record<KindAxis, string[]> = {
+  writer: [
+    "lib/voice",
+    "lib/intake",
+    "lib/test-harness",
+    "app/api",
+    "lib/curriculum",
+  ],
+  reader: [
+    "lib/voice",
+    "lib/pipeline",
+    "lib/curriculum",
+    "lib/prompt",
+    "app/api",
+    "app/x",
+    "components",
+  ],
+};
+
+// ────────────────────────────────────────────────────────────
+// Exempt list — (kind, axis) cells where the gap is consciously
+// accepted (kind reserved for future implementation, or already
+// retired but kept in union for backwards compat).
+// Required: one-line reason >20 chars.
+// ────────────────────────────────────────────────────────────
+
+interface ExemptEntry {
+  reason: string;
+}
+
+type CellKey = `${SessionKind}.${KindAxis}`;
+
+const SESSIONKIND_AXIS_EXEMPT: Partial<Record<CellKey, ExemptEntry>> = {
+  // ASSESSMENT — declared on epic #1338 alongside ENROLLMENT for
+  // future formal-assessment session kinds (separate from VOICE_CALL
+  // because counterFlags differ). No writer or reader today. Decision
+  // pending: implement (paired with #2015 Distinction-tier rubric) or
+  // remove from union.
+  "ASSESSMENT.writer": {
+    reason:
+      "type-only ghost since epic #1338; reserved for future formal assessment session kind, decision pending #2015 Distinction-tier rubric",
+  },
+  "ASSESSMENT.reader": {
+    reason:
+      "type-only ghost since epic #1338; no admin/learner surface consumes it yet, paired with ASSESSMENT.writer exemption",
+  },
+  // TEXT_CHAT — declared on epic #1338 for a future in-app text-only
+  // chat session kind (no voice infrastructure). No writer or reader
+  // today. Same decision-pending status as ASSESSMENT.
+  "TEXT_CHAT.writer": {
+    reason:
+      "type-only ghost since epic #1338; reserved for future text-only chat session kind without VAPI/voice infrastructure",
+  },
+  "TEXT_CHAT.reader": {
+    reason:
+      "type-only ghost since epic #1338; PROSODY explicitly no-ops on TEXT_CHAT per session-rules.ts comment, but no consumer reads it",
+  },
+};
+
+/** Ratchet — exempt count. Drops as kinds get wired or removed. */
+const EXPECTED_EXEMPT_COUNT = 4;
+
+/** Ratchet — open gaps (cells with no consumer + no exemption). */
+const EXPECTED_GAP_COUNT = 0;
+
+// ────────────────────────────────────────────────────────────
+// Source-walk
+// ────────────────────────────────────────────────────────────
+
+function walkSource(dir: string): string[] {
+  const out: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    const full = join(dir, e);
+    let st;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      if (e === "node_modules" || e === "__tests__" || e === ".next") continue;
+      out.push(...walkSource(full));
+    } else if (
+      (e.endsWith(".ts") || e.endsWith(".tsx")) &&
+      !e.endsWith(".test.ts") &&
+      !e.endsWith(".test.tsx")
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function concatSourceForAxis(axis: KindAxis): string {
+  const files: string[] = [];
+  for (const rel of AXIS_DIRS[axis]) {
+    files.push(...walkSource(resolve(REPO_ADMIN, rel)));
+  }
+  return files
+    .map((f) => {
+      try {
+        return readFileSync(f, "utf8");
+      } catch {
+        return "";
+      }
+    })
+    .join("\n");
+}
+
+const AXIS_SOURCE: Record<KindAxis, string> = {
+  writer: concatSourceForAxis("writer"),
+  reader: concatSourceForAxis("reader"),
+};
+
+/** Writer pattern — kind appears as an object literal field or
+ *  variable assignment with the kind value as a string literal. */
+function kindHasWriter(kind: SessionKind, source: string): boolean {
+  const esc = kind.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // Match: `kind: "X"`, `kind = "X"`, `kind:"X"`, `kind="X"`
+  const re = new RegExp(`\\bkind\\s*[:=]\\s*["']${esc}["']`, "m");
+  return re.test(source);
+}
+
+/** Reader pattern — kind appears either:
+ *    (a) in an equality comparison against `kind` / `.kind`, OR
+ *    (b) as a Prisma `where: { kind: "X" }` query field, OR
+ *    (c) as a Prisma `data: { kind: "X" }` field on a write whose
+ *        downstream pipeline reads it back.
+ *  All three are legitimate consumer signals — the kind value carries
+ *  semantic meaning that some code path acts on.
+ *
+ *  Excludes `case "X":` branches because the type-exhaustiveness
+ *  switch at `lib/voice/session-rules.ts::initialCounterFlags`
+ *  enumerates every union member by `case` — that's type plumbing,
+ *  not a business-logic reader. ASSESSMENT and TEXT_CHAT have those
+ *  `case` branches but no `kind: "X"` or `=== "X"` reader, which is
+ *  exactly the "ghost" state this test pins. */
+function kindHasReader(kind: SessionKind, source: string): boolean {
+  const esc = kind.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(
+    `(?:\\.\\s*kind\\s*[!=]==\\s*["']${esc}["'])|(?:\\bkind\\s*[!=]==\\s*["']${esc}["'])|(?:\\bkind\\s*:\\s*["']${esc}["'])`,
+    "m",
+  );
+  return re.test(source);
+}
+
+type Classification = "covered" | "exempt" | "gap";
+
+interface CellResult {
+  kind: SessionKind;
+  axis: KindAxis;
+  key: CellKey;
+  classification: Classification;
+  reason?: string;
+}
+
+function classifyCell(kind: SessionKind, axis: KindAxis): CellResult {
+  const key: CellKey = `${kind}.${axis}`;
+  const exempt = SESSIONKIND_AXIS_EXEMPT[key];
+  if (exempt) {
+    return { kind, axis, key, classification: "exempt", reason: exempt.reason };
+  }
+  const consumed =
+    axis === "writer"
+      ? kindHasWriter(kind, AXIS_SOURCE.writer)
+      : kindHasReader(kind, AXIS_SOURCE.reader);
+  if (consumed) return { kind, axis, key, classification: "covered" };
+  return { kind, axis, key, classification: "gap" };
+}
+
+// ────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────
+
+describe("SessionKind writer + reader coverage (Lattice Coverage)", () => {
+  const results: CellResult[] = SESSION_KIND_VALUES.flatMap((k) =>
+    AXES.map((a) => classifyCell(k, a)),
+  );
+
+  it("test matrix matches the source-of-truth type union", () => {
+    const src = readFileSync(UNION_SOURCE_PATH, "utf8");
+    const m = src.match(
+      /export\s+type\s+SessionKindString\s*=\s*([^;]+);/m,
+    );
+    expect(m, "SessionKindString export not found in session-rules.ts").toBeTruthy();
+    const sourceValues = (m![1].match(/["']([^"']+)["']/g) ?? []).map((s) =>
+      s.replace(/["']/g, ""),
+    );
+    const sorted = [...sourceValues].sort();
+    const local = [...SESSION_KIND_VALUES].sort();
+    expect(
+      sorted,
+      `Source SessionKindString diverged from test matrix. Source: ${sorted.join(", ")}; matrix: ${local.join(", ")}. Update SESSION_KIND_VALUES + add coverage rows.`,
+    ).toEqual(local);
+  });
+
+  it("no (kind, axis) cell is an uncovered gap beyond the ratchet", () => {
+    const gaps = results.filter((r) => r.classification === "gap");
+    expect(
+      gaps.length,
+      `SessionKind coverage gaps (no writer / reader, no exemption):\n  ${gaps
+        .map((g) => g.key)
+        .join("\n  ")}\n\nFix: implement the missing side, OR remove the value from SessionKindString, OR add to SESSIONKIND_AXIS_EXEMPT with a >20-char reason.`,
+    ).toBeLessThanOrEqual(EXPECTED_GAP_COUNT);
+  });
+
+  it("ratchet — exempt count matches EXPECTED_EXEMPT_COUNT exactly", () => {
+    const ex = Object.keys(SESSIONKIND_AXIS_EXEMPT);
+    expect(
+      ex.length,
+      `Exempt-list size drifted from ${EXPECTED_EXEMPT_COUNT}. ` +
+        `Current: ${ex.join(", ")}.`,
+    ).toBe(EXPECTED_EXEMPT_COUNT);
+  });
+
+  it("every exempt entry has a substantive reason (>20 chars)", () => {
+    for (const [k, entry] of Object.entries(SESSIONKIND_AXIS_EXEMPT)) {
+      expect(
+        entry!.reason.trim().length,
+        `${k}: reason too short`,
+      ).toBeGreaterThan(20);
+    }
+  });
+
+  it("no exempt entry is contradicted by an actual consumer match", () => {
+    const contradicted: string[] = [];
+    for (const [k] of Object.entries(SESSIONKIND_AXIS_EXEMPT)) {
+      const [kind, axis] = k.split(".") as [SessionKind, KindAxis];
+      const matched =
+        axis === "writer"
+          ? kindHasWriter(kind, AXIS_SOURCE.writer)
+          : kindHasReader(kind, AXIS_SOURCE.reader);
+      if (matched) contradicted.push(k);
+    }
+    expect(
+      contradicted,
+      `Exempt entries that now have real matches — remove from SESSIONKIND_AXIS_EXEMPT:\n  ${contradicted.join("\n  ")}`,
+    ).toEqual([]);
+  });
+
+  it("no exempt entry references an unknown kind (stale row)", () => {
+    const known = new Set<string>(SESSION_KIND_VALUES);
+    const stale: string[] = [];
+    for (const k of Object.keys(SESSIONKIND_AXIS_EXEMPT)) {
+      const [kind] = k.split(".");
+      if (!known.has(kind)) stale.push(k);
+    }
+    expect(stale, `Stale exempt entries: ${stale.join(", ")}`).toEqual([]);
+  });
+
+  it("classification distribution sanity (operator-facing log)", () => {
+    const counts: Record<Classification, number> = {
+      covered: 0,
+      exempt: 0,
+      gap: 0,
+    };
+    for (const r of results) counts[r.classification]++;
+    const sum = counts.covered + counts.exempt + counts.gap;
+    expect(sum).toBe(SESSION_KIND_VALUES.length * AXES.length);
+  });
+});

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-20T11:14:37.491Z",
+  "generatedAt": "2026-06-21T10:45:23.549Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1868,
-  "edgeCount": 4400,
+  "fileCount": 1871,
+  "edgeCount": 4407,
   "skippedEdges": 1,
   "edges": [
     {
@@ -12956,6 +12956,10 @@
       "to": "lib/types/json-fields.ts"
     },
     {
+      "from": "lib/curriculum/derive-focus-area.ts",
+      "to": "lib/curriculum/validate-ielts-completion.ts"
+    },
+    {
       "from": "lib/curriculum/diagnostic-from-mock.ts",
       "to": "lib/curriculum/compute-mastery.ts"
     },
@@ -15337,6 +15341,10 @@
     },
     {
       "from": "lib/prompt/composition/transforms/instructions.ts",
+      "to": "lib/prompt/composition/transforms/part3-focus.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/instructions.ts",
       "to": "lib/prompt/composition/transforms/personality.ts"
     },
     {
@@ -15470,6 +15478,22 @@
     {
       "from": "lib/prompt/composition/transforms/parametersAsDirectives.ts",
       "to": "lib/tolerance/getEffectiveBehaviorTargetsForCaller.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/part3-focus.ts",
+      "to": "lib/curriculum/derive-focus-area.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/part3-focus.ts",
+      "to": "lib/journey/module-settings-flag.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/part3-focus.ts",
+      "to": "lib/prompt/composition/types.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/part3-focus.ts",
+      "to": "lib/types/json-fields.ts"
     },
     {
       "from": "lib/prompt/composition/transforms/pedagogy-mode.ts",
@@ -16718,6 +16742,10 @@
     {
       "from": "lib/voice/runtime-features.ts",
       "to": "lib/voice/sse-registry.ts"
+    },
+    {
+      "from": "lib/voice/select-pinned-card.ts",
+      "to": "lib/curriculum/derive-focus-area.ts"
     },
     {
       "from": "lib/voice/select-pinned-card.ts",
@@ -23930,6 +23958,11 @@
       "outDegree": 1
     },
     {
+      "path": "lib/curriculum/derive-focus-area.ts",
+      "inDegree": 2,
+      "outDegree": 1
+    },
+    {
       "path": "lib/curriculum/diagnostic-from-mock.ts",
       "inDegree": 1,
       "outDegree": 2
@@ -24051,7 +24084,7 @@
     },
     {
       "path": "lib/curriculum/validate-ielts-completion.ts",
-      "inDegree": 1,
+      "inDegree": 2,
       "outDegree": 1
     },
     {
@@ -24651,7 +24684,7 @@
     },
     {
       "path": "lib/journey/module-settings-flag.ts",
-      "inDegree": 8,
+      "inDegree": 9,
       "outDegree": 0
     },
     {
@@ -25332,7 +25365,7 @@
     {
       "path": "lib/prompt/composition/transforms/instructions.ts",
       "inDegree": 2,
-      "outDegree": 9
+      "outDegree": 10
     },
     {
       "path": "lib/prompt/composition/transforms/interleaveReview.ts",
@@ -25372,6 +25405,11 @@
     {
       "path": "lib/prompt/composition/transforms/parametersAsDirectives.ts",
       "inDegree": 0,
+      "outDegree": 4
+    },
+    {
+      "path": "lib/prompt/composition/transforms/part3-focus.ts",
+      "inDegree": 1,
       "outDegree": 4
     },
     {
@@ -25461,7 +25499,7 @@
     },
     {
       "path": "lib/prompt/composition/types.ts",
-      "inDegree": 46,
+      "inDegree": 47,
       "outDegree": 1
     },
     {
@@ -25801,7 +25839,7 @@
     },
     {
       "path": "lib/types/json-fields.ts",
-      "inDegree": 136,
+      "inDegree": 137,
       "outDegree": 0
     },
     {
@@ -26022,7 +26060,7 @@
     {
       "path": "lib/voice/select-pinned-card.ts",
       "inDegree": 1,
-      "outDegree": 1
+      "outDegree": 2
     },
     {
       "path": "lib/voice/session-flag.ts",
@@ -26885,6 +26923,11 @@
       "outDegree": 0
     },
     {
+      "path": "scripts/verify-1955-precondition.ts",
+      "inDegree": 0,
+      "outDegree": 0
+    },
+    {
       "path": "scripts/verify-409-resolution.ts",
       "inDegree": 0,
       "outDegree": 2
@@ -26963,7 +27006,7 @@
     },
     {
       "path": "lib/types/json-fields.ts",
-      "inDegree": 136,
+      "inDegree": 137,
       "outDegree": 0
     },
     {
@@ -26998,7 +27041,7 @@
     },
     {
       "path": "lib/prompt/composition/types.ts",
-      "inDegree": 46,
+      "inDegree": 47,
       "outDegree": 1
     },
     {

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-20T11:14:38.112Z",
+  "generatedAt": "2026-06-21T10:45:24.093Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-20T11:14:35.796Z",
+  "generatedAt": "2026-06-21T10:45:21.996Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-20T11:14:38.776Z",
+  "generatedAt": "2026-06-21T10:45:24.705Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/parameter-inventory.json
+++ b/docs/kb/generated/parameter-inventory.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-20T11:14:27.994Z",
+  "generatedAt": "2026-06-21T10:45:26.876Z",
   "generator": "scripts/capture/parameter-inventory.ts",
   "parameterCount": 154,
   "active": 139,

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,6 +1,6 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-20T11:14:36.566Z",
+  "generatedAt": "2026-06-21T10:45:22.694Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {

--- a/docs/lattice-chains.md
+++ b/docs/lattice-chains.md
@@ -120,6 +120,7 @@ Three structural patterns, in order of preference:
 | RBAC role-level adoption (no magic role arrays) | `lib/roles.ts` (`ROLE_LEVEL` + `isRoleAtOrAbove` + `rolesAtOrAbove` + `isOperatorTrackAdmin`) | 4 sites: `ViewModeContext`, `dashboard-config`, `dashboard/route`, `system-ini` | ✅ PROTECTED | `tests/lib/roles.test.ts` | — | Ratchet rejects new `["SUPERADMIN","ADMIN","OPERATOR"]` triplet literals in `app`/`lib`/`contexts`. EDUCATOR exclusion documented (track distinction, not level). |
 | `TEACHING_CALLER_ROLES` (CallerRole subset) | `lib/caller-roles.ts` (`TEACHING_CALLER_ROLES` + `isTeachingCallerRole`) | 3 routes: `classroom`, `cohorts`, `ensure-cohort` | ✅ PROTECTED | `tests/lib/teaching-caller-roles.test.ts` | — | Ratchet rejects bare `["TEACHER","TUTOR"]` literals and `role === "TEACHER" \|\| role === "TUTOR"` chains. |
 | `DEFAULT_VOICE_PROVIDER_SLUG` | `lib/voice/default-provider.ts` | `load-voice-config.ts:48` + `poll-stale-calls.ts:112` | ✅ PROTECTED | `tests/lib/voice/default-provider.test.ts` | — | Ratchet rejects `?? "vapi"` fallbacks under `lib/voice/` outside the provider's own identity files. |
+| `AuthoredModuleMode` value → 3-axis consumer (teaching/adminUI/learnerUI) | `lib/types/json-fields.ts::AuthoredModuleMode` | `lib/prompt/composition/transforms/instructions.ts` (teaching) + `app/x/courses/[courseId]/_components/{AuthoredModulesPanel,LearnerModulePicker}.tsx` (adminUI) + `components/sim/ExamModeShell.tsx` (learnerUI) | ⚠️ PARTIAL | `tests/lib/sim-chat/mode-ui-coverage.test.ts` (2026-06-21) | MED (2 incumbent gaps) | Bidirectional 3-axis coverage. Exempts: 6 (tutor×3 + mixed×2 + examiner.teaching template). Gaps: quiz.learnerUI + mock-exam.learnerUI — learner experiences identical SimChat regardless of mode. Closing PRs #2077/#2081/#2090 wired teaching + adminUI but never landed learner UI. |
 
 ### Cascade
 
@@ -219,6 +220,8 @@ Three structural patterns, in order of preference:
 | `pipeline-and-prompt.md` | `qmd search` mandate + docs cross-ref | ⚠️ CONVENTION-ONLY |
 | `database-patterns.md` | Author discipline | ⚠️ CONVENTION-ONLY |
 | `ui-design-system.md` | `arch-checker` + `ui-reviewer` agents | ⚠️ CONVENTION-ONLY |
+| `mode-ui-coverage.md` | `tests/lib/sim-chat/mode-ui-coverage.test.ts` (2026-06-21) | ⚠️ PARTIAL (2 incumbent learner-UI gaps) |
+| `sessionkind-reader-coverage.md` | `tests/lib/voice/sessionkind-reader-coverage.test.ts` (2026-06-21) | ⚠️ PARTIAL (2 type-only ghosts: ASSESSMENT, TEXT_CHAT) |
 
 ### Session / learner boundaries
 
@@ -226,6 +229,7 @@ Three structural patterns, in order of preference:
 |---|---|---|---|---|---|---|
 | Pipeline-stage output → learner-facing sanitiser | pipeline output strings | `app/api/student/scheduler-decision` + SCHEDULER_REASONS constant | ✅ PROTECTED | `epic-100-chain-walk.md` Link L1 (2026-05-27) + #923 / PR #924 + tests | — | Regex guard blocks log-prefix strings; read-side sanitizer + stale guard |
 | Composed prompt → ComposedPrompt persistence | `lib/prompt/composition/persist.ts` | `Call.usedPromptId` FK + `next call read` | ✅ PROTECTED | `docs/CHAIN-CONTRACTS.md` Link 3 (Session boundary I-CT2 cascade) + atomic create-session helper | — | Most-recent-active ComposedPrompt resolution cascade |
+| `SessionKindString` value → writer + reader pairing | `lib/voice/session-rules.ts::SessionKindString` (5 values) | writers under `lib/voice` + `lib/intake` + `lib/test-harness` + `app/api`; readers via `=== "X"` or Prisma `where: { kind: "X" }` | ⚠️ PARTIAL | `tests/lib/voice/sessionkind-reader-coverage.test.ts` (2026-06-21) | MED (2 ghost kinds) | Bidirectional writer + reader coverage. Exempts: 4 (ASSESSMENT writer/reader + TEXT_CHAT writer/reader — both declared on epic #1338, both type-only ghosts). Type-exhaustiveness `case "X":` branches in `initialCounterFlags` deliberately excluded — that's type plumbing, not business logic. Decision pending per ghost: implement or remove from union. |
 
 ### Privacy / consent (epic #1915)
 

--- a/docs/lattice-chains.md
+++ b/docs/lattice-chains.md
@@ -222,6 +222,7 @@ Three structural patterns, in order of preference:
 | `ui-design-system.md` | `arch-checker` + `ui-reviewer` agents | ⚠️ CONVENTION-ONLY |
 | `mode-ui-coverage.md` | `tests/lib/sim-chat/mode-ui-coverage.test.ts` (2026-06-21) | ⚠️ PARTIAL (2 incumbent learner-UI gaps) |
 | `sessionkind-reader-coverage.md` | `tests/lib/voice/sessionkind-reader-coverage.test.ts` (2026-06-21) | ⚠️ PARTIAL (2 type-only ghosts: ASSESSMENT, TEXT_CHAT) |
+| `learner-ui-leak-coverage.md` | `tests/lib/sim-chat/learner-ui-leak-coverage.test.ts` (2026-06-21) — static-literal class | ⚠️ PARTIAL (runtime data-flow class deferred to #2135 S4 / #2139 SUPERVISE-spec) |
 
 ### Session / learner boundaries
 
@@ -230,6 +231,7 @@ Three structural patterns, in order of preference:
 | Pipeline-stage output → learner-facing sanitiser | pipeline output strings | `app/api/student/scheduler-decision` + SCHEDULER_REASONS constant | ✅ PROTECTED | `epic-100-chain-walk.md` Link L1 (2026-05-27) + #923 / PR #924 + tests | — | Regex guard blocks log-prefix strings; read-side sanitizer + stale guard |
 | Composed prompt → ComposedPrompt persistence | `lib/prompt/composition/persist.ts` | `Call.usedPromptId` FK + `next call read` | ✅ PROTECTED | `docs/CHAIN-CONTRACTS.md` Link 3 (Session boundary I-CT2 cascade) + atomic create-session helper | — | Most-recent-active ComposedPrompt resolution cascade |
 | `SessionKindString` value → writer + reader pairing | `lib/voice/session-rules.ts::SessionKindString` (5 values) | writers under `lib/voice` + `lib/intake` + `lib/test-harness` + `app/api`; readers via `=== "X"` or Prisma `where: { kind: "X" }` | ⚠️ PARTIAL | `tests/lib/voice/sessionkind-reader-coverage.test.ts` (2026-06-21) | MED (2 ghost kinds) | Bidirectional writer + reader coverage. Exempts: 4 (ASSESSMENT writer/reader + TEXT_CHAT writer/reader — both declared on epic #1338, both type-only ghosts). Type-exhaustiveness `case "X":` branches in `initialCounterFlags` deliberately excluded — that's type plumbing, not business logic. Decision pending per ghost: implement or remove from union. |
+| Internal-only labels → MUST NOT leak into learner-UI source (static literals) | `INTERNAL_LABEL_REGISTRY` in test file — course-agnostic (IELTS_CRITERIA + IELTS_CRITERION_SLUGS today) | `components/sim/**` + `app/x/student/**` + `apps/foh/app/**` + `apps/foh/components/**` | ⚠️ PARTIAL | `tests/lib/sim-chat/learner-ui-leak-coverage.test.ts` (2026-06-21) | HIGH (live #1955 bug class) | Catches the static-literal class. Exempts: 2 (Mock Results screen sanctioned per BDD US-Mock-05). Runtime data-flow class (the actual #1955 leak — `IELTS_SKILL_LABELS` flowing through props from `select-pinned-card.ts` to SimChat) deferred to epic #2135 S4 / #2139 SUPERVISE-spec scan. Static + runtime gates close the loop together. |
 
 ### Privacy / consent (epic #1915)
 


### PR DESCRIPTION
## Summary

Three new Lattice Coverage-pillar tests + paired rule files + inventory rows, all addressing the BIG LATTICE MISS exposed by PR #2134 (#1955): producer-only type unions and internal-label leaks reaching the learner without structural protection.

These align with epic #2135 S4 (#2139) — Lattice coverage gates for the IELTS LLM scoring cascade. This PR can ship now as the **static-literal + UI-consumer** layer; #2139 then adds the **runtime SUPERVISE-spec** layer on top.

## What's in the three gates

| Gate | File | What it pins |
|---|---|---|
| S1 — Mode UI coverage | `tests/lib/sim-chat/mode-ui-coverage.test.ts` | Every `AuthoredModuleMode` value has a consumer on 3 axes (teaching / adminUI / learnerUI). 8 vitests + paired rule. Incumbents: 6 exempt + 2 gaps (quiz.learnerUI + mock-exam.learnerUI). |
| S2 — SessionKind reader coverage | `tests/lib/voice/sessionkind-reader-coverage.test.ts` | Every `SessionKindString` value has a writer AND a reader. 7 vitests + paired rule. Incumbents: 4 exempt (ASSESSMENT + TEXT_CHAT writer/reader ghosts), 0 gaps. |
| S3 — Learner-UI leak coverage | `tests/lib/sim-chat/learner-ui-leak-coverage.test.ts` | Internal-only labels (criterion names, parameter slugs) MUST NOT appear as quoted string literals in learner-UI dirs. 9 vitests + paired rule. Course-agnostic via `INTERNAL_LABEL_REGISTRY`. Incumbents: 2 exempt (Mock Results screen sanctioned per BDD US-Mock-05). |

## Inventory updates

- `docs/lattice-chains.md` — 3 new chain rows (Compose + Session/learner boundaries + RBAC/redaction) + 3 new rule-registry entries
- `lattice-self-maintenance.test.ts` — ratchets stay at incumbent levels (rows added in same commit, no orphans)

## Live signal — the leak gate fired RED on first run

When initially set with `EXPECTED_LEAK_COUNT = 0` and no exempts, the leak test caught two real leaks in `apps/foh/app/api/scores/route.ts`:
- `IELTS_CRITERIA:Lexical Resource`
- `IELTS_CRITERIA:Pronunciation`

Both serve the Mock Results screen, which per BDD US-Mock-05 + HF-IELTS-Pre-Voice-Testing-Checklist Unit 5 is explicitly sanctioned to display per-criterion bands. Exempted with reason citing the spec. The test detected real leaks against live code on first run — confirms the structural check works.

## Alignment with epic #2135

Epic [#2135](https://github.com/WANDERCOLTD/HF/issues/2135) (6 OPEN stories #2136-2141) addresses the architectural root cause: IELTS scoring today is OUTSIDE the canonical PIPELINE (only fires when prosody vendor is wired; today vendor isn't wired → `CallerTarget.currentScore = NULL` → #1955 Part-3 focus pin has nothing to derive from).

- **#2139 S4** explicitly calls for Lattice coverage gates. This PR is preparatory groundwork for that story.
- **The runtime SUPERVISE-spec gate** (the complement to my static-literal gate) is owed by #2139.
- **Part3TechniqueFocus generic SessionFocus substrate** (REWARD-spec driven, course-agnostic) is the deeper fix — deferred to follow-on under #2135 or a sibling epic.

## What this PR explicitly does NOT do

- Does NOT fix #1955's actual runtime leak (criterion label flowing through props from `select-pinned-card.ts`). That's owed by #2139 SUPERVISE-spec.
- Does NOT add the canonical IELTS MEASURE spec (owed by #2136).
- Does NOT introduce a `Part3TechniqueFocus` type union. The 4 technique labels per BDD spec need their own story.
- Does NOT bridge mode → learning data (Gate A from prior analysis — mode → which AnalysisSpec fires). That's owed by #2137.

## Verified by

- `npx vitest run tests/lib/sim-chat tests/lib/voice/sessionkind-reader-coverage tests/lib/lattice-self-maintenance` → 34 passed (8 + 7 + 9 + 10)
- Live grep confirmed every exemption points at the cited file
- Tests fired RED on initial run before exempts were calibrated to real code state (S1 caught my 4 mental-model errors; S3 caught 2 real Mock Results leaks)
- No new ESLint errors
- pre-push hook passed

## Test plan

- [x] All vitests pass locally
- [x] Pre-push hook clean
- [ ] CI green
- [ ] Tech-lead review of the architectural shape (3-axis matrix for S1, course-agnostic registry for S3)
- [ ] Confirm exempts for IELTS_CRITERIA:Lexical Resource + Pronunciation match operator intent (Mock Results screen sanctioned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)