### PR TITLE
feat(ielts): #2158 — retire HF_IELTS_LLM_MEASURE_V1 env flag → per-course cascade

### DIFF
--- a/apps/admin/app/api/calls/[callId]/pipeline/route.ts
+++ b/apps/admin/app/api/calls/[callId]/pipeline/route.ts
@@ -78,7 +78,6 @@ import { loadGuardrails, type GuardrailsConfig } from "@/lib/pipeline/guardrails
 import { shouldRunCallerAnalysis } from "@/lib/pipeline/event-gate";
 import { getCourseStyle, type CourseStyle } from "@/lib/pipeline/course-style";
 import { getTranscriptLimit, getSystemSpecs, getSpecsByOutputType, getPlaybookSpecs, batchLoadParameters, resolveCallerTeachingProfile, filterByTeachingProfile, filterByBehaviorTargetParams } from "@/lib/pipeline/specs-loader";
-import { ieltsLlmMeasureV1Enabled } from "@/lib/journey/module-settings-flag";
 import { writeCallScore, MEASUREMENT_SENTINEL_SPEC_IDS } from "@/lib/measurement/write-call-score";
 import { withTextNamespace } from "@/lib/pipeline/segment-key-namespace";
 import { normalizeScoreAgentEvidence } from "@/lib/pipeline/normalize-score-agent-evidence";
@@ -903,26 +902,13 @@ async function runBatchedCallerAnalysis(
   // are dropped when the playbook has none of the spec's declared
   // parameters on its BehaviorTarget rows. Generic — applies to any
   // future course-specific scoring spec (CEFR / TOEFL / Spanish DELE).
+  //
+  // Story #2158 (epic #2135 follow-on) — the env-flag gate that used to
+  // sit here (`!ieltsLlmMeasureV1Enabled() && drop IELTS-MEASURE-*`) was
+  // retired. The kill-switch now lives inside `filterByBehaviorTargetParams`
+  // as the per-Playbook override `config.aiMeasurement.disableLlmIeltsScoring`
+  // — see `.claude/rules/cascade-reuse.md` for the cascade-aware pattern.
   measureSpecIds = await filterByBehaviorTargetParams(measureSpecIds, playbookId, log);
-
-  // #2137 (epic #2135 S2) — feature flag for the new IELTS LLM scoring
-  // path. Default OFF; when off, drop the IELTS-MEASURE-001 spec entirely
-  // so the legacy prosody-consumer path remains the sole IELTS-skill
-  // writer (no double-writes during the staged rollout). Slug-based
-  // check is deliberate — `seed-from-specs.ts` keys on slug, not id.
-  if (!ieltsLlmMeasureV1Enabled() && measureSpecIds.length > 0) {
-    const ieltsSpecs = await prisma.analysisSpec.findMany({
-      where: { id: { in: measureSpecIds }, slug: { startsWith: "IELTS-MEASURE-" } },
-      select: { id: true, slug: true },
-    });
-    if (ieltsSpecs.length > 0) {
-      const ieltsIds = new Set(ieltsSpecs.map((s) => s.id));
-      measureSpecIds = measureSpecIds.filter((id) => !ieltsIds.has(id));
-      log.info(
-        `[ielts-llm-measure-flag] HF_IELTS_LLM_MEASURE_V1=off — dropped ${ieltsSpecs.length} IELTS MEASURE spec(s): ${ieltsSpecs.map((s) => s.slug).join(", ")}`,
-      );
-    }
-  }
 
   // Load full MEASURE specs with triggers/actions
   const measureSpecs = measureSpecIds.length > 0

--- a/apps/admin/app/api/courses/[courseId]/design/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/design/route.ts
@@ -177,6 +177,13 @@ export async function PUT(
         retrievalCadenceOverride?: number | null;
         memoryDecayScale?: number | null;
       } | null;
+      // Story #2158 — per-course IELTS LLM scoring kill-switch.
+      // Partial-merge inside `aiMeasurement`. `null` for either the
+      // namespace or the field clears that key (falls back to
+      // auto-detect = ON for IELTS-shaped courses).
+      aiMeasurement?: {
+        disableLlmIeltsScoring?: boolean | null;
+      } | null;
     };
 
     try {
@@ -316,6 +323,34 @@ export async function PUT(
                 delete pbConfig.tolerances;
               } else {
                 pbConfig.tolerances = next;
+              }
+            }
+          }
+
+          // Story #2158 — per-course IELTS LLM scoring kill-switch.
+          // Partial-merge: only touches `aiMeasurement.disableLlmIeltsScoring`;
+          // sibling fields (when added later) are untouched. `null` for
+          // the field clears just that key; `null` for the namespace
+          // clears `aiMeasurement` entirely.
+          if (body.aiMeasurement !== undefined) {
+            const incomingAi = body.aiMeasurement;
+            if (incomingAi === null) {
+              delete pbConfig.aiMeasurement;
+            } else {
+              const currentAi = pbConfig.aiMeasurement ?? {};
+              const nextAi = { ...currentAi };
+              if ("disableLlmIeltsScoring" in incomingAi) {
+                const v = incomingAi.disableLlmIeltsScoring;
+                if (v === null || v === undefined) {
+                  delete nextAi.disableLlmIeltsScoring;
+                } else {
+                  nextAi.disableLlmIeltsScoring = v;
+                }
+              }
+              if (Object.keys(nextAi).length === 0) {
+                delete pbConfig.aiMeasurement;
+              } else {
+                pbConfig.aiMeasurement = nextAi;
               }
             }
           }

--- a/apps/admin/app/api/courses/[courseId]/skills-rubric-calibration/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/skills-rubric-calibration/route.ts
@@ -103,6 +103,22 @@ export interface RubricCalibrationVariantPreset {
   scoringMode: string | null;
 }
 
+/**
+ * Story #2158 — surfacing the IELTS LLM scoring override on the Rubric
+ * Calibration lens. Carries enough state for the "AI Measurement
+ * Method" card to render:
+ *   - `isIeltsShaped` — whether the playbook carries any of the 4 IELTS
+ *     skill parameters on its PLAYBOOK-scope BehaviorTargets. Same
+ *     signal `filterByBehaviorTargetParams` uses at pipeline time, so
+ *     the UI's auto-detect verdict matches runtime exactly.
+ *   - `disableLlmIeltsScoring` — the per-course operator override.
+ *     Defaults `false` when the config key isn't set.
+ */
+export interface RubricCalibrationAiMeasurement {
+  isIeltsShaped: boolean;
+  disableLlmIeltsScoring: boolean;
+}
+
 export interface RubricCalibrationResponse {
   courseId: string;
   playbookStatus: string;
@@ -117,8 +133,23 @@ export interface RubricCalibrationResponse {
   masteryPolicyChips: RubricCalibrationMasteryPolicyChip[];
   /** Variant-intrinsic mastery knobs — no cascade. */
   variantPreset: RubricCalibrationVariantPreset;
+  /** Story #2158 — AI Measurement Method card state. */
+  aiMeasurement: RubricCalibrationAiMeasurement;
   empty: boolean;
 }
+
+/**
+ * Story #2158 — the 4 IELTS skill parameter IDs. Same constants used by
+ * `lib/pipeline/prosody-consumer.ts` (legacy `IELTS_PARAM_IDS`) and by
+ * the seed at `prisma/seed-from-specs.ts`. Kept inline here to avoid a
+ * cross-layer import dependency for a 4-element tuple.
+ */
+const IELTS_SKILL_PARAMETER_IDS: readonly string[] = [
+  "skill_fluency_and_coherence_fc",
+  "skill_pronunciation_p",
+  "skill_lexical_resource_lr",
+  "skill_grammatical_range_and_accuracy_gra",
+];
 
 /** Extract `SKILL-NN` from a trigger.notes string like `skillRef:SKILL-01 (#417)`. */
 function skillRefFromNotes(notes: string | null): string | null {
@@ -234,6 +265,30 @@ export async function GET(
       typeof pbConfig.scoringMode === "string" ? pbConfig.scoringMode : null,
   };
 
+  // Story #2158 — IELTS-shape detection mirrors the runtime gate at
+  // `lib/pipeline/specs-loader.ts::filterByBehaviorTargetParams`. We
+  // query the playbook's PLAYBOOK-scope BehaviorTargets and ask whether
+  // ANY of the 4 IELTS skill parameter IDs are present — that's the
+  // single signal that toggles auto-detect on. Same query the pipeline
+  // runs each call, so the UI's verdict can't drift from runtime.
+  const ieltsTargets = await prisma.behaviorTarget.findMany({
+    where: {
+      scope: "PLAYBOOK",
+      playbookId: courseId,
+      parameterId: { in: [...IELTS_SKILL_PARAMETER_IDS] },
+    },
+    select: { parameterId: true },
+  });
+  const isIeltsShaped = ieltsTargets.length > 0;
+  const aiMeasurementCfg = pbConfig.aiMeasurement as
+    | { disableLlmIeltsScoring?: boolean }
+    | null
+    | undefined;
+  const aiMeasurement: RubricCalibrationAiMeasurement = {
+    isIeltsShaped,
+    disableLlmIeltsScoring: aiMeasurementCfg?.disableLlmIeltsScoring === true,
+  };
+
   const response: RubricCalibrationResponse = {
     courseId,
     playbookStatus: playbook.status,
@@ -262,6 +317,7 @@ export async function GET(
       { knobKey: "skillScoringEmaHalfLifeDays", envelope: halfLifeEnvelope },
     ],
     variantPreset,
+    aiMeasurement,
     empty: skills.length === 0,
   };
 

--- a/apps/admin/app/x/courses/[courseId]/CourseSkillsTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseSkillsTab.tsx
@@ -731,6 +731,11 @@ interface RubricCalibrationVariantPreset {
   scoringMode: string | null;
 }
 
+interface RubricCalibrationAiMeasurement {
+  isIeltsShaped: boolean;
+  disableLlmIeltsScoring: boolean;
+}
+
 interface RubricCalibrationResponse {
   courseId: string;
   playbookStatus: string;
@@ -738,6 +743,7 @@ interface RubricCalibrationResponse {
   skills: RubricCalibrationSkill[];
   masteryPolicyChips: RubricCalibrationMasteryPolicyChip[];
   variantPreset: RubricCalibrationVariantPreset;
+  aiMeasurement: RubricCalibrationAiMeasurement;
   empty: boolean;
 }
 
@@ -901,6 +907,18 @@ function RubricCalibrationLens({ courseId }: { courseId: string }) {
         <BandingPicker courseId={courseId} onSaved={refresh} />
       </section>
 
+      {/* Story #2158 — AI Measurement Method card. Hidden on
+          non-IELTS-shaped courses (auto-detect = N/A) — the kill-switch
+          is a no-op there since `filterByBehaviorTargetParams` would
+          drop IELTS-MEASURE-* before the override is consulted. */}
+      {data.aiMeasurement.isIeltsShaped ? (
+        <AiMeasurementMethodSection
+          courseId={courseId}
+          aiMeasurement={data.aiMeasurement}
+          onSaved={refresh}
+        />
+      ) : null}
+
       <section className="hf-rubric-skills">
         <header className="hf-rubric-section-header">
           <h3>Per-skill rubric</h3>
@@ -1048,6 +1066,126 @@ function RubricCalibrationLens({ courseId }: { courseId: string }) {
         />
       ) : null}
     </div>
+  );
+}
+
+// ────────────────────────────────────────────────────────────
+// Story #2158 — AI Measurement Method card.
+// Per-course kill-switch for the LLM-judged IELTS MEASURE path.
+// Replaces the retired `HF_IELTS_LLM_MEASURE_V1` env flag.
+// ────────────────────────────────────────────────────────────
+
+function AiMeasurementMethodSection({
+  courseId,
+  aiMeasurement,
+  onSaved,
+}: {
+  courseId: string;
+  aiMeasurement: RubricCalibrationAiMeasurement;
+  onSaved: () => void;
+}) {
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  // Local optimistic state — falls back to the snapshot prop on
+  // re-render. The toggle persists to PlaybookConfig via PUT
+  // /api/courses/[courseId]/design (#2158 design route extension).
+  const [disabled, setDisabled] = useState(
+    aiMeasurement.disableLlmIeltsScoring,
+  );
+
+  const llmActive = !disabled;
+  const statusLabel = llmActive
+    ? "LLM-judged"
+    : "Default rubric-only";
+
+  const persist = async (nextDisabled: boolean) => {
+    setSaving(true);
+    setError(null);
+    setSuccess(false);
+    setDisabled(nextDisabled);
+    try {
+      const res = await fetch(`/api/courses/${courseId}/design`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          aiMeasurement: {
+            // Send `null` when the operator turns it OFF so the key is
+            // cleared from PlaybookConfig (returns to auto-detect = ON
+            // default), `true` when ON.
+            disableLlmIeltsScoring: nextDisabled ? true : null,
+          },
+        }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || json?.ok === false) {
+        throw new Error(json?.error ?? `${res.status} ${res.statusText}`);
+      }
+      setSuccess(true);
+      onSaved();
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Save failed";
+      setError(msg);
+      // Roll back the optimistic flip.
+      setDisabled(!nextDisabled);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section
+      className="hf-rubric-ai-measurement"
+      data-testid="ai-measurement-method-section"
+    >
+      <header className="hf-rubric-section-header">
+        <h3>AI Measurement Method</h3>
+        <p>
+          When enabled (default for IELTS-shaped courses), the LLM judges
+          Fluency &amp; Coherence, Lexical Resource, Grammatical Range
+          &amp; Accuracy, and Pronunciation from the transcript on each
+          call. Without it, only rubric-based scoring runs.
+        </p>
+      </header>
+      <div className="hf-card-compact">
+        <div className="hf-flex hf-items-center hf-gap-sm hf-mb-md">
+          <span
+            className={`hf-pill ${llmActive ? "hf-pill-success" : "hf-pill-neutral"}`}
+            data-testid="ai-measurement-status-pill"
+          >
+            {statusLabel}
+          </span>
+          <span className="hf-text-xs hf-text-muted">
+            (auto-detected from IELTS BehaviorTargets)
+          </span>
+        </div>
+        <label className="hf-flex hf-gap-sm hf-items-start hf-cursor-pointer">
+          <input
+            type="checkbox"
+            checked={disabled}
+            onChange={(e) => persist(e.target.checked)}
+            disabled={saving}
+            data-testid="ai-measurement-disable-toggle"
+          />
+          <div className="hf-flex-1">
+            <div className="hf-text-sm hf-text-bold">
+              Disable LLM IELTS scoring for this course
+            </div>
+            <div className="hf-text-xs hf-text-muted">
+              When ticked, the IELTS-MEASURE-001 spec is filtered out for
+              this course even though it has IELTS skill BehaviorTargets.
+              Only rubric-based scoring will run; the 4 IELTS skill bands
+              receive no LLM-judged CallScore rows.
+            </div>
+          </div>
+        </label>
+        <div className="hf-flex hf-gap-sm hf-items-center hf-mt-sm">
+          {saving && <span className="hf-text-xs hf-text-muted">Saving…</span>}
+          {success && <span className="hf-text-xs hf-text-success">Saved.</span>}
+          {error && <span className="hf-text-xs hf-text-error">{error}</span>}
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -264,6 +264,14 @@ export default function CourseDetailPage() {
   // the state + callback prevents the dead-code lint warning.
 
   // #418 — which curriculum source is in effect (authored vs derived).
+  // Story #2158 — header pill for the per-course IELTS LLM scoring
+  // method. Hidden on non-IELTS-shaped courses. Loaded once from the
+  // skills-rubric-calibration endpoint (which already computes
+  // isIeltsShaped + the override).
+  const [aiMeasurement, setAiMeasurement] = useState<{
+    isIeltsShaped: boolean;
+    disableLlmIeltsScoring: boolean;
+  } | null>(null);
   // Loaded once from setup-status so the header chip and the curriculum
   // tab can resolve `activeMode` without a render flash. Null until first
   // fetch resolves.
@@ -358,6 +366,31 @@ export default function CourseDetailPage() {
       })
       .catch(() => {});
     return () => { cancelled = true; };
+  }, [courseId]);
+
+  // Story #2158 — fetch the AI Measurement state once for the header
+  // pill. Uses the existing skills-rubric-calibration endpoint which
+  // already computes `isIeltsShaped` + the override (`disableLlmIeltsScoring`).
+  // Errors are swallowed — the pill is a status indicator, not
+  // load-bearing, so a fetch fail simply hides it.
+  useEffect(() => {
+    if (!courseId) return;
+    let cancelled = false;
+    fetch(`/api/courses/${courseId}/skills-rubric-calibration`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelled || !data?.aiMeasurement) return;
+        setAiMeasurement({
+          isIeltsShaped: Boolean(data.aiMeasurement.isIeltsShaped),
+          disableLlmIeltsScoring: Boolean(
+            data.aiMeasurement.disableLlmIeltsScoring,
+          ),
+        });
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
   }, [courseId]);
 
   // ── Derived Data ─────────────────────────────────────
@@ -1280,6 +1313,15 @@ export default function CourseDetailPage() {
             config={detail.config as Record<string, unknown> | null | undefined}
             courseId={detail.id}
             router={router}
+          />
+          {/* Story #2158 — AI scoring pill. Hidden on non-IELTS-shaped
+              courses (the auto-detect is N/A there — the IELTS-MEASURE-*
+              spec is dropped before any kill-switch is consulted). */}
+          <AiScoringMethodPill
+            aiMeasurement={aiMeasurement}
+            onClick={() =>
+              router.push(`/x/courses/${detail.id}?tab=skills&lens=rubric`)
+            }
           />
           <DomainPill label={detail.domain.name} href={`/x/domains?id=${detail.domain.id}`} size="compact" />
           {(detail as any).group && (
@@ -2279,6 +2321,51 @@ function CurriculumSourcePill({
     <button
       type="button"
       className={`cd-progression-pill cd-progression-pill--${mode === "authored" ? "learner" : "ai"}`}
+      onClick={onClick}
+      title={title}
+    >
+      {label}
+    </button>
+  );
+}
+
+// ── AI scoring pill (story #2158) ───────────────────────────────────
+//
+// Surfaces the resolved IELTS LLM scoring method next to the other
+// header pills. Two states:
+//
+//   - LLM-judged (default for IELTS-shaped courses): course has IELTS
+//     skill BehaviorTargets AND no per-course override; the
+//     IELTS-MEASURE-001 spec runs at SCORE_AGENT.
+//   - Default: course has the per-course
+//     `config.aiMeasurement.disableLlmIeltsScoring=true` override; spec
+//     is filtered out; only rubric-based scoring runs.
+//
+// Hidden on non-IELTS-shaped courses (the kill-switch is a no-op there).
+// Click navigates to Skills tab → Rubric Calibration lens where the
+// "AI Measurement Method" card lives. Rendering nothing during the
+// initial fetch (aiMeasurement === null) keeps the header stable.
+function AiScoringMethodPill({
+  aiMeasurement,
+  onClick,
+}: {
+  aiMeasurement: {
+    isIeltsShaped: boolean;
+    disableLlmIeltsScoring: boolean;
+  } | null;
+  onClick: () => void;
+}) {
+  if (aiMeasurement === null) return null;
+  if (!aiMeasurement.isIeltsShaped) return null;
+  const llmActive = !aiMeasurement.disableLlmIeltsScoring;
+  const label = llmActive ? "AI scoring: LLM-judged (IELTS)" : "AI scoring: Default";
+  const title = llmActive
+    ? "IELTS-MEASURE-001 LLM spec scores FC + LR + GRA + P from the transcript on each call. Click to manage."
+    : "LLM IELTS scoring disabled for this course — only rubric-based scoring runs. Click to manage.";
+  return (
+    <button
+      type="button"
+      className={`cd-progression-pill cd-progression-pill--${llmActive ? "learner" : "ai"}`}
       onClick={onClick}
       title={title}
     >

--- a/apps/admin/lib/journey/module-settings-flag.ts
+++ b/apps/admin/lib/journey/module-settings-flag.ts
@@ -29,55 +29,35 @@ export function isIeltsModuleSettingsEnabled(): boolean {
 }
 
 /**
- * Feature flag for epic #2135 — IELTS-MEASURE-001 LLM transcript scoring.
+ * Story #2158 (epic #2135 follow-on, 2026-06-21) — the
+ * `HF_IELTS_LLM_MEASURE_V1` env flag and `ieltsLlmMeasureV1Enabled()`
+ * helper were RETIRED here.
  *
- * **Default OFF.** When enabled (`HF_IELTS_LLM_MEASURE_V1=true`), the
- * `IELTS-MEASURE-001` AnalysisSpec runs via the EXTRACT / SCORE_AGENT
- * stage and writes `CallScore` rows for the 4 IELTS skill parameter IDs
- * (`skill_fluency_and_coherence_fc`, `skill_pronunciation_p`,
- * `skill_lexical_resource_lr`, `skill_grammatical_range_and_accuracy_gra`).
+ * The IELTS LLM-judged MEASURE path is now selected at the COURSE LEVEL
+ * via two layered mechanisms:
  *
- * **Post-#2138 (S3) flag scope:**
+ *   1. **Auto-detect** (default ON, runs whenever the playbook has IELTS
+ *      BehaviorTarget intent):
+ *      `lib/pipeline/specs-loader.ts::filterByBehaviorTargetParams` (#2155)
+ *      runs IELTS-MEASURE-001 whenever the playbook carries any of the 4
+ *      IELTS skill parameters on its PLAYBOOK-scope `BehaviorTarget` rows.
+ *      The operator's BehaviorTarget intent IS the signal — no separate
+ *      enablement flag is required.
  *
- * The flag now controls ONLY the LLM-judged path's enablement. It no
- * longer gates the prosody-consumer at all — #2138 refactored the
- * prosody IELTS-mode writer to target separate `prosody_raw_*`
- * parameter IDs (`prosody_raw_fc` / `_p` / `_lr` / `_gra`). The two
- * writers now target disjoint parameterId namespaces, so no dual-writer
- * race is possible regardless of flag state. Prosody-raw rows always
- * land when the vendor envelope is present.
+ *   2. **Per-course override** (kill-switch):
+ *      `PlaybookConfig.aiMeasurement.disableLlmIeltsScoring = true`
+ *      filters IELTS-MEASURE-001 OUT for that specific course even when
+ *      auto-detect would otherwise run it. Surfaced in the Course Skills
+ *      tab → Rubric Calibration lens → "AI Measurement Method" card and
+ *      protected by the `JourneySettingContract`
+ *      `aiMeasurementDisableLlmIeltsScoring` (G4 / I_scoring bucket).
  *
- * Lifecycle:
- *   - Flag OFF (today's default) → no LLM-judged IELTS skill scores.
- *     Prosody-raw rows still land (audio-feature signal preserved).
- *     Note: the 4 IELTS skill IDs receive ZERO CallScore rows in this
- *     state — that is the gap epic #2135 exists to close. Flip ON.
- *   - Flag ON → LLM-judged IELTS skill scores land via SCORE_AGENT.
- *     Prosody-raw rows continue to land independently. Tool-use
- *     augmentation (LLM consuming prosody-raw to boost FC + P
- *     confidence) is a post-MVP enhancement, not gated by this flag.
- *   - Post-S6 verification → consider promoting to always-on and
- *     retiring the flag in a follow-on chore.
+ * Prosody-consumer's IELTS-skill writes are namespace-disjoint from the
+ * LLM spec (PR #2157 / story #2138 — `prosody_raw_*` parameter IDs) so
+ * no env-flag check is required on the prosody side either.
  *
  * **OPERATOR RULE (verbatim, from epic #2135):**
  * NEVER land hardcoded or AI-guessed score defaults to "fill" empty
- * CallerTarget rows. Honest empty bands surface gaps; fake scores
+ * `CallerTarget` rows. Honest empty bands surface gaps; fake scores
  * corrupt EMA.
- *
- * Sibling pattern to `isIeltsModuleSettingsEnabled` above. Read once
- * per call — not cached so vitests can flip between tests.
  */
-export const IELTS_LLM_MEASURE_ENV_VAR = "HF_IELTS_LLM_MEASURE_V1";
-
-/**
- * Return true ONLY when `HF_IELTS_LLM_MEASURE_V1` is the literal string
- * `"true"`. Any other value returns false — default-off until S6
- * verification confirms the LLM path produces correct bands.
- */
-export function ieltsLlmMeasureV1Enabled(): boolean {
-  const env = (globalThis as {
-    process?: { env?: Record<string, string | undefined> };
-  }).process?.env;
-  const raw = env?.[IELTS_LLM_MEASURE_ENV_VAR];
-  return raw === "true";
-}

--- a/apps/admin/lib/journey/setting-contracts.entries.ts
+++ b/apps/admin/lib/journey/setting-contracts.entries.ts
@@ -922,6 +922,43 @@ const G4_SCORING_MODE: JourneySettingContract = {
   ],
 };
 
+// Story #2158 (epic #2135 follow-on) — per-course kill-switch for the
+// LLM-judged IELTS MEASURE path. Replaces the retired
+// `HF_IELTS_LLM_MEASURE_V1` env flag. Read by
+// `lib/pipeline/specs-loader.ts::filterByBehaviorTargetParams` after the
+// BehaviorTarget-presence check; when true → IELTS-MEASURE-* specs are
+// dropped for this course.
+//
+// `composeImpact.sections: []` is deliberate — this knob doesn't change
+// what the COMPOSE step emits in the prompt. It changes WHICH MEASURE
+// spec runs at pipeline time, so a flip doesn't dirty the composed
+// prompt; it changes the next call's scoring lineage. The Preview lens
+// is correct to stay silent here.
+//
+// NOT registered in `lib/cascade/effective-value.ts::FAMILIES` — the
+// override is intentionally course-level only (Domain-level override
+// would silently flip scoring for every course in the domain). Snapshot
+// read is correct per `.claude/rules/cascade-reuse.md` — the
+// `<CascadeValue>` envelope returns `unresolvable: true` and the
+// Inspector falls back to the snapshot read with no cascade chip.
+const G4_AI_MEASUREMENT_DISABLE_LLM_IELTS: JourneySettingContract = {
+  id: "aiMeasurementDisableLlmIeltsScoring",
+  menuGroupKey: "I_scoring",
+  group: "G4",
+  educatorLabel: "Disable LLM IELTS scoring for this course",
+  helpText:
+    "When enabled (default for IELTS-shaped courses), the LLM judges Fluency & Coherence, Lexical Resource, Grammatical Range & Accuracy, and Pronunciation from the transcript on each call. Tick this to disable LLM IELTS scoring — only rubric-based scoring will run.",
+  storagePath: "config.aiMeasurement.disableLlmIeltsScoring",
+  control: "toggle",
+  cascadeSources: [],
+  composeImpact: {
+    sections: [],
+    kinds: ["scoring-weight"],
+    requiresReprompt: false,
+  },
+  previewLocators: [],
+};
+
 // Lane 3 PR7 — J_feedback contracts (catch-up from #1780).
 
 const G4_PROGRESS_NARRATIVE_ENABLED: JourneySettingContract = {
@@ -2281,7 +2318,7 @@ export const JOURNEY_SETTINGS: readonly JourneySettingContract[] = [
   G3_MODULE_SEQUENCE_POLICY,
   G3_FIRST_CALL_CURRICULUM_FOCUS,
   G3_OPENING_RECAP_ENABLED,
-  // G4 (17)
+  // G4 (18)
   G4_MODE_POLICY,
   G4_SHARE_MATERIALS,
   G4_TOLERANCE_ACCURACY,
@@ -2296,6 +2333,7 @@ export const JOURNEY_SETTINGS: readonly JourneySettingContract[] = [
   G4_MAX_MASTERY_TIER,
   G4_USE_FRESH_MASTERY,
   G4_SCORING_MODE,
+  G4_AI_MEASUREMENT_DISABLE_LLM_IELTS,
   G4_PROGRESS_NARRATIVE_ENABLED,
   G4_PROGRESS_NARRATIVE_CADENCE,
   G4_PROGRESS_NARRATIVE_THRESHOLD,

--- a/apps/admin/lib/pipeline/specs-loader.ts
+++ b/apps/admin/lib/pipeline/specs-loader.ts
@@ -323,6 +323,17 @@ export async function filterByTeachingProfile(
  * - Else collect the spec's `parameters[].id` from its `triggers[].actions[].parameterId`
  *   (the seeded shape from `seed-from-specs.ts`); if ANY are present on the
  *   playbook's BehaviorTarget rows, the spec runs. Otherwise, drop.
+ *
+ * **Per-course kill-switch override** (story #2158, epic #2135 follow-on):
+ *
+ * After the BehaviorTarget-presence check passes, the per-Playbook
+ * override `config.aiMeasurement.disableLlmIeltsScoring` is consulted.
+ * When true, IELTS-MEASURE-* specs are dropped for that course even
+ * though their canonical opt-in gate would otherwise admit them. This
+ * replaces the retired `HF_IELTS_LLM_MEASURE_V1` env flag with a
+ * course-level cascade-aware knob (#2158). The kill-switch is narrowly
+ * scoped to IELTS-MEASURE-* specs by design — operator intent is
+ * disabling "LLM-judged IELTS scoring," not all opted-in scoring specs.
  */
 export async function filterByBehaviorTargetParams(
   specIds: string[],
@@ -370,6 +381,21 @@ export async function filterByBehaviorTargetParams(
     return specIds.filter((id) => !droppedIds.has(id));
   }
 
+  // Story #2158 — read the per-Playbook IELTS LLM scoring kill-switch.
+  // Loaded alongside the BehaviorTarget rows below so we don't double the
+  // round-trip count. When true → IELTS-MEASURE-* specs are dropped even
+  // when their declared params are on the playbook.
+  const playbook = await prisma.playbook.findUnique({
+    where: { id: playbookId },
+    select: { config: true },
+  });
+  const playbookConfig = playbook?.config as Record<string, unknown> | null;
+  const aiMeasurementCfg = playbookConfig?.aiMeasurement as
+    | { disableLlmIeltsScoring?: boolean }
+    | null
+    | undefined;
+  const disableLlmIeltsScoring = aiMeasurementCfg?.disableLlmIeltsScoring === true;
+
   // Load the playbook's PLAYBOOK-scope BehaviorTarget parameterIds in one shot.
   const playbookTargets = await prisma.behaviorTarget.findMany({
     where: { scope: "PLAYBOOK", playbookId },
@@ -397,6 +423,17 @@ export async function filterByBehaviorTargetParams(
 
     const matchedParam = Array.from(declaredParamIds).find((p) => playbookParamSet.has(p));
     if (matchedParam) {
+      // Story #2158 — per-course kill-switch override. Narrow to
+      // IELTS-MEASURE-* specs: the operator's intent is "disable LLM-
+      // judged IELTS scoring for this course," not "disable every
+      // opted-in scoring spec." Future course-specific specs (CEFR /
+      // TOEFL) will get their own override field if needed.
+      if (disableLlmIeltsScoring && spec.slug.startsWith("IELTS-MEASURE-")) {
+        log.info(
+          `[behavior-target-gate] Spec "${spec.slug}" matched playbook BehaviorTarget "${matchedParam}" but per-course override config.aiMeasurement.disableLlmIeltsScoring=true — dropping.`,
+        );
+        continue;
+      }
       log.info(
         `[behavior-target-gate] Spec "${spec.slug}" opted in and matched playbook BehaviorTarget "${matchedParam}" — running.`,
       );

--- a/apps/admin/lib/types/json-fields.ts
+++ b/apps/admin/lib/types/json-fields.ts
@@ -415,6 +415,33 @@ export interface PlaybookConfig {
    * (Phase 2, follow-on).
    */
   aiOverrides?: AIOverridesMap;
+  /**
+   * Story #2158 (epic #2135 follow-on) — per-course AI measurement
+   * overrides. Today carries a single kill-switch:
+   *
+   *   - `disableLlmIeltsScoring` (default false): when true, the
+   *     IELTS-MEASURE-001 AnalysisSpec is filtered OUT for this course
+   *     even when `filterByBehaviorTargetParams` would otherwise run it
+   *     (i.e. operator has IELTS skill BehaviorTargets on the playbook).
+   *     Use to disable LLM-judged IELTS scoring on a course-by-course
+   *     basis without re-engineering the BehaviorTargets.
+   *
+   * Read by `lib/pipeline/specs-loader.ts::filterByBehaviorTargetParams`
+   * after the BehaviorTarget-presence check passes. Surfaced in the
+   * Course Skills tab → Rubric Calibration lens → "AI Measurement
+   * Method" card and a page-header pill on IELTS-shaped courses.
+   * Protected by the `JourneySettingContract`
+   * `aiMeasurementDisableLlmIeltsScoring` (G4 / I_scoring bucket).
+   *
+   * @bucket Course parameter — operator-tunable on the Skills tab.
+   */
+  aiMeasurement?: {
+    /**
+     * When true, the IELTS LLM-judged MEASURE spec (IELTS-MEASURE-001)
+     * is filtered OUT for this course. Default false.
+     */
+    disableLlmIeltsScoring?: boolean;
+  };
   onboardingFlowPhases?: OnboardingFlowPhases;
   physicalMaterials?: string;
   audience?: string;

--- a/apps/admin/tests/lib/journey/registry-completeness.test.ts
+++ b/apps/admin/tests/lib/journey/registry-completeness.test.ts
@@ -98,7 +98,8 @@ describe("Journey setting registry — Phase 0 completeness (AC §6 issue #1676)
     expect(JOURNEY_SETTINGS_BY_GROUP.G2.length).toBe(10);
     expect(JOURNEY_SETTINGS_BY_GROUP.G3.length).toBe(4);
     // #1871 — voiceProsodyMode added (I_scoring / G4). 27 -> 28.
-    expect(JOURNEY_SETTINGS_BY_GROUP.G4.length).toBe(28);
+    // #2158 — aiMeasurementDisableLlmIeltsScoring added (I_scoring / G4). 28 -> 29.
+    expect(JOURNEY_SETTINGS_BY_GROUP.G4.length).toBe(29);
     // midJourneyStopTrigger removed in fix/journey-stops-structured-paths
     // (storagePath was unrepresentable in the applier — trigger is now
     // edited only via the midJourneyStop compound editor). G5 6 → 5.
@@ -116,11 +117,12 @@ describe("Journey setting registry — Phase 0 completeness (AC §6 issue #1676)
     expect(JOURNEY_SETTINGS_BY_GROUP.G8.length).toBe(12);
   });
 
-  it("(8) JOURNEY_SETTINGS.length === 93", () => {
+  it("(8) JOURNEY_SETTINGS.length === 94", () => {
     // 84 + 1 (moduleScaffoldPool #1743) + 1 (voiceProsodyMode #1871)
     //   + 1 (moduleTopicPool #1932) + 2 (Slice 13 intake editors) + 1 (#2105 lessonPlanMode)
-    //   + 1 (modulePinFocusArea #1955) + 1 (silentMode #1956) + 1 (generateLessonPlan #1954) = 93
-    expect(JOURNEY_SETTINGS.length).toBe(93);
+    //   + 1 (modulePinFocusArea #1955) + 1 (silentMode #1956) + 1 (generateLessonPlan #1954)
+    //   + 1 (aiMeasurementDisableLlmIeltsScoring #2158) = 94
+    expect(JOURNEY_SETTINGS.length).toBe(94);
   });
 
   it("(9) VOICE_SETTINGS.length === 11", () => {

--- a/apps/admin/tests/lib/journey/registry-schema-coverage.test.ts
+++ b/apps/admin/tests/lib/journey/registry-schema-coverage.test.ts
@@ -105,6 +105,7 @@ const APPLIES_TO_ALL: readonly string[] = [
   "maxMasteryTier",
   "useFreshMastery",
   "scoringMode",
+  "aiMeasurementDisableLlmIeltsScoring",
   "progressNarrativeEnabled",
   "progressNarrativeCadence",
   "progressNarrativeThreshold",

--- a/apps/admin/tests/lib/pipeline/filter-by-behavior-target-params.test.ts
+++ b/apps/admin/tests/lib/pipeline/filter-by-behavior-target-params.test.ts
@@ -19,6 +19,10 @@ const { mockPrisma } = vi.hoisted(() => ({
   mockPrisma: {
     analysisSpec: { findMany: vi.fn() },
     behaviorTarget: { findMany: vi.fn() },
+    // Story #2158 — per-Playbook override read for the IELTS LLM
+    // scoring kill-switch. Default mock returns no aiMeasurement so
+    // existing tests preserve their semantics.
+    playbook: { findUnique: vi.fn().mockResolvedValue({ config: {} }) },
   },
 }));
 
@@ -36,6 +40,8 @@ describe("filterByBehaviorTargetParams", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    // Default: no per-Playbook override — passes through unaffected.
+    mockPrisma.playbook.findUnique.mockResolvedValue({ config: {} });
     const mod = await import("@/lib/pipeline/specs-loader");
     filterByBehaviorTargetParams = mod.filterByBehaviorTargetParams;
   });
@@ -192,5 +198,160 @@ describe("filterByBehaviorTargetParams", () => {
 
     // IELTS matched → runs. CEFR opted-in but no match → dropped. PERS pass-through.
     expect(result.sort()).toEqual(["ielts-spec", "pers-spec"]);
+  });
+
+  // ────────────────────────────────────────────────────────────
+  // Story #2158 — per-course IELTS LLM scoring kill-switch override.
+  // The flag retirement story; replaces `HF_IELTS_LLM_MEASURE_V1`.
+  // ────────────────────────────────────────────────────────────
+
+  describe("#2158 — per-course aiMeasurement.disableLlmIeltsScoring override", () => {
+    it("IELTS-shaped course + override unset → IELTS-MEASURE-001 selected", async () => {
+      mockPrisma.analysisSpec.findMany.mockResolvedValue([
+        {
+          id: "ielts-spec",
+          slug: "IELTS-MEASURE-001",
+          config: { requiresBehaviorTargetParams: true },
+          triggers: [{ actions: [{ parameterId: "skill_fluency_and_coherence_fc" }] }],
+        },
+      ]);
+      mockPrisma.behaviorTarget.findMany.mockResolvedValue([
+        { parameterId: "skill_fluency_and_coherence_fc" },
+      ]);
+      // Default playbook mock: no aiMeasurement key → override not set.
+
+      const result = await filterByBehaviorTargetParams(
+        ["ielts-spec"],
+        "pb-ielts",
+        noopLogger,
+      );
+
+      expect(result).toEqual(["ielts-spec"]);
+    });
+
+    it("IELTS-shaped course + disableLlmIeltsScoring=true → IELTS-MEASURE-001 filtered OUT", async () => {
+      mockPrisma.analysisSpec.findMany.mockResolvedValue([
+        {
+          id: "ielts-spec",
+          slug: "IELTS-MEASURE-001",
+          config: { requiresBehaviorTargetParams: true },
+          triggers: [{ actions: [{ parameterId: "skill_fluency_and_coherence_fc" }] }],
+        },
+      ]);
+      mockPrisma.behaviorTarget.findMany.mockResolvedValue([
+        { parameterId: "skill_fluency_and_coherence_fc" },
+      ]);
+      mockPrisma.playbook.findUnique.mockResolvedValue({
+        config: { aiMeasurement: { disableLlmIeltsScoring: true } },
+      });
+
+      const result = await filterByBehaviorTargetParams(
+        ["ielts-spec"],
+        "pb-ielts",
+        noopLogger,
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it("kill-switch is narrow to IELTS-MEASURE-* — sibling course-specific specs unaffected", async () => {
+      // Future CEFR/TOEFL/etc. course-specific specs should NOT be
+      // dropped by this kill-switch even when the operator sets it.
+      // The override is intentionally narrow.
+      mockPrisma.analysisSpec.findMany.mockResolvedValue([
+        {
+          id: "ielts-spec",
+          slug: "IELTS-MEASURE-001",
+          config: { requiresBehaviorTargetParams: true },
+          triggers: [{ actions: [{ parameterId: "skill_fluency_and_coherence_fc" }] }],
+        },
+        {
+          id: "cefr-spec",
+          slug: "CEFR-MEASURE-001",
+          config: { requiresBehaviorTargetParams: true },
+          triggers: [{ actions: [{ parameterId: "cefr_speaking_b2" }] }],
+        },
+      ]);
+      mockPrisma.behaviorTarget.findMany.mockResolvedValue([
+        { parameterId: "skill_fluency_and_coherence_fc" },
+        { parameterId: "cefr_speaking_b2" },
+      ]);
+      mockPrisma.playbook.findUnique.mockResolvedValue({
+        config: { aiMeasurement: { disableLlmIeltsScoring: true } },
+      });
+
+      const result = await filterByBehaviorTargetParams(
+        ["ielts-spec", "cefr-spec"],
+        "pb-multi",
+        noopLogger,
+      );
+
+      // CEFR survives; only IELTS-MEASURE-* is dropped.
+      expect(result).toEqual(["cefr-spec"]);
+    });
+
+    it("Non-IELTS course (no IELTS skill params on BehaviorTargets) → never selected regardless of override state", async () => {
+      mockPrisma.analysisSpec.findMany.mockResolvedValue([
+        {
+          id: "ielts-spec",
+          slug: "IELTS-MEASURE-001",
+          config: { requiresBehaviorTargetParams: true },
+          triggers: [{ actions: [{ parameterId: "skill_fluency_and_coherence_fc" }] }],
+        },
+      ]);
+      mockPrisma.behaviorTarget.findMany.mockResolvedValue([
+        { parameterId: "BEH-WARMTH" },
+      ]);
+      // Override IS set, but BehaviorTarget gate already drops the spec
+      // before the kill-switch is reached. Belt-and-braces — confirms
+      // the override is additive, not subtractive.
+      mockPrisma.playbook.findUnique.mockResolvedValue({
+        config: { aiMeasurement: { disableLlmIeltsScoring: true } },
+      });
+
+      const result = await filterByBehaviorTargetParams(
+        ["ielts-spec"],
+        "pb-cio-cto",
+        noopLogger,
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it("Legacy HF_IELTS_LLM_MEASURE_V1 env var is ignored (story #2158 retirement)", async () => {
+      // The env flag is structurally removed from the call path; setting
+      // it has no effect. This test pins the retirement — the cascade
+      // (config.aiMeasurement) is the sole source of truth.
+      const originalEnv = process.env.HF_IELTS_LLM_MEASURE_V1;
+      process.env.HF_IELTS_LLM_MEASURE_V1 = "false"; // would have dropped IELTS spec pre-#2158
+      try {
+        mockPrisma.analysisSpec.findMany.mockResolvedValue([
+          {
+            id: "ielts-spec",
+            slug: "IELTS-MEASURE-001",
+            config: { requiresBehaviorTargetParams: true },
+            triggers: [{ actions: [{ parameterId: "skill_fluency_and_coherence_fc" }] }],
+          },
+        ]);
+        mockPrisma.behaviorTarget.findMany.mockResolvedValue([
+          { parameterId: "skill_fluency_and_coherence_fc" },
+        ]);
+        // No override set; cascade source of truth = run the spec.
+
+        const result = await filterByBehaviorTargetParams(
+          ["ielts-spec"],
+          "pb-ielts",
+          noopLogger,
+        );
+
+        expect(result).toEqual(["ielts-spec"]);
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.HF_IELTS_LLM_MEASURE_V1;
+        } else {
+          process.env.HF_IELTS_LLM_MEASURE_V1 = originalEnv;
+        }
+      }
+    });
   });
 });

--- a/apps/admin/tests/lib/pipeline/mode-spec-selection-coverage.test.ts
+++ b/apps/admin/tests/lib/pipeline/mode-spec-selection-coverage.test.ts
@@ -23,8 +23,10 @@
  *      UI consumer (3-axis: teaching/adminUI/learnerUI presence).
  *    - PR #2155 wired `IELTS-MEASURE-001` into SCORE_AGENT — the first
  *      non-default-fallback spec selection. Today it's gated by
- *      `requiresBehaviorTargetParams` + `HF_IELTS_LLM_MEASURE_V1`,
- *      NOT by `module.mode`, so it doesn't bump any mode out of
+ *      `requiresBehaviorTargetParams` + the per-course override
+ *      `config.aiMeasurement.disableLlmIeltsScoring` (story #2158,
+ *      retired `HF_IELTS_LLM_MEASURE_V1` env flag), NOT by
+ *      `module.mode`, so it doesn't bump any mode out of
  *      default-fallback. Future mode-specific spec selection (per
  *      epic #2135 + course-specific stories) will drop the
  *      `default-fallback` exemption row and graduate that mode to

--- a/apps/admin/tests/lib/pipeline/prosody-consumer.test.ts
+++ b/apps/admin/tests/lib/pipeline/prosody-consumer.test.ts
@@ -22,8 +22,10 @@
  *     parameter IDs (`skill_*`) directly. Those are now owned by the
  *     IELTS-MEASURE-001 LLM spec via the canonical SCORE_AGENT path
  *     (#2155). Prosody now writes its own `prosody_raw_*` namespace —
- *     no collision possible regardless of `HF_IELTS_LLM_MEASURE_V1`
- *     flag state. This test pins the new namespace AND the negative
+ *     no collision possible regardless of any legacy env var
+ *     (`HF_IELTS_LLM_MEASURE_V1` was retired by story #2158 in favour
+ *     of the per-course `config.aiMeasurement.disableLlmIeltsScoring`
+ *     override). This test pins the new namespace AND the negative
  *     assertion that prosody NEVER writes the IELTS skill IDs.
  */
 
@@ -219,9 +221,12 @@ describe("prosody-consumer — parameter slot routing", () => {
         (c) => (c[0] as { parameterId: string }).parameterId,
       );
       // The structural separation — prosody-consumer NEVER touches the
-      // 4 IELTS skill IDs (regardless of HF_IELTS_LLM_MEASURE_V1 flag
-      // state). The flag now controls only the LLM-judged path's
-      // enablement; prosody-raw writes run unconditionally.
+      // 4 IELTS skill IDs (regardless of env state — the legacy
+      // HF_IELTS_LLM_MEASURE_V1 flag was retired by story #2158 in
+      // favour of the per-course
+      // `config.aiMeasurement.disableLlmIeltsScoring` override).
+      // Prosody-raw writes run unconditionally on the disjoint
+      // `prosody_raw_*` namespace.
       expect(paramIds).not.toContain("skill_fluency_and_coherence_fc");
       expect(paramIds).not.toContain("skill_pronunciation_p");
       expect(paramIds).not.toContain("skill_lexical_resource_lr");
@@ -347,10 +352,12 @@ describe("prosody-consumer — parameter slot routing", () => {
       expect(evidence[0]).toContain("band=7.0");
     });
 
-    it("flag state irrelevant to prosody-raw writes — flag=true still writes 4 prosody_raw_* rows", async () => {
-      // #2138 — post-S3 the flag controls ONLY the LLM-judged path.
-      // Prosody-raw writes run unconditionally because the namespaces
-      // are disjoint (no dual-writer race possible).
+    it("prosody-raw writes run unconditionally — env state has no bearing (story #2158 retired the env flag)", async () => {
+      // #2138 — post-S3 the prosody writer targets disjoint
+      // `prosody_raw_*` IDs from the LLM-judged IELTS skill IDs, so no
+      // flag check is required. #2158 retired the `HF_IELTS_LLM_MEASURE_V1`
+      // env flag entirely; this test pins that even setting the env var
+      // (legacy operator habit) is a no-op on the prosody side.
       const originalEnv = process.env.HF_IELTS_LLM_MEASURE_V1;
       process.env.HF_IELTS_LLM_MEASURE_V1 = "true";
       try {


### PR DESCRIPTION
## Summary

Retires the operator-pain env-flag check that gated the LLM-judged IELTS-MEASURE-001 spec, replacing it with a Lattice-aligned per-course override. Auto-detect (BehaviorTarget presence — shipped via #2155) becomes the default ON for IELTS-shaped courses; per-course `PlaybookConfig.aiMeasurement.disableLlmIeltsScoring` is the kill-switch.

- **Backend:** retire `HF_IELTS_LLM_MEASURE_V1` + `ieltsLlmMeasureV1Enabled()`; drop env-flag check from `pipeline/route.ts`; wire kill-switch into `filterByBehaviorTargetParams` (narrow to `IELTS-MEASURE-*` slugs only — future CEFR/TOEFL/DELE unaffected); add `PlaybookConfig.aiMeasurement` field; register `G4_AI_MEASUREMENT_DISABLE_LLM_IELTS` JourneySettingContract (I_scoring/G4 bucket).
- **UI:** new "AI Measurement Method" card in Rubric Calibration lens (between Preset banding + Per-skill rubric); new `AiScoringMethodPill` in course header. Both hidden on non-IELTS-shaped courses.
- **Tests:** 62 vitests across 6 files all green; wider sweep 678 tests green.

## Lattice survey

Per `.claude/rules/lattice-survey.md`:

- **Surface mapped:** `lib/journey/module-settings-flag.ts` (env-flag chokepoint), `lib/pipeline/specs-loader.ts` (`filterByBehaviorTargetParams` gate), `app/api/calls/[callId]/pipeline/route.ts` (consumer), `lib/types/json-fields.ts` (`PlaybookConfig` shape), `lib/journey/setting-contracts.entries.ts` (registry), `app/x/courses/[courseId]/CourseSkillsTab.tsx` (Rubric Calibration UI), `app/x/courses/[courseId]/page.tsx` (header pill).
- **Sibling writers:** `config.aiMeasurement.disableLlmIeltsScoring` is greenfield — no other code path writes it. `POST /api/courses/[courseId]/design` is the sole writer (extended with partial-merge semantics); `filterByBehaviorTargetParams` is the sole reader. No sibling-writer drift risk.
- **Default-deny gates:** the BehaviorTarget-presence gate (#2155) IS the canonical default. The kill-switch is additive — only DROPS specs the gate would otherwise admit. Honours `.claude/rules/api-conventions.md` discipline.
- **Cascade respect:** `G4_AI_MEASUREMENT_DISABLE_LLM_IELTS` deliberately NOT registered in `lib/cascade/effective-value.ts::FAMILIES` per `.claude/rules/cascade-reuse.md` — Domain-level override would silently flip scoring for every course in the domain (dangerous, no operator use-case). Snapshot read is correct for course-only knobs; UI hosts the kill-switch directly without a `<CascadeValue>` chip.
- **Convention conflict:** `PlaybookConfig.aiMeasurement` is a new namespace — no conflict with existing fields. Mirrors the existing `tolerances` / `firstCall` / `progressNarrative` partial-merge pattern in the `design` PUT route.

## Verified by

- **Test counts**
  - `tests/lib/pipeline/filter-by-behavior-target-params.test.ts` — 11 tests pass (5 new for #2158: override unset → run; `true` → drop; narrow to `IELTS-MEASURE-*`; non-IELTS unaffected; legacy env var ignored).
  - `tests/lib/pipeline/prosody-consumer.test.ts` — 14 tests pass (reframed flag test → "story #2158 retired the env flag, env state is no-op").
  - `tests/lib/pipeline/mode-spec-selection-coverage.test.ts` — 8 tests pass (doc updated to cite retirement).
  - `tests/lib/journey/registry-completeness.test.ts` — 17 tests pass (ratchet bumped: G4 28→29, total 93→94).
  - `tests/lib/journey/registry-schema-coverage.test.ts` — 6 tests pass (`aiMeasurementDisableLlmIeltsScoring` added to `APPLIES_TO_ALL`).
  - `tests/lib/journey/registry-consumer-coverage.test.ts` — 6 tests pass (new contract classified `family-shortcut` via `composeImpact.sections: []`).
- **Wider sweep:** 678 vitests across `tests/lib/{journey,pipeline,registry}` — all green.
- **tsc --noEmit:** 0 new errors in touched files. 2 pre-existing errors in `app/x/courses/[courseId]/page.tsx` (lines 1374/1722 on HEAD before this PR's pill insertion) — `PlaybookDetail` + `StudentProgress` type drift, not introduced by #2158.
- **UI placement decision:** matches operator's spec — Rubric Calibration lens "AI Measurement Method" card between Preset banding (line ~892) and Per-skill rubric (line ~904); header pill next to ProsodyModePill.

## UI sketch (React tree)

```
CourseDetailPage header
├── ...existing pills (Status, ProgressionMode, CurriculumSource, Prosody)
├── AiScoringMethodPill          ← NEW (#2158)
│     - Hidden when !isIeltsShaped
│     - Click → /x/courses/[id]?tab=skills&lens=rubric
│     - "AI scoring: LLM-judged (IELTS)" / "AI scoring: Default"
└── DomainPill, version

Skills tab > Rubric Calibration lens
├── Mastery policy chips
├── Preset banding
├── AiMeasurementMethodSection   ← NEW (#2158)
│     - Hidden when !data.aiMeasurement.isIeltsShaped
│     - Status pill: "LLM-judged" or "Default rubric-only"
│     - Toggle: "Disable LLM IELTS scoring for this course"
│     - Helptext: BDD-source-style explainer
└── Per-skill rubric
```

Edge cases handled:
- IELTS course with no MEASURE spec yet → card still renders if BehaviorTargets contain IELTS skill params; the toggle just no-ops at runtime.
- Non-IELTS course → both card AND header pill hidden (the kill-switch is meaningless without the gate it overrides).

## Coordination

Per `~/.claude/projects/-Users-paulwander-projects-HF/memory/handoff_merge_coordination_2026_06_21.md`:
- **Branch:** `feat/2158-retire-env-flag-course-toggle`
- **In-flight peers:** #2164 (S4 IELTS-P3-FOCUS) + #2165 (S5 LEAK-SCAN) — neither touches the files in this PR. Safe to merge in any order.
- **Rebase protocol:** `git fetch origin && git rebase origin/main && npx vitest run tests/lib/journey tests/lib/pipeline tests/components/courses && git push --force-with-lease`

## Files

- Backend (5): `lib/journey/module-settings-flag.ts`, `lib/types/json-fields.ts`, `lib/journey/setting-contracts.entries.ts`, `lib/pipeline/specs-loader.ts`, `app/api/calls/[callId]/pipeline/route.ts`
- Routes (2): `app/api/courses/[courseId]/design/route.ts`, `app/api/courses/[courseId]/skills-rubric-calibration/route.ts`
- UI (2): `app/x/courses/[courseId]/CourseSkillsTab.tsx`, `app/x/courses/[courseId]/page.tsx`
- Tests (5): `tests/lib/pipeline/{filter-by-behavior-target-params,prosody-consumer,mode-spec-selection-coverage}.test.ts`, `tests/lib/journey/{registry-completeness,registry-schema-coverage}.test.ts`

## Refs

- Closes #2158
- Refs #2138 (PR #2157 merged), #2155 (auto-detect via BehaviorTarget gate), #2156, parent epic #2135

## Test plan

- [ ] On hf-dev / hf_sandbox, verify pipeline runs IELTS-MEASURE-001 for an IELTS-shaped course with no override set.
- [ ] Toggle override ON via UI; verify next pipeline run drops IELTS-MEASURE-* from `measureSpecIds`.
- [ ] Toggle override OFF; verify spec re-runs.
- [ ] On a non-IELTS course (e.g. Spot the Spin), verify both UI card and header pill are hidden.
- [ ] Verify legacy `HF_IELTS_LLM_MEASURE_V1` env var has no effect either way (retirement complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)