### PR TITLE
feat(prosody): #2138 — refactor prosody-consumer to write prosody_raw_* IDs (S3 of #2135)

### DIFF
--- a/apps/admin/lib/curriculum/validate-ielts-completion.ts
+++ b/apps/admin/lib/curriculum/validate-ielts-completion.ts
@@ -36,7 +36,11 @@
 
 import { prisma } from "@/lib/prisma";
 
-/** IELTS 4-criteria parameter ids — must mirror prosody-consumer.ts::IELTS_PARAM_IDS. */
+/** IELTS 4-criteria parameter ids. Post-#2138 (epic #2135 S3) these are
+ *  written by the IELTS-MEASURE-001 LLM spec via the canonical SCORE_AGENT
+ *  path (#2155); prosody-consumer writes its own `prosody_raw_*` namespace
+ *  instead. The IDs here are the LLM-judged scores the completion gate
+ *  reads to decide whether all 4 criteria have a non-zero score. */
 export const IELTS_COMPLETION_PARAM_IDS = {
   fluencyCoherence: "skill_fluency_and_coherence_fc",
   pronunciation: "skill_pronunciation_p",
@@ -57,9 +61,10 @@ export interface ValidateIeltsCompletionResult {
 
 /**
  * Check whether the call's aggregate IELTS scores satisfy the 4-criteria
- * gate. Reads the aggregate (`segmentKey IS NULL`) rows written by
- * `prosody-consumer.ts::writeIeltsCallScores` — per-phase rows are
- * intentionally NOT consulted because the gate runs at call-level.
+ * gate. Reads the aggregate (`segmentKey IS NULL`) rows written by the
+ * IELTS-MEASURE-001 LLM spec via the canonical SCORE_AGENT path (post-#2138).
+ * Per-phase rows are intentionally NOT consulted because the gate runs
+ * at call-level.
  *
  * Score must be `> 0` (the writer skips non-finite bands but a zero
  * band would still produce a `score = 0` row; that's an incomplete

--- a/apps/admin/lib/journey/module-settings-flag.ts
+++ b/apps/admin/lib/journey/module-settings-flag.ts
@@ -32,15 +32,32 @@ export function isIeltsModuleSettingsEnabled(): boolean {
  * Feature flag for epic #2135 — IELTS-MEASURE-001 LLM transcript scoring.
  *
  * **Default OFF.** When enabled (`HF_IELTS_LLM_MEASURE_V1=true`), the
- * `IELTS-MEASURE-001` AnalysisSpec runs via the EXTRACT stage and writes
- * `CallScore` rows for the 4 IELTS skill parameters. The legacy
- * prosody-consumer's `writeIeltsCallScores` then skips IELTS-skill writes
- * (LLM spec owns those rows).
+ * `IELTS-MEASURE-001` AnalysisSpec runs via the EXTRACT / SCORE_AGENT
+ * stage and writes `CallScore` rows for the 4 IELTS skill parameter IDs
+ * (`skill_fluency_and_coherence_fc`, `skill_pronunciation_p`,
+ * `skill_lexical_resource_lr`, `skill_grammatical_range_and_accuracy_gra`).
  *
- * When disabled, the legacy path is unchanged — prosody-consumer
- * continues to be the sole writer for the 4 IELTS skill params (which
- * means callers without prosody-vendor signal continue to get NO IELTS
- * skill scores at all, the very gap epic #2135 closes).
+ * **Post-#2138 (S3) flag scope:**
+ *
+ * The flag now controls ONLY the LLM-judged path's enablement. It no
+ * longer gates the prosody-consumer at all — #2138 refactored the
+ * prosody IELTS-mode writer to target separate `prosody_raw_*`
+ * parameter IDs (`prosody_raw_fc` / `_p` / `_lr` / `_gra`). The two
+ * writers now target disjoint parameterId namespaces, so no dual-writer
+ * race is possible regardless of flag state. Prosody-raw rows always
+ * land when the vendor envelope is present.
+ *
+ * Lifecycle:
+ *   - Flag OFF (today's default) → no LLM-judged IELTS skill scores.
+ *     Prosody-raw rows still land (audio-feature signal preserved).
+ *     Note: the 4 IELTS skill IDs receive ZERO CallScore rows in this
+ *     state — that is the gap epic #2135 exists to close. Flip ON.
+ *   - Flag ON → LLM-judged IELTS skill scores land via SCORE_AGENT.
+ *     Prosody-raw rows continue to land independently. Tool-use
+ *     augmentation (LLM consuming prosody-raw to boost FC + P
+ *     confidence) is a post-MVP enhancement, not gated by this flag.
+ *   - Post-S6 verification → consider promoting to always-on and
+ *     retiring the flag in a follow-on chore.
  *
  * **OPERATOR RULE (verbatim, from epic #2135):**
  * NEVER land hardcoded or AI-guessed score defaults to "fill" empty

--- a/apps/admin/lib/pipeline/prosody-consumer.ts
+++ b/apps/admin/lib/pipeline/prosody-consumer.ts
@@ -1,18 +1,40 @@
 /**
- * AGGREGATE consumer of VOICE_PROSODY_V1 envelopes (#1119).
+ * AGGREGATE consumer of VOICE_PROSODY_V1 envelopes (#1119, refactored #2138).
  *
  * Reads `Call.voiceProsody` (populated upstream by `prosody-runner.ts`)
  * and writes downstream rows:
  *
- *   mode === "ielts"        → 4 CallScore rows on the IELTS skill
- *                             parameters (normalised 0–9 → 0–1 for the
- *                             existing SKILL-AGG-001 EMA pipeline)
- *   mode === "general"      → CallScore deltas on `CONV_PACE` and
- *                             `pace_indicators` (the two confirmed
- *                             general-mode parameters). `confidenceProxy`
- *                             stays on the envelope but has no consumer
- *                             in this story.
+ *   mode === "ielts"        → up to 4 CallScore rows on `prosody_raw_*`
+ *                             parameters (audio-feature signal, distinct
+ *                             from the LLM-judged IELTS skill IDs owned
+ *                             by IELTS-MEASURE-001 via SCORE_AGENT).
+ *                             Normalised 0–9 → 0–1.
+ *   mode === "general"      → CallScore deltas on `prosody_pace_wpm` and
+ *                             `prosody_hesitation_rate` (the two
+ *                             confirmed general-mode parameters).
+ *                             `confidenceProxy` stays on the envelope
+ *                             but has no parameter consumer.
  *   mode === "unavailable"  → skip silently (no rows written)
+ *
+ * #2138 (epic #2135 S3) — IELTS-mode writer refactor:
+ *
+ *   Pre-#2138, the IELTS-mode writer targeted the 4 IELTS skill parameter
+ *   IDs (`skill_*`) directly. That was structurally wrong because (a) the
+ *   vendor cannot reliably score LR or GRA from audio features alone —
+ *   those need LLM judgment of transcript text content; and (b) the
+ *   bespoke prosody writer bypassed the canonical MEASURE-spec path.
+ *
+ *   #2155 (S2) introduced IELTS-MEASURE-001 — an LLM transcript-judgment
+ *   spec running via the canonical SCORE_AGENT path. It now writes the 4
+ *   IELTS skill CallScore rows. S2 flag-gated the prosody-consumer's
+ *   IELTS-skill writes to avoid a dual-writer race during transition.
+ *
+ *   S3 (this refactor) closes the transition by giving prosody its own
+ *   `prosody_raw_*` parameter IDs. The two writers now target disjoint
+ *   parameterId namespaces — no collision possible regardless of flag
+ *   state. The IELTS-MEASURE-001 spec MAY optionally consume the
+ *   prosody-raw rows via tool-use (post-MVP) to augment FC + P
+ *   confidence. LR + GRA stay LLM-only forever.
  *
  * Idempotent — uses `upsert` on the CallScore `(callId, parameterId,
  * moduleId)` unique index. A repeat call with the same envelope produces
@@ -30,7 +52,6 @@ import {
   writeCallScore,
   MEASUREMENT_SENTINEL_SPEC_IDS,
 } from "@/lib/measurement/write-call-score";
-import { ieltsLlmMeasureV1Enabled } from "@/lib/journey/module-settings-flag";
 
 import type {
   GeneralSignals,
@@ -39,15 +60,50 @@ import type {
   VoiceProsodyFeatures,
 } from "./prosody-types";
 
-/** Parameter IDs targeted by the IELTS mode write. These map onto the
- *  existing SKILL_MEASURE_V1 contract parameters that already flow into
- *  the SKILL-AGG-001 EMA pipeline. */
-const IELTS_PARAM_IDS = {
-  fluencyCoherence: "skill_fluency_and_coherence_fc",
-  pronunciation: "skill_pronunciation_p",
-  lexicalResource: "skill_lexical_resource_lr",
-  grammaticalRange: "skill_grammatical_range_and_accuracy_gra",
+/**
+ * #2138 (epic #2135 S3) — IELTS-mode prosody-raw parameter IDs.
+ *
+ * These are the SEPARATE namespace from the 4 IELTS skill parameter IDs
+ * (`skill_fluency_and_coherence_fc`, `skill_pronunciation_p`,
+ * `skill_lexical_resource_lr`, `skill_grammatical_range_and_accuracy_gra`)
+ * which are owned by the IELTS-MEASURE-001 LLM spec via the canonical
+ * SCORE_AGENT path (#2155).
+ *
+ * Confidence per row:
+ *   - FC + P → 0.9 (audio fluency + phoneme features are vendor's strength)
+ *   - LR + GRA → 0.7 (vendor cannot reliably score vocab/grammar from
+ *                     audio — included for completeness; LR+GRA stay
+ *                     LLM-only forever)
+ *
+ * Optionally consumed by IELTS-MEASURE-001 via tool-use (post-MVP) to
+ * augment FC + P LLM judgment when vendor signal is present. LR + GRA
+ * remain LLM-only regardless.
+ */
+const PROSODY_RAW_PARAM_IDS = {
+  fluencyCoherence: "prosody_raw_fc",
+  pronunciation: "prosody_raw_p",
+  lexicalResource: "prosody_raw_lr",
+  grammaticalRange: "prosody_raw_gra",
 } as const;
+
+/**
+ * #2138 — Per-criterion confidence for the prosody-raw IELTS rows.
+ *
+ * FC + P are reasonably observable from vendor audio features. LR + GRA
+ * are audio-feature approximations of text-content phenomena — the
+ * vendor cannot score them reliably. The lower confidence flags this to
+ * any future tool-use consumer (e.g. IELTS-MEASURE-001 reading these
+ * rows to augment its LLM judgment).
+ */
+const PROSODY_RAW_CONFIDENCE: Record<
+  keyof typeof PROSODY_RAW_PARAM_IDS,
+  number
+> = {
+  fluencyCoherence: 0.9,
+  pronunciation: 0.9,
+  lexicalResource: 0.7,
+  grammaticalRange: 0.7,
+};
 
 /** Parameter IDs targeted by the general-mode write.
  *
@@ -118,7 +174,7 @@ export async function applyProsodyContractToAggregate(
     // row shape that AGGREGATE EMA + Snapshot read. Skip when top-level
     // is "unavailable" (every phase failed).
     if (envelope.mode === "ielts" && envelope.ieltsScores) {
-      written += await writeIeltsCallScores(
+      written += await writeProsodyRawCallScores(
         callId,
         callerId,
         envelope.ieltsScores,
@@ -134,7 +190,7 @@ export async function applyProsodyContractToAggregate(
   }
 
   if (envelope.mode === "ielts" && envelope.ieltsScores) {
-    const written = await writeIeltsCallScores(
+    const written = await writeProsodyRawCallScores(
       callId,
       callerId,
       envelope.ieltsScores,
@@ -171,34 +227,67 @@ async function writePhaseEnvelope(
 ): Promise<number> {
   if (phase.mode === "unavailable") return 0;
   if (phase.mode === "ielts") {
-    return writeIeltsCallScores(callId, callerId, phase.ieltsScores, phaseKey);
+    return writeProsodyRawCallScores(callId, callerId, phase.ieltsScores, phaseKey);
   }
   return writeGeneralCallScores(callId, callerId, phase.generalSignals, phaseKey);
 }
 
-async function writeIeltsCallScores(
+/**
+ * #2138 (epic #2135 S3) — Write vendor-derived IELTS audio-feature signal
+ * to the `prosody_raw_*` parameter slots.
+ *
+ * This used to target the 4 IELTS skill parameter IDs (`skill_*`) directly,
+ * but those are now owned by the IELTS-MEASURE-001 LLM spec via the
+ * canonical SCORE_AGENT path (#2155). Prosody writes its OWN namespace
+ * (`prosody_raw_fc` / `_p` / `_lr` / `_gra`) so the two writers never
+ * collide — no flag gating is needed because the parameterId namespaces
+ * are disjoint.
+ *
+ * Per criterion: FC + P land at confidence 0.9 (vendor's strong suit —
+ * audio fluency + phoneme features). LR + GRA land at confidence 0.7 —
+ * vendor cannot reliably score vocab / grammar from audio features, but
+ * the row is still recorded for forensics + completeness. The LLM is the
+ * authoritative scorer for LR + GRA via IELTS-MEASURE-001.
+ *
+ * Per OPERATOR RULE (epic #2135): null / non-finite bands → no write
+ * out. Never hardcode a score default to fill an empty row.
+ */
+async function writeProsodyRawCallScores(
   callId: string,
   callerId: string | null,
   ielts: IeltsScores,
   segmentKey?: string,
 ): Promise<number> {
-  // #2137 (epic #2135 S2) — when the LLM MEASURE path is on, the
-  // IELTS-MEASURE-001 spec owns the 4 IELTS skill CallScore rows.
-  // Prosody-consumer MUST skip the IELTS-skill write to avoid the
-  // dual-writer race documented in epic #2135 ("LLM spec writes first
-  // via canonical chokepoint; prosody-consumer ONLY writes if the LLM
-  // spec produced a row OR via different parameterIds"). The prosody-
-  // raw augmentation path (#2138 / S3) introduces separate parameter
-  // ids (`prosody_raw_*`) that the LLM spec reads via tool-use.
-  if (ieltsLlmMeasureV1Enabled()) {
-    return 0;
-  }
-
-  const rows: Array<{ parameterId: string; band: number }> = [
-    { parameterId: IELTS_PARAM_IDS.fluencyCoherence, band: ielts.fluencyCoherence },
-    { parameterId: IELTS_PARAM_IDS.pronunciation, band: ielts.pronunciation },
-    { parameterId: IELTS_PARAM_IDS.lexicalResource, band: ielts.lexicalResource },
-    { parameterId: IELTS_PARAM_IDS.grammaticalRange, band: ielts.grammaticalRange },
+  const rows: Array<{
+    parameterId: string;
+    band: number;
+    confidence: number;
+    criterion: keyof typeof PROSODY_RAW_PARAM_IDS;
+  }> = [
+    {
+      parameterId: PROSODY_RAW_PARAM_IDS.fluencyCoherence,
+      band: ielts.fluencyCoherence,
+      confidence: PROSODY_RAW_CONFIDENCE.fluencyCoherence,
+      criterion: "fluencyCoherence",
+    },
+    {
+      parameterId: PROSODY_RAW_PARAM_IDS.pronunciation,
+      band: ielts.pronunciation,
+      confidence: PROSODY_RAW_CONFIDENCE.pronunciation,
+      criterion: "pronunciation",
+    },
+    {
+      parameterId: PROSODY_RAW_PARAM_IDS.lexicalResource,
+      band: ielts.lexicalResource,
+      confidence: PROSODY_RAW_CONFIDENCE.lexicalResource,
+      criterion: "lexicalResource",
+    },
+    {
+      parameterId: PROSODY_RAW_PARAM_IDS.grammaticalRange,
+      band: ielts.grammaticalRange,
+      confidence: PROSODY_RAW_CONFIDENCE.grammaticalRange,
+      criterion: "grammaticalRange",
+    },
   ];
 
   let written = 0;
@@ -220,9 +309,12 @@ async function writeIeltsCallScores(
       moduleId: null,
       segmentKey: segmentKey ?? null,
       score: normalisedScore,
-      confidence: 0.9,
-      evidence: [`prosody/ielts:band=${row.band.toFixed(1)}`],
-      reasoning: "PROSODY stage IELTS sub-band (0-9 normalised to 0-1)",
+      confidence: row.confidence,
+      evidence: [`prosody/ielts:${row.criterion}:band=${row.band.toFixed(1)}`],
+      reasoning:
+        "PROSODY stage IELTS audio-feature signal (0-9 normalised to 0-1); " +
+        "raw vendor signal, distinct from the LLM-judged skill_* IDs " +
+        "owned by IELTS-MEASURE-001.",
       scoredBy: "prosody_v1",
     });
     written++;

--- a/apps/admin/prisma/seed-prosody-parameters.ts
+++ b/apps/admin/prisma/seed-prosody-parameters.ts
@@ -24,6 +24,38 @@
  *   They measure different things — qualitative judgment vs quantitative
  *   signal. Both surfaces stay alive; neither overwrites the other.
  *
+ * #2138 (epic #2135 S3) — same shape applied to the IELTS mode:
+ *
+ *   Pre-#2138, `lib/pipeline/prosody-consumer.ts` IELTS-mode wrote to the 4
+ *   IELTS skill parameter IDs (`skill_fluency_and_coherence_fc`,
+ *   `skill_pronunciation_p`, `skill_lexical_resource_lr`,
+ *   `skill_grammatical_range_and_accuracy_gra`). #2155 (epic #2135 S2)
+ *   introduced the canonical IELTS-MEASURE-001 LLM spec as the rightful
+ *   writer of those 4 IDs — the prosody vendor cannot reliably score LR or
+ *   GRA (those require LLM judgment of transcript content; the vendor only
+ *   sees audio features). The S2 path was flag-gated to avoid a dual-writer
+ *   race during transition.
+ *
+ *   S3 closes the transition: prosody-consumer now writes to its own
+ *   `prosody_raw_*` slots instead. The LLM spec is the sole writer to the
+ *   IELTS skill IDs; the prosody vendor's raw audio-feature signal lives in
+ *   `prosody_raw_*` rows that the IELTS-MEASURE-001 spec MAY optionally
+ *   consume via tool-use (post-MVP) to augment FC + P confidence. LR + GRA
+ *   stay LLM-only forever — but the prosody-raw rows still land so the
+ *   vendor signal isn't silently dropped.
+ *
+ *     - `prosody_raw_fc` — vendor-measured Fluency & Coherence band signal
+ *       (band 0–9 normalised to 0–1), confidence 0.9 — audio fluency
+ *       features are reasonably observable from vendor signal
+ *     - `prosody_raw_p`  — vendor-measured Pronunciation band signal,
+ *       confidence 0.9 — phoneme accuracy is the vendor's strong suit
+ *     - `prosody_raw_lr` — vendor-measured Lexical Resource band signal,
+ *       confidence 0.7 — vendor cannot reliably score vocabulary from
+ *       audio features; this is an audio-feature approximation
+ *     - `prosody_raw_gra`— vendor-measured Grammatical Range & Accuracy
+ *       band signal, confidence 0.7 — same caveat as LR; included for
+ *       completeness but the LLM is the authority
+ *
  * Note on values today: the vendor adapter at
  * `lib/pipeline/prosody-runner.ts:367-373` hardcodes `paceWpm: 0` and
  * `hesitationRate: 0` because the SpeechAce / SpeechSuper response shape
@@ -33,12 +65,22 @@
  * The split is still correct: the zeros are now isolated to their own
  * parameter slot, not polluting the AI-judged `CONV_PACE` value.
  *
+ * On `domainGroup`: per `lib/registry/canonical-domain-group.ts`, the
+ * canonical 12-tuple includes `voice-delivery` — the closest match for
+ * vendor-derived voice signals. The 4 new IELTS prosody-raw rows use the
+ * same group as the existing `prosody_pace_wpm` / `prosody_hesitation_rate`
+ * (`voice`). Pre-existing `voice` value is non-canonical (legacy debt) —
+ * we mirror it here for consistency rather than introducing a fresh
+ * divergence. The DB-parity ratchet (#2040 S7) tracks this.
+ *
  * Idempotent — uses `findUnique → update | create`. Re-running is a no-op
  * when the rows already exist with the same shape.
  *
  * @see prisma/seed-tolerance-parameters.ts — template for this shape
  * @see lib/pipeline/prosody-consumer.ts::GENERAL_PARAM_IDS — the constants
- *      that route the writes
+ *      that route the general-mode writes
+ * @see lib/pipeline/prosody-consumer.ts::PROSODY_RAW_PARAM_IDS — the
+ *      constants that route the IELTS-mode prosody-raw writes (#2138)
  * @see docs/decisions/2026-06-15-agent-report-verification.md — context
  *      for the audit that surfaced the overwrite
  */
@@ -84,6 +126,89 @@ const PROSODY_PARAMETERS: ProsodyParameterSeed[] = [
       "consumer.ts during AGGREGATE when the prosody envelope mode is " +
       "'general'. Distinct from pace_indicators (which is the AI-judged " +
       "hesitation marker count from EXTRACT). Observational signal.",
+    sectionId: "prosody",
+    domainGroup: "voice",
+    scaleType: "0-1",
+    directionality: "positive",
+    computedBy: "prosody-vendor",
+  },
+  // #2138 (epic #2135 S3) — IELTS-mode prosody-raw slots. Separate from
+  // the 4 IELTS skill parameter IDs (`skill_fluency_and_coherence_fc`,
+  // `skill_pronunciation_p`, `skill_lexical_resource_lr`,
+  // `skill_grammatical_range_and_accuracy_gra`) which are owned by the
+  // IELTS-MEASURE-001 LLM spec via the canonical SCORE_AGENT path (#2155).
+  // These prosody-raw rows carry the vendor's audio-feature signal so
+  // (a) it isn't silently dropped, and (b) the IELTS-MEASURE-001 spec MAY
+  // optionally consume them via tool-use (post-MVP) to augment FC + P
+  // confidence. LR + GRA confidence stays 0.7 — vendor cannot reliably
+  // score vocab/grammar from audio features alone.
+  {
+    parameterId: "prosody_raw_fc",
+    name: "Prosody — Fluency & Coherence raw signal",
+    definition:
+      "Vendor-measured Fluency & Coherence band signal (band 0–9 " +
+      "normalised to 0–1). Written by lib/pipeline/prosody-consumer.ts " +
+      "during AGGREGATE when the prosody envelope mode is 'ielts'. " +
+      "Distinct from skill_fluency_and_coherence_fc (which is the " +
+      "LLM-judged transcript score from IELTS-MEASURE-001 via " +
+      "SCORE_AGENT). Audio fluency features are reasonably observable " +
+      "from vendor signal, so confidence is 0.9. Optionally consumed by " +
+      "IELTS-MEASURE-001 via tool-use (post-MVP) to augment LLM judgment.",
+    sectionId: "prosody",
+    domainGroup: "voice",
+    scaleType: "0-1",
+    directionality: "positive",
+    computedBy: "prosody-vendor",
+  },
+  {
+    parameterId: "prosody_raw_p",
+    name: "Prosody — Pronunciation raw signal",
+    definition:
+      "Vendor-measured Pronunciation band signal (band 0–9 normalised " +
+      "to 0–1). Written by lib/pipeline/prosody-consumer.ts during " +
+      "AGGREGATE when the prosody envelope mode is 'ielts'. Distinct " +
+      "from skill_pronunciation_p (which is the LLM-judged transcript " +
+      "score from IELTS-MEASURE-001). Phoneme accuracy is the vendor's " +
+      "strongest signal — confidence 0.9. Optionally consumed by " +
+      "IELTS-MEASURE-001 via tool-use (post-MVP) to augment LLM judgment.",
+    sectionId: "prosody",
+    domainGroup: "voice",
+    scaleType: "0-1",
+    directionality: "positive",
+    computedBy: "prosody-vendor",
+  },
+  {
+    parameterId: "prosody_raw_lr",
+    name: "Prosody — Lexical Resource raw signal",
+    definition:
+      "Vendor-measured Lexical Resource band signal (band 0–9 normalised " +
+      "to 0–1). Written by lib/pipeline/prosody-consumer.ts during " +
+      "AGGREGATE when the prosody envelope mode is 'ielts'. Distinct " +
+      "from skill_lexical_resource_lr (which is the LLM-judged " +
+      "transcript score from IELTS-MEASURE-001 — the authoritative LR " +
+      "score). The vendor cannot reliably score vocabulary from audio " +
+      "features alone; this row is an audio-feature approximation only, " +
+      "confidence 0.7. NOT consumed by IELTS-MEASURE-001 — kept for " +
+      "completeness + forensics.",
+    sectionId: "prosody",
+    domainGroup: "voice",
+    scaleType: "0-1",
+    directionality: "positive",
+    computedBy: "prosody-vendor",
+  },
+  {
+    parameterId: "prosody_raw_gra",
+    name: "Prosody — Grammatical Range & Accuracy raw signal",
+    definition:
+      "Vendor-measured Grammatical Range & Accuracy band signal (band " +
+      "0–9 normalised to 0–1). Written by lib/pipeline/prosody-" +
+      "consumer.ts during AGGREGATE when the prosody envelope mode is " +
+      "'ielts'. Distinct from skill_grammatical_range_and_accuracy_gra " +
+      "(which is the LLM-judged transcript score from IELTS-MEASURE-001 " +
+      "— the authoritative GRA score). The vendor cannot reliably score " +
+      "grammar from audio features alone; this row is an audio-feature " +
+      "approximation only, confidence 0.7. NOT consumed by " +
+      "IELTS-MEASURE-001 — kept for completeness + forensics.",
     sectionId: "prosody",
     domainGroup: "voice",
     scaleType: "0-1",

--- a/apps/admin/tests/lib/pipeline/prosody-consumer.test.ts
+++ b/apps/admin/tests/lib/pipeline/prosody-consumer.test.ts
@@ -3,20 +3,31 @@
  *
  * Pins the canonical writer→param-slot mapping enforced by
  * `lib/pipeline/prosody-consumer.ts::GENERAL_PARAM_IDS` and
- * `IELTS_PARAM_IDS`. If a future refactor changes the constant values,
- * this bank fails before reaching hf_sandbox.
+ * `PROSODY_RAW_PARAM_IDS`. If a future refactor changes the constant
+ * values, this bank fails before reaching hf_sandbox.
  *
- * Why this matters (2026-06-15 audit):
- *   Pre-split, `GENERAL_PARAM_IDS` pointed at `CONV_PACE` /
- *   `pace_indicators` — also written by EXTRACT from AI transcript
- *   analysis. With `writeCallScore`'s `(callId, parameterId, moduleId)`
- *   idempotency, the AGGREGATE prosody consumer ran AFTER EXTRACT and
- *   overwrote the AI-judged values with vendor-derived ones (today:
- *   hardcoded zeros). This test pins the split that keeps both writers'
- *   surfaces alive.
+ * Why this matters (2026-06-15 audit + #2138 refactor):
+ *
+ *   GENERAL mode (2026-06-15):
+ *     Pre-split, `GENERAL_PARAM_IDS` pointed at `CONV_PACE` /
+ *     `pace_indicators` — also written by EXTRACT from AI transcript
+ *     analysis. With `writeCallScore`'s `(callId, parameterId,
+ *     moduleId)` idempotency, the AGGREGATE prosody consumer ran AFTER
+ *     EXTRACT and overwrote the AI-judged values with vendor-derived
+ *     ones (today: hardcoded zeros). This test pins the split that
+ *     keeps both writers' surfaces alive.
+ *
+ *   IELTS mode (#2138, epic #2135 S3):
+ *     Pre-#2138, the IELTS-mode writer targeted the 4 IELTS skill
+ *     parameter IDs (`skill_*`) directly. Those are now owned by the
+ *     IELTS-MEASURE-001 LLM spec via the canonical SCORE_AGENT path
+ *     (#2155). Prosody now writes its own `prosody_raw_*` namespace —
+ *     no collision possible regardless of `HF_IELTS_LLM_MEASURE_V1`
+ *     flag state. This test pins the new namespace AND the negative
+ *     assertion that prosody NEVER writes the IELTS skill IDs.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { VoiceProsodyFeatures } from "@/lib/pipeline/prosody-types";
 
 const { mockPrisma, mockWriteCallScore } = vi.hoisted(() => ({
@@ -154,8 +165,8 @@ describe("prosody-consumer — parameter slot routing", () => {
     });
   });
 
-  describe("IELTS mode — 4 skill_* slots untouched by the split", () => {
-    it("writes the 4 IELTS skill CallScore rows", async () => {
+  describe("#2138 — IELTS mode writes to prosody_raw_* slots (NEVER skill_*)", () => {
+    it("writes the 4 prosody_raw_* CallScore rows", async () => {
       const envelope: VoiceProsodyFeatures = {
         mode: "ielts",
         ieltsScores: {
@@ -177,14 +188,211 @@ describe("prosody-consumer — parameter slot routing", () => {
       const paramIds = mockWriteCallScore.mock.calls.map(
         (c) => (c[0] as { parameterId: string }).parameterId,
       );
+      // Prosody-raw IDs land — vendor signal preserved without colliding
+      // with the IELTS skill IDs owned by IELTS-MEASURE-001.
       expect(paramIds).toEqual(
         expect.arrayContaining([
-          "skill_fluency_and_coherence_fc",
-          "skill_pronunciation_p",
-          "skill_lexical_resource_lr",
-          "skill_grammatical_range_and_accuracy_gra",
+          "prosody_raw_fc",
+          "prosody_raw_p",
+          "prosody_raw_lr",
+          "prosody_raw_gra",
         ]),
       );
+    });
+
+    it("NEVER writes the 4 IELTS skill IDs — those are owned by IELTS-MEASURE-001 (#2155)", async () => {
+      const envelope: VoiceProsodyFeatures = {
+        mode: "ielts",
+        ieltsScores: {
+          fluencyCoherence: 7,
+          pronunciation: 6.5,
+          lexicalResource: 7.5,
+          grammaticalRange: 6,
+          overall: 7,
+        },
+      };
+      mockPrisma.call.findUnique.mockResolvedValue({ voiceProsody: envelope });
+
+      await applyProsodyContractToAggregate("call-1", "caller-1");
+
+      const paramIds = mockWriteCallScore.mock.calls.map(
+        (c) => (c[0] as { parameterId: string }).parameterId,
+      );
+      // The structural separation — prosody-consumer NEVER touches the
+      // 4 IELTS skill IDs (regardless of HF_IELTS_LLM_MEASURE_V1 flag
+      // state). The flag now controls only the LLM-judged path's
+      // enablement; prosody-raw writes run unconditionally.
+      expect(paramIds).not.toContain("skill_fluency_and_coherence_fc");
+      expect(paramIds).not.toContain("skill_pronunciation_p");
+      expect(paramIds).not.toContain("skill_lexical_resource_lr");
+      expect(paramIds).not.toContain("skill_grammatical_range_and_accuracy_gra");
+    });
+
+    it("normalises band 0–9 → score 0–1 (band 7 → 0.778)", async () => {
+      const envelope: VoiceProsodyFeatures = {
+        mode: "ielts",
+        ieltsScores: {
+          fluencyCoherence: 7,
+          pronunciation: 0,
+          lexicalResource: 0,
+          grammaticalRange: 0,
+          overall: 7,
+        },
+      };
+      mockPrisma.call.findUnique.mockResolvedValue({ voiceProsody: envelope });
+
+      await applyProsodyContractToAggregate("call-1", "caller-1");
+
+      const fcCall = mockWriteCallScore.mock.calls.find(
+        (c) => (c[0] as { parameterId: string }).parameterId === "prosody_raw_fc",
+      );
+      expect(fcCall).toBeDefined();
+      expect((fcCall![0] as { score: number }).score).toBeCloseTo(7 / 9, 5);
+    });
+
+    it("FC + P stamp confidence 0.9 (vendor's strong suit — audio fluency + phonemes)", async () => {
+      const envelope: VoiceProsodyFeatures = {
+        mode: "ielts",
+        ieltsScores: {
+          fluencyCoherence: 7,
+          pronunciation: 6.5,
+          lexicalResource: 7,
+          grammaticalRange: 6,
+          overall: 7,
+        },
+      };
+      mockPrisma.call.findUnique.mockResolvedValue({ voiceProsody: envelope });
+
+      await applyProsodyContractToAggregate("call-1", "caller-1");
+
+      const fcCall = mockWriteCallScore.mock.calls.find(
+        (c) => (c[0] as { parameterId: string }).parameterId === "prosody_raw_fc",
+      );
+      const pCall = mockWriteCallScore.mock.calls.find(
+        (c) => (c[0] as { parameterId: string }).parameterId === "prosody_raw_p",
+      );
+      expect((fcCall![0] as { confidence: number }).confidence).toBe(0.9);
+      expect((pCall![0] as { confidence: number }).confidence).toBe(0.9);
+    });
+
+    it("LR + GRA stamp confidence 0.7 (vendor cannot reliably score vocab/grammar from audio)", async () => {
+      const envelope: VoiceProsodyFeatures = {
+        mode: "ielts",
+        ieltsScores: {
+          fluencyCoherence: 7,
+          pronunciation: 6.5,
+          lexicalResource: 7,
+          grammaticalRange: 6,
+          overall: 7,
+        },
+      };
+      mockPrisma.call.findUnique.mockResolvedValue({ voiceProsody: envelope });
+
+      await applyProsodyContractToAggregate("call-1", "caller-1");
+
+      const lrCall = mockWriteCallScore.mock.calls.find(
+        (c) => (c[0] as { parameterId: string }).parameterId === "prosody_raw_lr",
+      );
+      const graCall = mockWriteCallScore.mock.calls.find(
+        (c) => (c[0] as { parameterId: string }).parameterId === "prosody_raw_gra",
+      );
+      expect((lrCall![0] as { confidence: number }).confidence).toBe(0.7);
+      expect((graCall![0] as { confidence: number }).confidence).toBe(0.7);
+    });
+
+    it("skips non-finite bands — null → no write (operator rule: never fabricate defaults)", async () => {
+      const envelope: VoiceProsodyFeatures = {
+        mode: "ielts",
+        ieltsScores: {
+          fluencyCoherence: 7,
+          pronunciation: NaN, // vendor returned no signal for P
+          lexicalResource: 7,
+          grammaticalRange: 6,
+          overall: 7,
+        },
+      };
+      mockPrisma.call.findUnique.mockResolvedValue({ voiceProsody: envelope });
+
+      const result = await applyProsodyContractToAggregate("call-1", "caller-1");
+
+      // 3 of 4 lands — P is skipped because vendor returned no signal.
+      // Honest empty rather than hardcoded zero.
+      expect(result.scoresWritten).toBe(3);
+      const paramIds = mockWriteCallScore.mock.calls.map(
+        (c) => (c[0] as { parameterId: string }).parameterId,
+      );
+      expect(paramIds).not.toContain("prosody_raw_p");
+    });
+
+    it("evidence string identifies the criterion + raw band (forensics)", async () => {
+      const envelope: VoiceProsodyFeatures = {
+        mode: "ielts",
+        ieltsScores: {
+          fluencyCoherence: 7,
+          pronunciation: 6.5,
+          lexicalResource: 7,
+          grammaticalRange: 6,
+          overall: 7,
+        },
+      };
+      mockPrisma.call.findUnique.mockResolvedValue({ voiceProsody: envelope });
+
+      await applyProsodyContractToAggregate("call-1", "caller-1");
+
+      const fcCall = mockWriteCallScore.mock.calls.find(
+        (c) => (c[0] as { parameterId: string }).parameterId === "prosody_raw_fc",
+      );
+      const evidence = (fcCall![0] as { evidence: string[] }).evidence;
+      expect(evidence[0]).toContain("fluencyCoherence");
+      expect(evidence[0]).toContain("band=7.0");
+    });
+
+    it("flag state irrelevant to prosody-raw writes — flag=true still writes 4 prosody_raw_* rows", async () => {
+      // #2138 — post-S3 the flag controls ONLY the LLM-judged path.
+      // Prosody-raw writes run unconditionally because the namespaces
+      // are disjoint (no dual-writer race possible).
+      const originalEnv = process.env.HF_IELTS_LLM_MEASURE_V1;
+      process.env.HF_IELTS_LLM_MEASURE_V1 = "true";
+      try {
+        vi.resetModules();
+        const mod = await import("@/lib/pipeline/prosody-consumer");
+        const fn = mod.applyProsodyContractToAggregate;
+
+        const envelope: VoiceProsodyFeatures = {
+          mode: "ielts",
+          ieltsScores: {
+            fluencyCoherence: 7,
+            pronunciation: 6.5,
+            lexicalResource: 7.5,
+            grammaticalRange: 6,
+            overall: 7,
+          },
+        };
+        mockPrisma.call.findUnique.mockResolvedValue({ voiceProsody: envelope });
+
+        const result = await fn("call-1", "caller-1");
+
+        expect(result.applied).toBe(true);
+        expect(result.scoresWritten).toBe(4);
+        const paramIds = mockWriteCallScore.mock.calls.map(
+          (c) => (c[0] as { parameterId: string }).parameterId,
+        );
+        expect(paramIds).toEqual(
+          expect.arrayContaining([
+            "prosody_raw_fc",
+            "prosody_raw_p",
+            "prosody_raw_lr",
+            "prosody_raw_gra",
+          ]),
+        );
+        expect(paramIds).not.toContain("skill_fluency_and_coherence_fc");
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.HF_IELTS_LLM_MEASURE_V1;
+        } else {
+          process.env.HF_IELTS_LLM_MEASURE_V1 = originalEnv;
+        }
+      }
     });
   });
 
@@ -205,70 +413,6 @@ describe("prosody-consumer — parameter slot routing", () => {
       expect(result.applied).toBe(false);
       expect(result.mode).toBe("unavailable");
       expect(mockWriteCallScore).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("#2137 — HF_IELTS_LLM_MEASURE_V1 flag gating of IELTS-skill writes", () => {
-    const originalEnv = process.env.HF_IELTS_LLM_MEASURE_V1;
-
-    afterEach(() => {
-      if (originalEnv === undefined) {
-        delete process.env.HF_IELTS_LLM_MEASURE_V1;
-      } else {
-        process.env.HF_IELTS_LLM_MEASURE_V1 = originalEnv;
-      }
-    });
-
-    it("when HF_IELTS_LLM_MEASURE_V1=true → skips IELTS-skill writes (LLM spec owns those rows)", async () => {
-      process.env.HF_IELTS_LLM_MEASURE_V1 = "true";
-      vi.resetModules();
-      const mod = await import("@/lib/pipeline/prosody-consumer");
-      const fn = mod.applyProsodyContractToAggregate;
-
-      const envelope: VoiceProsodyFeatures = {
-        mode: "ielts",
-        ieltsScores: {
-          fluencyCoherence: 7,
-          pronunciation: 6.5,
-          lexicalResource: 7.5,
-          grammaticalRange: 6,
-          overall: 7,
-        },
-      };
-      mockPrisma.call.findUnique.mockResolvedValue({ voiceProsody: envelope });
-
-      const result = await fn("call-1", "caller-1");
-
-      // Envelope was applied (mode resolved), but ZERO IELTS-skill rows written.
-      expect(result.applied).toBe(true);
-      expect(result.mode).toBe("ielts");
-      expect(result.scoresWritten).toBe(0);
-      expect(mockWriteCallScore).not.toHaveBeenCalled();
-    });
-
-    it("when flag is unset → preserves the legacy 4-row IELTS write (no regression)", async () => {
-      delete process.env.HF_IELTS_LLM_MEASURE_V1;
-      vi.resetModules();
-      const mod = await import("@/lib/pipeline/prosody-consumer");
-      const fn = mod.applyProsodyContractToAggregate;
-
-      const envelope: VoiceProsodyFeatures = {
-        mode: "ielts",
-        ieltsScores: {
-          fluencyCoherence: 7,
-          pronunciation: 6.5,
-          lexicalResource: 7.5,
-          grammaticalRange: 6,
-          overall: 7,
-        },
-      };
-      mockPrisma.call.findUnique.mockResolvedValue({ voiceProsody: envelope });
-
-      const result = await fn("call-1", "caller-1");
-
-      expect(result.applied).toBe(true);
-      expect(result.scoresWritten).toBe(4);
-      expect(mockWriteCallScore).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/apps/admin/tests/lib/specs/ielts-measure-001-shape.test.ts
+++ b/apps/admin/tests/lib/specs/ielts-measure-001-shape.test.ts
@@ -4,8 +4,11 @@
  * Pins the canonical shape of `IELTS-MEASURE-001-ielts-speaking-criteria.spec.json`
  * so that future refactors cannot:
  *
- * 1. Rename or drop any of the four canonical IELTS skill parameter ids
- *    (must exactly match `prosody-consumer.ts::IELTS_PARAM_IDS`).
+ * 1. Rename or drop any of the four canonical IELTS skill parameter ids.
+ *    Post-#2138 (epic #2135 S3) the IELTS-MEASURE-001 LLM spec is the
+ *    SOLE writer of these IDs via the canonical SCORE_AGENT path;
+ *    prosody-consumer now writes its own disjoint `prosody_raw_*`
+ *    namespace.
  * 2. Re-classify outputType away from `MEASURE` (would silently drop the
  *    spec from the SCORE_AGENT stage's `["MEASURE", "MEASURE_AGENT"]` pickup).
  * 3. Remove `profileCondition: ["ielts-speaking"]` (would fire the spec on
@@ -51,10 +54,11 @@ const SPEC_PATH = join(
   "IELTS-MEASURE-001-ielts-speaking-criteria.spec.json",
 );
 
-// Canonical IELTS skill parameter ids — MUST match
-// `lib/pipeline/prosody-consumer.ts::IELTS_PARAM_IDS` verbatim.
-// These are the four slots that flow into SKILL-AGG-001's EMA pipeline
-// and bind to the SKILL_MEASURE_V1 contract's parameter set.
+// Canonical IELTS skill parameter ids. Post-#2138 (epic #2135 S3) these
+// are written EXCLUSIVELY by IELTS-MEASURE-001 via SCORE_AGENT — prosody
+// writes a disjoint `prosody_raw_*` namespace. These four slots flow into
+// SKILL-AGG-001's EMA pipeline and bind to the SKILL_MEASURE_V1 contract's
+// parameter set.
 const CANONICAL_IELTS_PARAM_IDS = [
   "skill_fluency_and_coherence_fc",
   "skill_lexical_resource_lr",


### PR DESCRIPTION
## Summary

S3 of epic #2135. Refactors `lib/pipeline/prosody-consumer.ts` so the IELTS-mode writer targets **disjoint** `prosody_raw_*` parameter IDs instead of the 4 IELTS skill IDs. Closes the S2-S3 transition window opened by #2155.

- Pre-#2138: prosody-consumer was the sole writer of `skill_fluency_and_coherence_fc` / `_pronunciation_p` / `_lexical_resource_lr` / `_grammatical_range_and_accuracy_gra`. Vendor cannot reliably score LR / GRA from audio features — those need LLM judgment of transcript content.
- #2155 (S2) introduced IELTS-MEASURE-001 (LLM-judged transcript scoring via the canonical SCORE_AGENT path), flag-gated to avoid a dual-writer race.
- S3 (this PR) gives prosody its own namespace: `prosody_raw_fc` / `_p` / `_lr` / `_gra`. Namespaces are disjoint, so `HF_IELTS_LLM_MEASURE_V1` no longer needs to gate prosody — its scope shrinks to "enables the LLM-judged path".

Per-criterion confidence: FC + P land at 0.9 (vendor's strong suit — audio fluency + phonemes); LR + GRA land at 0.7 (vendor cannot reliably score vocab / grammar from audio; rows kept for forensics). IELTS-MEASURE-001 MAY optionally consume the prosody-raw rows via tool-use (post-MVP) to augment FC + P confidence.

## Files changed

| File | Change |
|---|---|
| `lib/pipeline/prosody-consumer.ts` | `IELTS_PARAM_IDS` → `PROSODY_RAW_PARAM_IDS` + `PROSODY_RAW_CONFIDENCE` map; `writeIeltsCallScores` → `writeProsodyRawCallScores`; removed flag gate |
| `prisma/seed-prosody-parameters.ts` | Added 4 new seeds: `prosody_raw_fc` / `_p` / `_lr` / `_gra` (idempotent) |
| `lib/journey/module-settings-flag.ts` | Documented `HF_IELTS_LLM_MEASURE_V1` reduced scope post-S3 |
| `tests/lib/pipeline/prosody-consumer.test.ts` | Replaced IELTS-skill assertions with `prosody_raw_*`; +4 new tests (confidence per criterion, null-skip, negative skill-ID assertion, flag-irrelevance) |
| `lib/curriculum/validate-ielts-completion.ts` | Stale-comment fix (LLM spec now owns the 4 skill IDs) |
| `tests/lib/specs/ielts-measure-001-shape.test.ts` | Stale-comment fix |

## Verified by

**Lattice survey** (per `.claude/rules/lattice-survey.md`):

- **Surface**: `lib/pipeline/prosody-consumer.ts` IELTS-mode CallScore writes (parameterId surface — retire 4 IELTS-skill writes, add 4 prosody-raw writes).
- **Sibling writers mapped** [verified at `lib/pipeline/prosody-consumer.ts:185-256`]:
  - `writeProsodyRawCallScores` (this PR) → `prosody_raw_*` namespace
  - IELTS-MEASURE-001 spec via SCORE_AGENT (#2155, merged) → `skill_*` namespace
  - Two writers, disjoint namespaces — no collision possible regardless of flag state.
- **Chokepoint**: `lib/measurement/write-call-score.ts::writeCallScore` — both writers route through it; `hf-measurement/no-bare-call-score-write` ESLint rule enforces (no bypass).
- **Catalogues read row-by-row** [verified ratchets unmoved]:
  - `.claude/rules/parameter-coverage.md` — new `prosody_raw_*` IDs are seeded via dedicated `seed-prosody-parameters.ts` (NOT in `behavior-parameters.registry.json`), same pattern as existing `prosody_pace_wpm` / `prosody_hesitation_rate` siblings — outside this ratchet's scope by design.
  - `.claude/rules/parameter-measurement-coverage.md` — same reasoning; ratchet unmoved.
  - `.claude/rules/learner-ui-leak-coverage.md` — green; `prosody_raw_*` IDs are not in `INTERNAL_LABEL_REGISTRY` (not learner-facing labels).
  - `.claude/rules/ai-to-db-guard.md` chokepoint enforced.
  - `.claude/rules/verify-before-fix.md` — n/a (refactor following a groomed story, not a fix from a symptom).
- **Risk-shape cross-check**:
  - Sibling-writer drift → CLOSED by namespace separation.
  - Default-deny → null/non-finite vendor band → no write (operator rule honoured).
  - Cascade respect → no cascade impact (`prosody_raw_*` are observational signals).
  - Convention conflict → `prosody_raw_*` mirrors the established `prosody_pace_wpm` / `prosody_hesitation_rate` naming convention.

**Vitests** [verified all green]:

| Test | Result |
|---|---|
| `tests/lib/pipeline/prosody-consumer.test.ts` (S3 refactor) | 14/14 green |
| `tests/lib/pipeline/*` (full pipeline suite) | 426/426 green |
| `tests/lib/measurement/parameter-coverage.test.ts` | 5/5 green (ratchet unmoved) |
| `tests/lib/measurement/parameter-measurement-coverage.test.ts` | 6/6 green (ratchet unmoved) |
| `tests/lib/sim-chat/learner-ui-leak-coverage.test.ts` | 11/11 green |
| `tests/lib/specs/ielts-measure-001-shape.test.ts` | 21/21 green |
| `tests/lib/curriculum/validate-ielts-completion.test.ts` | 6/6 green |
| `tests/scripts/seed-ielts-prosody.test.ts` | 15/15 green |
| `tests/lib/pipeline/prosody-consumer-segmented.test.ts` | 5/5 green |
| `tests/lib/measurement/` + `tests/lib/registry/` + `tests/lib/journey/` + `tests/lib/sim-chat/` | 296/296 green |

**Type-check** [verified]: `npx tsc --noEmit` → 38 errors total (-1 from baseline 39). Zero new errors in changed files.

**Lint** [verified]: `npx eslint` on all 6 changed files → 0 errors, 0 warnings.

**Operator rule honoured** (verbatim, epic #2135):

> NEVER land hardcoded or AI-guessed score defaults to "fill" empty CallerTarget rows. Honest empty bands surface gaps; fake scores corrupt EMA.

`writeProsodyRawCallScores` skips the `writeCallScore` call when the vendor returns a non-finite band — no hardcoded default fill.

## Operator-blocked

**Do NOT merge** without operator review per story #2138 — writer shape change touches the core scoring chain; operator wants eyeball before this lands.

## Out of scope (epic #2135 follow-on)

- Tool-use augmentation of IELTS-MEASURE-001 from `prosody_raw_*` rows (post-MVP enhancement; infrastructure now in place).
- S4 — Lattice coverage gates for the IELTS LLM cascade.
- S6 — live IELTS sim verification on hf-dev.
- Adding the 4 `prosody_raw_*` IDs to `behavior-parameters.registry.json` (today's seed pattern matches the existing prosody siblings; registry inclusion is a separate chore if/when the prosody namespace gets centralised).

## Test plan

- [ ] Operator: review writer-shape change + namespace decision
- [ ] Operator: confirm `prosody_raw_*` naming convention is acceptable
- [ ] Operator: confirm FC+P=0.9 vs LR+GRA=0.7 confidence split
- [ ] Operator: post-merge, run `npx tsx prisma/seed-prosody-parameters.ts` on hf_sandbox to seed the 4 new Parameter rows
- [ ] Operator: with `HF_IELTS_LLM_MEASURE_V1=true` + prosody vendor wired, verify both writers land (4 LLM-judged `skill_*` rows + 4 vendor `prosody_raw_*` rows)

Closes #2138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)