### PR TITLE
chore(content): #2167 S1 — extract IELTS Sources 1-5 from v2.3 course-ref as standalone source files

### DIFF
--- a/docs/courses/ielts-speaking/README.md
+++ b/docs/courses/ielts-speaking/README.md
@@ -1,0 +1,46 @@
+# IELTS Speaking Practice — Content Sources
+
+Five content sources backing the **IELTS Speaking Practice** playbook (1 PROD playbook). These files implement Sources 1–5 of the IELTS v2.3 Course Reference (`apps/admin/lib/wizard/__tests__/fixtures/course-reference-ielts-v2.3.md` §Content Sources).
+
+| Source | File | Format | Module ref | Setting ref | Items |
+|---|---|---|---|---|---|
+| 1 — Part 1 topic library | `source-1-part1-topic-library.md` | topic-pool | `part1` | `moduleTopicPool` | 52 frames |
+| 2 — Part 2 cue card bank | `source-2-cue-card-bank.md` | cueCardBank | `part2` | `moduleCueCardPool` | 88 cards |
+| 3 — Part 3 theme library | `source-3-part3-theme-library.md` | theme-pool | `part3` | `moduleTopicPool` | 13 themes / 64 sets |
+| 4 — Baseline topic pool | `source-4-baseline-topic-pool.md` | cueCardBank | `baseline` | `moduleCueCardPool` | 10 cards (curated subset of Source 2) |
+| 5 — Mock Exam topic pool | `source-5-mock-topic-pool.md` | cueCardBank | `mock` | `moduleCueCardPool` | 30 cards (larger curated subset of Source 2) |
+
+## Why Sources 4 and 5 exist as standalone files
+
+Per v2.3 §Source 4 — Baseline Assessment topic pool: *"A small, separate pool … Keeping this pool separate prevents Baseline content from being practised before the student takes their Baseline."*
+
+Per v2.3 §Source 5 — Mock Exam topic pool: *"A larger, separate pool … Mock Exam scenarios … constructed to be representative of real test difficulty."*
+
+The v2.3 Sources 9 + 10 alternative path (Mock + Baseline REUSE Source 2 wholesale) was authored as a stop-gap — `selectPinnedCardForModule` returning `null` is the partner-blocker that Source 9/10 patched. Sources 4 and 5 here implement the intended `## Modules` content-source refs from §Source 4 / §Source 5, giving the runtime separate pools so Baseline content isn't visible during Part 2 practice.
+
+## Parser compatibility
+
+All files match the markdown conventions parsed by `apps/admin/lib/wizard/parse-source-content.ts`:
+
+- **`cueCardBank`** (`### Card N — Topic` + `> You should say:` + `>   bullet` lines) — Sources 2, 4, 5
+- **`topic-pool`** (`## Frame N — Topic` + numbered question list) — Source 1
+- **`theme-pool`** (`## Theme: X` parent + `### Set N — Topic` children + numbered question list) — Source 3
+
+## Follow-on operator action
+
+1. Upload each of the 5 sources via the wizard's Source Upload flow for the IELTS Speaking Practice playbook.
+2. The wizard's Extract pass produces `ContentSource` + `ContentAssertion` (+ `ContentQuestion` for cue-card / topic-pool formats).
+3. `PlaybookSource` links are created automatically as part of the upload.
+4. Re-project the IELTS Speaking Practice playbook's module config to switch from name-based `contentSourceRef` to slug-based `cueCardPool` / `topicPool` refs (S3 of #2167, separate PR).
+
+## Provenance
+
+Cue-card / topic / theme content is HFF-authored in the style of published IELTS Part 1, Part 2, and Part 3 frames (Cambridge IELTS volumes 1–19). No copyrighted Cambridge exam material is reproduced. Source files mirror the `docs/external/ielts/ielts-speaking/Upload Docs/` authored corpus.
+
+## Related
+
+- Story: [#2167](https://github.com/WANDERCOLTD/HF/issues/2167)
+- Epic: [#2166](https://github.com/WANDERCOLTD/HF/issues/2166) — source-ref Coverage gate
+- v2.3 Course Reference: `apps/admin/lib/wizard/__tests__/fixtures/course-reference-ielts-v2.3.md`
+- Parser: `apps/admin/lib/wizard/parse-source-content.ts`
+- Runtime consumer: `apps/admin/lib/voice/select-pinned-card.ts::selectPinnedCardForModule`

--- a/docs/courses/ielts-speaking/source-1-part1-topic-library.md
+++ b/docs/courses/ielts-speaking/source-1-part1-topic-library.md
@@ -1,0 +1,773 @@
+---
+hf-template-version: "5.1"
+hf-document-type: QUESTION_BANK
+hf-default-category: practice_prompts
+hf-audience: tutor-only
+hf-source-format: topic-pool
+hf-source-slug: ielts-speaking-part1-topic-library-v1
+---
+
+# IELTS Speaking Question Bank — Part 1
+
+> **Document type:** QUESTION_BANK · **Intended classification:** practice prompts for the Part 1 (Familiar Topics) module · **Question type:** TUTOR_QUESTION · **Assessment use:** FORMATIVE · **Bloom:** APPLY
+
+Source: HFF-authored question sets in the style of published IELTS Part 1 frames. Topic clusters and question forms are modelled on published IELTS Part 1 samples and Cambridge IELTS volumes 1–19.
+
+This bank contains 50 topic frames, each with 4–6 questions, in the standard Part 1 form. Questions are HFF-authored to mirror the style and difficulty of published Cambridge tasks without reproducing copyrighted exam content. The tutor uses these frames directly as conversational prompts in the Part 1: Familiar Topics module — these are NOT comprehension or knowledge-check questions about the test itself.
+
+**Format note:** Each frame begins with a signposting line ("Let's talk about ..." or "Now I'd like to ask you about ..."), followed by 4–6 questions. Questions cluster around: identity, frequency, preference, past experience, future / hypothetical, and reason.
+
+**Coaching note:** Part 1 answers should run 2–4 sentences. The pattern reason → example → personal touch generally reaches Band 6+. Answers shorter than two sentences cap at Band 5 on Fluency.
+
+---
+
+## Frame 1 — Home town / village
+
+_Let's talk about your home town or village._
+
+1. What kind of place is it?
+2. What's the most interesting part of your town or village?
+3. What kind of jobs do the people in your town do?
+4. Would you say it's a good place to live? (Why?)
+5. Has your home town changed much since you were a child?
+
+_(source: ielts.org official sample — `speaking-sample-tasks-2023.pdf`, p. 3.)_
+
+---
+
+## Frame 2 — Accommodation
+
+_Let's move on to talk about accommodation._
+
+1. Tell me about the kind of accommodation you live in.
+2. How long have you lived there?
+3. What do you like about living there?
+4. What sort of accommodation would you most like to live in?
+5. Is your home easy to get to?
+
+_(source: ielts.org official sample — `speaking-sample-tasks-2023.pdf`, p. 3.)_
+
+---
+
+## Frame 3 — Work
+
+_Let's talk about your work._
+
+1. What kind of work do you do?
+2. What does a typical day at work look like for you?
+3. What do you find most enjoyable about your job?
+4. Is there anything you would like to change about your work?
+5. Would you recommend your job to other people? (Why or why not?)
+
+_(source: HFF-authored, modelled on published Part 1 frames; takeielts.britishcouncil.org Part 1 work-and-study sample, accessed 2026-05-08.)_
+
+---
+
+## Frame 4 — Studies
+
+_Now let's talk about your studies._
+
+1. What subject are you studying at the moment?
+2. Why did you choose that subject?
+3. Which part of your studies do you enjoy most?
+4. Do you prefer studying alone or in a group? (Why?)
+5. What do you hope to do after you finish your studies?
+
+_(source: HFF-authored; mirrors takeielts.britishcouncil.org Part 1 work-and-study sample.)_
+
+---
+
+## Frame 5 — Family
+
+_Let's talk about your family._
+
+1. Do you come from a large or a small family?
+2. Who do you spend the most time with in your family?
+3. How often do you see your relatives?
+4. What do you usually do when your family gets together?
+5. Has your family changed much in the last few years?
+
+_(source: HFF-authored; mirrors Cambridge IELTS published frames.)_
+
+---
+
+## Frame 6 — Friends
+
+_Now let's talk about your friends._
+
+1. How often do you see your friends?
+2. What do you usually do with your friends?
+3. Do you prefer to have a few close friends or many friends? (Why?)
+4. How did you meet your closest friend?
+5. Is it easy to make new friends as an adult?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 7 — Hobbies
+
+_Let's talk about hobbies._
+
+1. Do you have any hobbies?
+2. How did you become interested in your hobby?
+3. How often do you have time for your hobby?
+4. Do you think hobbies are important? (Why?)
+5. Would you like to take up a new hobby in the future?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 8 — Sports
+
+_Now let's talk about sports._
+
+1. Do you play any sports?
+2. Did you play sports when you were younger?
+3. Do you prefer playing sports or watching them?
+4. What sport is most popular in your country?
+5. Do you think children should be encouraged to play sports?
+
+_(source: HFF-authored; mirrors takeielts.britishcouncil.org Part 1 sports samples.)_
+
+---
+
+## Frame 9 — Food and cooking
+
+_Let's talk about food._
+
+1. What kinds of food do you most enjoy?
+2. Do you prefer eating at home or in restaurants?
+3. How often do you cook?
+4. Did your family eat together when you were a child?
+5. Has the food you eat changed over the years?
+6. Are there any foods you don't like?
+
+_(source: HFF-authored; mirrors Cambridge IELTS food-topic frames.)_
+
+---
+
+## Frame 10 — Travel
+
+_Let's talk about travel._
+
+1. Do you enjoy travelling?
+2. Where was the last place you visited?
+3. Do you prefer travelling alone or with other people?
+4. What kind of place would you most like to visit?
+5. Has the way people travel changed in recent years?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 11 — Holidays
+
+_Now let's talk about holidays._
+
+1. How do you usually spend your holidays?
+2. Do you prefer short holidays or long ones?
+3. Where did you go on your last holiday?
+4. What's the best holiday you've ever had?
+5. Would you ever like to spend a holiday abroad?
+
+_(source: HFF-authored; mirrors takeielts.britishcouncil.org Part 1 holidays sample.)_
+
+---
+
+## Frame 12 — Transport
+
+_Let's talk about transport._
+
+1. How do you usually get around your town or city?
+2. Do you prefer public transport or driving? (Why?)
+3. Has the transport in your area changed in recent years?
+4. Do you think people should use public transport more?
+5. What's the most uncomfortable journey you've ever had?
+
+_(source: HFF-authored; mirrors takeielts.britishcouncil.org Part 1 transport sample.)_
+
+---
+
+## Frame 13 — Technology
+
+_Let's talk about technology._
+
+1. How often do you use a computer?
+2. What do you mostly use it for?
+3. Are you good with new technology?
+4. Has technology changed your daily life much?
+5. Do you think people rely too much on technology?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 14 — Social media
+
+_Now let's talk about social media._
+
+1. Do you use social media?
+2. Which platform do you use most often?
+3. How much time do you spend on social media each day?
+4. Has social media changed the way you keep in touch with friends?
+5. Are there any aspects of social media you dislike?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 15 — Mobile phones
+
+_Let's talk about mobile phones._
+
+1. How often do you use your mobile phone?
+2. What do you use it for most?
+3. Did you have a mobile phone when you were a child?
+4. Could you live without your mobile phone for a week?
+5. How has the way people use mobile phones changed?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 16 — Music
+
+_Now let's talk about music._
+
+1. What kind of music do you enjoy listening to?
+2. When do you usually listen to music?
+3. Did you learn a musical instrument as a child?
+4. Has the music you like changed over the years?
+5. Do you ever go to concerts?
+
+_(source: HFF-authored; mirrors takeielts.britishcouncil.org Part 1 music sample.)_
+
+---
+
+## Frame 17 — Films
+
+_Let's talk about films._
+
+1. How often do you watch films?
+2. Do you prefer watching films at home or at the cinema?
+3. What kind of films do you most enjoy?
+4. What's the last film you saw?
+5. Are films from your country popular abroad?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 18 — Books
+
+_Now let's talk about books._
+
+1. Do you read much?
+2. What kind of books do you most enjoy?
+3. Do you prefer paper books or e-books? (Why?)
+4. Did you read a lot as a child?
+5. Is reading important to you?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 19 — News
+
+_Let's talk about the news._
+
+1. How do you usually get the news?
+2. How often do you check the news?
+3. What kind of news interests you most?
+4. Do you discuss the news with your family or friends?
+5. Is the way people get the news different now from in the past?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 20 — Art
+
+_Now let's talk about art._
+
+1. Did you do art at school?
+2. Do you ever visit art galleries?
+3. What kind of art do you most enjoy?
+4. Do you have any artistic hobbies?
+5. Do you think art is important for children?
+
+_(source: HFF-authored; mirrors Cambridge IELTS art-topic frames.)_
+
+---
+
+## Frame 21 — Weather
+
+_Let's talk about the weather._
+
+1. What kind of weather do you most enjoy?
+2. What's the weather like in your country at this time of year?
+3. Does the weather affect your mood?
+4. Has the weather where you live changed much over the years?
+5. Do you ever check the weather forecast?
+
+_(source: HFF-authored; mirrors takeielts.britishcouncil.org Part 1 weather sample.)_
+
+---
+
+## Frame 22 — Seasons
+
+_Now let's talk about seasons._
+
+1. Which is your favourite season?
+2. What do you usually do in that season?
+3. Are the seasons very different in your country?
+4. Do you prefer summer or winter?
+5. Has your favourite season changed since you were a child?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 23 — Clothes
+
+_Let's talk about clothes._
+
+1. What kind of clothes do you like to wear?
+2. Do you spend much time choosing what to wear?
+3. Where do you usually buy your clothes?
+4. Have your clothing tastes changed over the years?
+5. Are there any clothes you would never wear?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 24 — Shopping
+
+_Now let's talk about shopping._
+
+1. Do you enjoy shopping?
+2. What kinds of things do you most enjoy shopping for?
+3. Do you prefer shopping online or in shops?
+4. Who do you usually go shopping with?
+5. Has the way people shop changed in recent years?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 25 — Money
+
+_Let's talk about money._
+
+1. Do you find it easy to save money?
+2. Do you prefer to spend money on things or experiences?
+3. Did your parents teach you about money when you were young?
+4. Do you keep track of what you spend?
+5. Is it important to teach children about money?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 26 — Gifts
+
+_Now let's talk about gifts._
+
+1. Do you enjoy giving gifts?
+2. When did you last give someone a gift?
+3. Is it easy to choose a gift for someone?
+4. Do people in your country exchange gifts on special occasions?
+5. What's the best gift you've ever received?
+
+_(source: HFF-authored; mirrors Cambridge IELTS gifts-topic frames.)_
+
+---
+
+## Frame 27 — Festivals
+
+_Let's talk about festivals._
+
+1. What's the most important festival in your country?
+2. How is it celebrated?
+3. Do you usually celebrate it with your family?
+4. Has the way people celebrate festivals changed?
+5. Do you think traditional festivals are important?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 28 — Celebrations
+
+_Now let's talk about celebrations._
+
+1. What kinds of events do you usually celebrate?
+2. Who do you usually celebrate with?
+3. How did you celebrate your last birthday?
+4. Do you prefer big celebrations or small ones? (Why?)
+5. Are celebrations important in your country?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 29 — Photographs
+
+_Let's talk about photographs._
+
+1. Do you like taking photographs?
+2. Do you prefer taking photographs of people or places?
+3. How do you usually keep your photographs?
+4. Has the way people take photographs changed?
+5. Do you ever look back at old photographs?
+
+_(source: HFF-authored; mirrors Cambridge IELTS photographs-topic frames.)_
+
+---
+
+## Frame 30 — Neighbours
+
+_Now let's talk about neighbours._
+
+1. Do you know your neighbours well?
+2. How often do you see them?
+3. Do you think it's important to have good neighbours?
+4. Has the relationship between neighbours changed in your country?
+5. What makes a good neighbour?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 31 — Pets
+
+_Let's talk about pets._
+
+1. Do you have a pet?
+2. Did you have a pet when you were a child?
+3. What kind of pets are popular in your country?
+4. Do you think children should have pets?
+5. Are pets treated differently now from in the past?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 32 — Animals
+
+_Now let's talk about animals._
+
+1. What's your favourite animal?
+2. Are there many wild animals where you live?
+3. Did you visit zoos when you were younger?
+4. Do you think it's important to protect wild animals?
+5. Have you ever seen an animal you found really interesting?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 33 — Plants and flowers
+
+_Let's talk about plants and flowers._
+
+1. Do you have any plants at home?
+2. Do you ever buy flowers?
+3. Are flowers given as gifts in your country?
+4. Did you have a garden when you were a child?
+5. Are there any flowers that are special in your culture?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 34 — Gardens
+
+_Now let's talk about gardens._
+
+1. Do you have a garden?
+2. Do you enjoy gardening?
+3. Are there public gardens or parks where you live?
+4. Did you spend time in gardens when you were a child?
+5. What do you think people enjoy about gardening?
+
+_(source: HFF-authored; mirrors takeielts.britishcouncil.org Part 1 gardens sample.)_
+
+---
+
+## Frame 35 — Time management
+
+_Let's talk about how you manage your time._
+
+1. Do you find it easy to manage your time?
+2. Are you good at being on time?
+3. Do you make plans for each day?
+4. What do you do when you have free time?
+5. Has managing your time become easier or harder over the years?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 36 — Sleep
+
+_Now let's talk about sleep._
+
+1. How many hours of sleep do you usually get?
+2. Do you ever have trouble sleeping?
+3. Do you prefer to go to bed early or late?
+4. Did you sleep more when you were a child?
+5. Do you take naps during the day?
+
+_(source: HFF-authored; mirrors takeielts.britishcouncil.org Part 1 sleep sample.)_
+
+---
+
+## Frame 37 — Dreams
+
+_Let's talk about dreams._
+
+1. Do you usually remember your dreams?
+2. Do you ever have the same dream more than once?
+3. Have you ever had a dream that came true?
+4. Do you think dreams have any meaning?
+5. Have you ever talked about a dream with someone else?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 38 — Memory
+
+_Now let's talk about memory._
+
+1. Are you good at remembering things?
+2. What kinds of things do you find easy to remember?
+3. What do you do when you need to remember something important?
+4. Do you think children have better memories than adults?
+5. Have you ever forgotten something important?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 39 — Childhood
+
+_Let's talk about your childhood._
+
+1. Where did you grow up?
+2. What did you most enjoy doing as a child?
+3. Were you closer to your mother or your father?
+4. Has childhood changed since you were young?
+5. What's your happiest childhood memory?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 40 — School
+
+_Now let's talk about your school days._
+
+1. What primary school did you go to?
+2. What did you most enjoy at school?
+3. What was your favourite subject?
+4. Did you have a favourite teacher?
+5. What's the most important thing you learned at school?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 41 — Teachers
+
+_Let's talk about teachers._
+
+1. Did you have a favourite teacher when you were younger?
+2. What made them a good teacher?
+3. What qualities do you think a teacher should have?
+4. Have you ever taught anyone anything?
+5. Do you think teaching is a difficult job?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 42 — Languages
+
+_Now let's talk about languages._
+
+1. How many languages do you speak?
+2. When did you start learning English?
+3. Which language would you most like to learn next?
+4. Is learning a language difficult for you?
+5. What's the best way to learn a language, in your opinion?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 43 — Learning
+
+_Let's talk about learning new things._
+
+1. Do you enjoy learning new things?
+2. What was the last thing you learned?
+3. Do you prefer learning by yourself or being taught?
+4. What's the most useful skill you've ever learned?
+5. Is there anything you would like to learn in the future?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 44 — Future plans
+
+_Now let's talk about your future plans._
+
+1. Do you have any plans for the next few years?
+2. Where do you see yourself in five years' time?
+3. Are you the kind of person who plans ahead?
+4. Did you make plans for your future when you were younger?
+5. Is it important to make long-term plans, in your opinion?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 45 — The internet
+
+_Let's talk about the internet._
+
+1. How often do you use the internet?
+2. What do you most use it for?
+3. Did you use the internet when you were a child?
+4. Has the internet changed the way you do things?
+5. Are there any disadvantages to using the internet?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 46 — Email and letters
+
+_Now let's talk about written communication._
+
+1. How often do you write emails?
+2. Do you ever write letters by hand?
+3. Did you write letters when you were younger?
+4. Do you prefer writing or speaking when you communicate with someone far away?
+5. Has the way people communicate changed much in your lifetime?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 47 — Advertising
+
+_Let's talk about advertising._
+
+1. Do you pay attention to advertisements?
+2. Where do you see most adverts?
+3. Have you ever bought something because of an advert?
+4. Do you think there are too many advertisements these days?
+5. Do you think advertising affects children?
+
+_(source: HFF-authored; mirrors `speaking-sample-tasks-2023.pdf`, p. 6 advertising prompt.)_
+
+---
+
+## Frame 48 — Sky and stars
+
+_Now let's talk about the sky._
+
+1. Do you ever look at the sky?
+2. Have you ever watched the stars at night?
+3. Is the night sky clear where you live?
+4. Did you study the stars at school?
+5. Would you ever like to travel to space?
+
+_(source: HFF-authored; mirrors takeielts.britishcouncil.org Part 1 sky-and-stars sample.)_
+
+---
+
+## Frame 49 — Rain and wet weather
+
+_Let's talk about rainy weather._
+
+1. Does it rain much where you live?
+2. Do you enjoy rainy days?
+3. What do you usually do when it rains?
+4. Has the rainfall in your area changed in recent years?
+5. Are there places in your country where it rains a lot more than others?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 50 — Public transport
+
+_Now let's talk about public transport._
+
+1. How often do you use public transport?
+2. What kind of public transport do you most use?
+3. Is the public transport in your city good?
+4. Did you use public transport more when you were younger?
+5. Are there ways the public transport in your area could be improved?
+
+_(source: HFF-authored.)_
+
+---
+
+## Frame 51 — Free time
+
+_Let's talk about your free time._
+
+1. What do you usually do in your free time?
+2. Do you have enough free time during the week?
+3. Did you have more free time when you were younger?
+4. Do you prefer to spend your free time alone or with others?
+5. Is free time important to you?
+
+_(source: HFF-authored; mirrors Cambridge IELTS free-time frames.)_
+
+---
+
+## Frame 52 — Health and exercise
+
+_Now let's talk about health and exercise._
+
+1. Do you exercise regularly?
+2. What kind of exercise do you enjoy most?
+3. Did you do more exercise when you were younger?
+4. Do you think people in your country exercise enough?
+5. Is exercise important for staying healthy?
+
+_(source: HFF-authored.)_
+
+---
+
+## Coaching cheat sheet
+
+| Question form | Common candidate failure | Tutor cue |
+|---------------|-------------------------|-----------|
+| "Do you ...?" | One-word "Yes" / "No" | "Extend with a reason and an example." |
+| "How often ...?" | "Sometimes" or "Often" | "Anchor the frequency in time — once a week, a few times a year." |
+| "Tell me about ..." | Lists facts without elaboration | "Pick one feature and develop it." |
+| "Why ...?" | Vague reasoning | "Give a specific reason — what made you feel that way?" |
+| "Has ... changed?" | Present-only answer | "Compare past and present explicitly." |
+| "Would you most like to ...?" | Indecision | "Commit to one option and justify." |
+
+---
+
+## Sources
+
+- *IELTS Speaking Sample Tasks (2023)* — `speaking-sample-tasks-2023.pdf` (in this folder), pages 3, 6.
+- ielts.org — "Speaking Part 1 sample tasks". https://www.ielts.org (accessed 2026-05-08).
+- takeielts.britishcouncil.org — "Free IELTS Speaking practice tests Part 1". https://takeielts.britishcouncil.org/take-ielts/prepare/free-ielts-practice-tests/speaking (accessed 2026-05-08).
+- ielts.idp.com — "IELTS Speaking Part 1 sample". https://ielts.idp.com (accessed 2026-05-08).
+- Cambridge IELTS volumes 1–19 — published past papers (referenced as a pattern source; not reproduced verbatim).
+- All HFF-authored frames marked above are written in the style of the published frames and are original content; they are not reproduced from copyrighted Cambridge IELTS exam material.

--- a/docs/courses/ielts-speaking/source-2-cue-card-bank.md
+++ b/docs/courses/ielts-speaking/source-2-cue-card-bank.md
@@ -1,0 +1,1053 @@
+---
+hf-template-version: "5.1"
+hf-document-type: QUESTION_BANK
+hf-default-category: practice_prompts
+hf-audience: tutor-only
+hf-source-format: cueCardBank
+hf-source-slug: ielts-speaking-cue-card-bank-v1
+---
+
+# IELTS Speaking Question Bank — Part 2
+
+> **Document type:** QUESTION_BANK · **Intended classification:** practice prompts for the Part 2 module · **Question type:** TUTOR_QUESTION · **Assessment use:** FORMATIVE · **Bloom:** APPLY/EVALUATE
+
+Source: HFF-authored cue cards in the style of published IELTS Part 2 tasks. Card structure and topical clusters are modelled on published IELTS Part 2 samples and Cambridge IELTS volumes 1–19.
+
+This bank contains 88 cue cards in the standard four-bullet form, clustered by six Part 2 frames: **Person, Place, Object, Event, Experience, Activity**. Cards are HFF-authored to mirror the style and difficulty of published Cambridge tasks without reproducing copyrighted exam content. See `tutor-briefing.md` for the Part 2 format definition.
+
+**Format note:** Every card uses the official template:
+
+```
+Describe ...
+You should say:
+   [bullet 1]
+   [bullet 2]
+   [bullet 3]
+and explain ...
+```
+
+After the candidate's monologue, the examiner may ask one or two short rounding-off questions; representative rounding-off questions are listed where relevant.
+
+**Coaching note:** Each bullet is approximately one paragraph of the monologue. The "and explain" bullet is the substantive one — examiners look for it to be addressed with reasoning, not just a fact. A 2-minute monologue is typically 250–350 words.
+
+---
+
+## Person frame (cards 1–15)
+
+### Card 1 — Family member you admire
+
+> Describe a family member you admire.
+> You should say:
+>   who this person is
+>   how often you see them
+>   what kind of personality they have
+> and explain why you admire them.
+
+_Rounding-off: Have you tried to be like them in any way?_
+
+_(source: HFF-authored; mirrors Cambridge IELTS person-topic frames.)_
+
+### Card 2 — A friend who has helped you
+
+> Describe a friend who has helped you in some way.
+> You should say:
+>   who they are
+>   when they helped you
+>   what they did
+> and explain why their help was important.
+
+_(source: HFF-authored.)_
+
+### Card 3 — A teacher you remember
+
+> Describe a teacher you remember from school.
+> You should say:
+>   who they were
+>   what subject they taught
+>   what they were like
+> and explain why you remember them.
+
+_(source: HFF-authored.)_
+
+### Card 4 — A famous person you would like to meet
+
+> Describe a famous person you would like to meet.
+> You should say:
+>   who this person is
+>   how you first heard of them
+>   what you know about them
+> and explain why you would like to meet them.
+
+_(source: HFF-authored; mirrors takeielts.britishcouncil.org Part 2 sample.)_
+
+### Card 5 — An older person you respect
+
+> Describe an older person you respect.
+> You should say:
+>   who they are
+>   how you know them
+>   what kind of person they are
+> and explain why you respect them.
+
+_(source: HFF-authored.)_
+
+### Card 6 — A child you know
+
+> Describe a child you know well.
+> You should say:
+>   who the child is
+>   how often you see them
+>   what they are like
+> and explain why you enjoy spending time with them.
+
+_(source: HFF-authored.)_
+
+### Card 7 — A talented person
+
+> Describe a person you know who is good at a particular skill.
+> You should say:
+>   who they are
+>   what skill they are good at
+>   how they developed it
+> and explain why you find their skill impressive.
+
+_(source: HFF-authored.)_
+
+### Card 8 — A stranger who helped you
+
+> Describe a stranger who once helped you.
+> You should say:
+>   when this happened
+>   where you were
+>   what they did
+> and explain how you felt about their help.
+
+_(source: HFF-authored.)_
+
+### Card 9 — A neighbour you know well
+
+> Describe a neighbour you know well.
+> You should say:
+>   who they are
+>   how long you have known them
+>   what kind of person they are
+> and explain why you get on with them.
+
+_(source: HFF-authored.)_
+
+### Card 10 — A leader you admire
+
+> Describe a leader you admire.
+> You should say:
+>   who they are
+>   what they are known for
+>   what kind of person they are
+> and explain why you admire them.
+
+_(source: HFF-authored.)_
+
+### Card 11 — A person who taught you something
+
+> Describe a person who taught you something useful.
+> You should say:
+>   who this person is
+>   what they taught you
+>   when this happened
+> and explain why what they taught you was useful.
+
+_(source: HFF-authored.)_
+
+### Card 12 — A friend from your childhood
+
+> Describe a friend from your childhood.
+> You should say:
+>   who they were
+>   how you met
+>   what you used to do together
+> and explain how you feel about them now.
+
+_(source: HFF-authored.)_
+
+### Card 13 — A character from a book or film
+
+> Describe a character from a book or film you remember.
+> You should say:
+>   what the book or film is
+>   who the character is
+>   what kind of personality they have
+> and explain why you remember this character.
+
+_(source: HFF-authored.)_
+
+### Card 14 — A colleague you work well with
+
+> Describe a colleague you work well with.
+> You should say:
+>   who they are
+>   what they do
+>   how long you have worked together
+> and explain why you work well with them.
+
+_(source: HFF-authored.)_
+
+### Card 15 — A person you contact often
+
+> Describe a person you contact often by phone or message.
+> You should say:
+>   who they are
+>   how you usually contact them
+>   what you usually talk about
+> and explain why you stay in touch.
+
+_(source: HFF-authored.)_
+
+---
+
+## Place frame (cards 16–30)
+
+### Card 16 — A place you like to visit in your free time
+
+> Describe a place you like to visit in your free time.
+> You should say:
+>   where it is
+>   how often you go there
+>   what you do there
+> and explain why you enjoy spending time there.
+
+_(source: HFF-authored.)_
+
+### Card 17 — A beautiful natural place
+
+> Describe a beautiful natural place you have visited.
+> You should say:
+>   where it is
+>   when you went there
+>   what you saw or did
+> and explain what made it beautiful.
+
+_(source: HFF-authored; mirrors Cambridge IELTS place-topic frames.)_
+
+### Card 18 — A city or town you would like to visit
+
+> Describe a city or town you would like to visit in the future.
+> You should say:
+>   where it is
+>   how you first heard about it
+>   what you would do there
+> and explain why you would like to visit.
+
+_(source: HFF-authored.)_
+
+### Card 19 — A restaurant you enjoyed
+
+> Describe a restaurant you enjoyed visiting.
+> You should say:
+>   where it is
+>   when you went there
+>   what kind of food it serves
+> and explain why you enjoyed it.
+
+_(source: HFF-authored.)_
+
+### Card 20 — A shop you visit often
+
+> Describe a shop you visit often.
+> You should say:
+>   what kind of shop it is
+>   where it is
+>   what you usually buy there
+> and explain why you keep going back.
+
+_(source: HFF-authored.)_
+
+### Card 21 — A library or quiet study place
+
+> Describe a library or quiet place where you have studied.
+> You should say:
+>   where it is
+>   how often you went there
+>   what it was like
+> and explain why it was a good place to study.
+
+_(source: HFF-authored.)_
+
+### Card 22 — A park you like
+
+> Describe a park you like to spend time in.
+> You should say:
+>   where it is
+>   when you usually go
+>   what you do there
+> and explain why you enjoy this park.
+
+_(source: HFF-authored; mirrors takeielts.britishcouncil.org Part 2 sample.)_
+
+### Card 23 — A place from your childhood
+
+> Describe a place from your childhood that you remember well.
+> You should say:
+>   where it was
+>   what it looked like
+>   what you used to do there
+> and explain why you remember it.
+
+_(source: HFF-authored.)_
+
+### Card 24 — A historic place you have visited
+
+> Describe a historic place you have visited.
+> You should say:
+>   where it is
+>   when you went
+>   what you learned about it
+> and explain why it was interesting.
+
+_(source: HFF-authored.)_
+
+### Card 25 — A place where many people gather
+
+> Describe a place in your town where many people gather.
+> You should say:
+>   where it is
+>   when people gather there
+>   what they usually do
+> and explain why this place is popular.
+
+_(source: HFF-authored.)_
+
+### Card 26 — A peaceful place you have been to
+
+> Describe a peaceful place you have been to.
+> You should say:
+>   where it is
+>   when you went there
+>   what made it peaceful
+> and explain how you felt while you were there.
+
+_(source: HFF-authored.)_
+
+### Card 27 — A foreign country you have visited
+
+> Describe a foreign country you have visited.
+> You should say:
+>   which country it was
+>   why you went
+>   what you saw or did there
+> and explain what you most remember about your visit.
+
+_(source: HFF-authored.)_
+
+### Card 28 — A building you like
+
+> Describe a building you find impressive.
+> You should say:
+>   where it is
+>   what it looks like
+>   what it is used for
+> and explain why you find it impressive.
+
+_(source: HFF-authored.)_
+
+### Card 29 — A place where you have studied
+
+> Describe a school or place where you have studied.
+> You should say:
+>   where it was
+>   when you studied there
+>   what it was like
+> and explain how you feel about your time there.
+
+_(source: HFF-authored.)_
+
+### Card 30 — A place that's important to your family
+
+> Describe a place that is important to your family.
+> You should say:
+>   where it is
+>   why it matters to your family
+>   how often you go there
+> and explain how you feel about this place.
+
+_(source: HFF-authored.)_
+
+---
+
+## Object frame (cards 31–45)
+
+### Card 31 — Something you own that's important to you
+
+> Describe something you own that is very important to you.
+> You should say:
+>   where you got it from
+>   how long you have had it
+>   what you use it for
+> and explain why it is important to you.
+
+_Rounding-off: Is it valuable in terms of money? Would it be easy to replace?_
+
+_(source: ielts.org official sample — `speaking-sample-tasks-2023.pdf`, p. 5.)_
+
+### Card 32 — A useful piece of technology you own
+
+> Describe a piece of technology you find useful.
+> You should say:
+>   what it is
+>   when you got it
+>   how often you use it
+> and explain why you find it useful.
+
+_(source: HFF-authored.)_
+
+### Card 33 — A gift you received
+
+> Describe a gift you received that you really liked.
+> You should say:
+>   what it was
+>   who gave it to you
+>   when you received it
+> and explain why you liked it.
+
+_(source: HFF-authored; mirrors Cambridge IELTS gift-topic frames.)_
+
+### Card 34 — A photograph you remember
+
+> Describe a photograph you remember well.
+> You should say:
+>   what is in the photograph
+>   when it was taken
+>   who took it
+> and explain why you remember it.
+
+_(source: HFF-authored.)_
+
+### Card 35 — A book that influenced you
+
+> Describe a book that has influenced you.
+> You should say:
+>   what the book is
+>   when you read it
+>   what it is about
+> and explain how it influenced you.
+
+_(source: HFF-authored.)_
+
+### Card 36 — A piece of clothing you like to wear
+
+> Describe a piece of clothing you like to wear.
+> You should say:
+>   what it is
+>   when you wear it
+>   where you got it
+> and explain why you like wearing it.
+
+_(source: HFF-authored.)_
+
+### Card 37 — A traditional item from your country
+
+> Describe a traditional item from your country.
+> You should say:
+>   what it is
+>   where it comes from
+>   what it is used for
+> and explain why it is considered traditional.
+
+_(source: HFF-authored.)_
+
+### Card 38 — Something expensive you bought
+
+> Describe something expensive that you bought recently.
+> You should say:
+>   what it was
+>   why you bought it
+>   how much you paid
+> and explain whether you think it was worth the money.
+
+_(source: HFF-authored.)_
+
+### Card 39 — Something you use every day
+
+> Describe something you use every day.
+> You should say:
+>   what it is
+>   how long you have had it
+>   what you use it for
+> and explain why it is so useful to you.
+
+_(source: HFF-authored.)_
+
+### Card 40 — A piece of furniture in your home
+
+> Describe a piece of furniture in your home that you like.
+> You should say:
+>   what it is
+>   where it is in your home
+>   how long you have had it
+> and explain why you like it.
+
+_(source: HFF-authored.)_
+
+### Card 41 — A piece of jewellery you wear
+
+> Describe a piece of jewellery that you wear.
+> You should say:
+>   what it is
+>   when you got it
+>   when you usually wear it
+> and explain why it is special to you.
+
+_(source: HFF-authored.)_
+
+### Card 42 — A handmade item you own
+
+> Describe a handmade item you own.
+> You should say:
+>   what it is
+>   who made it
+>   when you got it
+> and explain why this item matters to you.
+
+_(source: HFF-authored.)_
+
+### Card 43 — A toy from your childhood
+
+> Describe a toy you remember from your childhood.
+> You should say:
+>   what it was
+>   who gave it to you
+>   how you played with it
+> and explain why you remember this toy.
+
+_(source: HFF-authored.)_
+
+### Card 44 — A device you would like to own
+
+> Describe a device or piece of technology you would like to own.
+> You should say:
+>   what it is
+>   why you want it
+>   what you would use it for
+> and explain how it would change your daily life.
+
+_(source: HFF-authored.)_
+
+### Card 45 — A meal you like to cook
+
+> Describe a meal you like to cook.
+> You should say:
+>   what the meal is
+>   who taught you to cook it
+>   when you usually make it
+> and explain why you enjoy cooking and eating it.
+
+_(source: HFF-authored.)_
+
+---
+
+## Event frame (cards 46–60)
+
+### Card 46 — A celebration in your family
+
+> Describe a recent celebration in your family.
+> You should say:
+>   what was being celebrated
+>   when it happened
+>   who attended
+> and explain how you felt about it.
+
+_(source: HFF-authored.)_
+
+### Card 47 — A festival in your country
+
+> Describe a festival that is important in your country.
+> You should say:
+>   what the festival is
+>   when it is celebrated
+>   what people do during it
+> and explain why it is important.
+
+_(source: HFF-authored.)_
+
+### Card 48 — A wedding you have attended
+
+> Describe a wedding you have attended.
+> You should say:
+>   whose wedding it was
+>   when it happened
+>   what people did
+> and explain what you most remember about it.
+
+_(source: HFF-authored.)_
+
+### Card 49 — A sports event you have watched
+
+> Describe a sports event you have watched in person or on television.
+> You should say:
+>   what the event was
+>   when you watched it
+>   who you watched it with
+> and explain why you remember it.
+
+_(source: HFF-authored.)_
+
+### Card 50 — A concert or live performance
+
+> Describe a concert or live performance you have been to.
+> You should say:
+>   what kind of performance it was
+>   when you went
+>   who you went with
+> and explain why you enjoyed it (or did not).
+
+_(source: HFF-authored.)_
+
+### Card 51 — A public event in your town
+
+> Describe a public event that took place in your town.
+> You should say:
+>   what kind of event it was
+>   when it took place
+>   what people did there
+> and explain why it was a notable event.
+
+_(source: HFF-authored.)_
+
+### Card 52 — A traditional ceremony
+
+> Describe a traditional ceremony from your country.
+> You should say:
+>   what kind of ceremony it is
+>   when it usually takes place
+>   what happens during it
+> and explain why this ceremony is important.
+
+_(source: HFF-authored.)_
+
+### Card 53 — A meal that was special
+
+> Describe a meal that was special to you.
+> You should say:
+>   what the meal was
+>   when it took place
+>   who you shared it with
+> and explain what made it special.
+
+_(source: HFF-authored.)_
+
+### Card 54 — A birthday you remember
+
+> Describe a birthday you remember well.
+> You should say:
+>   whose birthday it was
+>   when it took place
+>   what happened
+> and explain why you remember this birthday.
+
+_(source: HFF-authored.)_
+
+### Card 55 — A meeting that was important
+
+> Describe a meeting that was important to you.
+> You should say:
+>   what the meeting was about
+>   who was there
+>   what was discussed
+> and explain why it was important.
+
+_(source: HFF-authored.)_
+
+### Card 56 — A trip you took recently
+
+> Describe a trip you have taken recently.
+> You should say:
+>   where you went
+>   why you went
+>   who you went with
+> and explain what you most enjoyed about the trip.
+
+_(source: HFF-authored.)_
+
+### Card 57 — An exhibition or museum you visited
+
+> Describe an exhibition or museum you have visited.
+> You should say:
+>   what kind of exhibition it was
+>   where it was
+>   what you saw
+> and explain why it was interesting.
+
+_(source: HFF-authored.)_
+
+### Card 58 — A school event you remember
+
+> Describe a school event you remember.
+> You should say:
+>   what kind of event it was
+>   when it happened
+>   what you did
+> and explain why this event stands out.
+
+_(source: HFF-authored.)_
+
+### Card 59 — A family gathering
+
+> Describe a family gathering you have attended.
+> You should say:
+>   what the occasion was
+>   who was there
+>   what you did
+> and explain how you felt about being there.
+
+_(source: HFF-authored.)_
+
+### Card 60 — A graduation you witnessed
+
+> Describe a graduation ceremony you have attended.
+> You should say:
+>   whose graduation it was
+>   where it took place
+>   what happened at the ceremony
+> and explain why you remember it.
+
+_(source: HFF-authored.)_
+
+---
+
+## Experience frame (cards 61–75)
+
+### Card 61 — A time you helped someone
+
+> Describe a time when you helped someone.
+> You should say:
+>   who you helped
+>   what they needed help with
+>   what you did
+> and explain how you felt about helping them.
+
+_(source: HFF-authored.)_
+
+### Card 62 — A time you were late
+
+> Describe a time when you were late for something important.
+> You should say:
+>   what you were late for
+>   why you were late
+>   what happened
+> and explain how you felt about being late.
+
+_(source: HFF-authored.)_
+
+### Card 63 — A journey you remember
+
+> Describe a journey you remember well.
+> You should say:
+>   where you were going
+>   how you travelled
+>   who was with you
+> and explain why you remember this journey.
+
+_(source: HFF-authored.)_
+
+### Card 64 — A time you learned something quickly
+
+> Describe a time when you learned something quickly.
+> You should say:
+>   what you learned
+>   how you learned it
+>   when this happened
+> and explain why you were able to learn it so quickly.
+
+_(source: HFF-authored.)_
+
+### Card 65 — A time you waited a long time
+
+> Describe a time when you had to wait a long time for something.
+> You should say:
+>   what you were waiting for
+>   how long you waited
+>   what you did during the wait
+> and explain how you felt about it.
+
+_(source: HFF-authored.)_
+
+### Card 66 — A time you changed your mind
+
+> Describe a time when you changed your mind about something.
+> You should say:
+>   what you originally thought
+>   why you changed your mind
+>   when this happened
+> and explain how you feel about the change now.
+
+_(source: HFF-authored.)_
+
+### Card 67 — An achievement you are proud of
+
+> Describe an achievement you are proud of.
+> You should say:
+>   what the achievement was
+>   how long it took
+>   how you achieved it
+> and explain why you are proud of it.
+
+_(source: HFF-authored.)_
+
+### Card 68 — A time you tried something new
+
+> Describe a time when you tried something new.
+> You should say:
+>   what you tried
+>   when you tried it
+>   why you wanted to try it
+> and explain how the experience went.
+
+_(source: HFF-authored.)_
+
+### Card 69 — A time you solved a problem
+
+> Describe a time when you solved a difficult problem.
+> You should say:
+>   what the problem was
+>   how you tried to solve it
+>   what the result was
+> and explain how you felt afterwards.
+
+_(source: HFF-authored.)_
+
+### Card 70 — A time you met someone new
+
+> Describe a time when you met someone new and got on well with them.
+> You should say:
+>   who you met
+>   when you met
+>   what you talked about
+> and explain why you got on well.
+
+_(source: HFF-authored.)_
+
+### Card 71 — A time you got lost
+
+> Describe a time when you got lost somewhere.
+> You should say:
+>   where you were
+>   what happened
+>   how you found your way again
+> and explain how you felt about getting lost.
+
+_(source: HFF-authored.)_
+
+### Card 72 — A time you saw something unusual
+
+> Describe a time when you saw something unusual.
+> You should say:
+>   what you saw
+>   when and where you saw it
+>   who was with you
+> and explain why it was unusual.
+
+_(source: HFF-authored.)_
+
+### Card 73 — A time you received good news
+
+> Describe a time when you received some good news.
+> You should say:
+>   what the news was
+>   how you heard it
+>   who you shared it with
+> and explain how the news made you feel.
+
+_(source: HFF-authored.)_
+
+### Card 74 — A time you taught someone
+
+> Describe a time when you taught someone something.
+> You should say:
+>   who you taught
+>   what you taught them
+>   how you taught them
+> and explain how you felt about teaching them.
+
+_(source: HFF-authored.)_
+
+### Card 75 — A challenge you overcame
+
+> Describe a challenge you have overcome.
+> You should say:
+>   what the challenge was
+>   when it happened
+>   how you dealt with it
+> and explain what you learned from overcoming it.
+
+_(source: HFF-authored.)_
+
+---
+
+## Activity frame (cards 76–88)
+
+### Card 76 — A sport you play or follow
+
+> Describe a sport you enjoy playing or watching.
+> You should say:
+>   what the sport is
+>   how often you play or watch it
+>   who you do this with
+> and explain why you enjoy this sport.
+
+_(source: HFF-authored.)_
+
+### Card 77 — A hobby you started recently
+
+> Describe a hobby you have started recently.
+> You should say:
+>   what the hobby is
+>   when you started it
+>   how often you do it
+> and explain why you decided to take it up.
+
+_(source: HFF-authored.)_
+
+### Card 78 — A skill you would like to learn
+
+> Describe a skill you would like to learn.
+> You should say:
+>   what the skill is
+>   why you want to learn it
+>   how you plan to learn it
+> and explain how this skill would be useful to you.
+
+_(source: HFF-authored.)_
+
+### Card 79 — An outdoor activity you enjoy
+
+> Describe an outdoor activity you enjoy.
+> You should say:
+>   what the activity is
+>   where you do it
+>   how often you do it
+> and explain why you enjoy this activity.
+
+_(source: HFF-authored.)_
+
+### Card 80 — An indoor activity for a rainy day
+
+> Describe an activity you enjoy doing indoors when the weather is bad.
+> You should say:
+>   what the activity is
+>   when you usually do it
+>   what you need for it
+> and explain why you enjoy doing it on rainy days.
+
+_(source: HFF-authored.)_
+
+### Card 81 — Something you do with your family
+
+> Describe something you regularly do with your family.
+> You should say:
+>   what you do
+>   how often you do it
+>   who is involved
+> and explain why this activity is meaningful to your family.
+
+_(source: HFF-authored.)_
+
+### Card 82 — A game you played as a child
+
+> Describe a game you used to play as a child.
+> You should say:
+>   what the game was
+>   who you played with
+>   when you played it
+> and explain why you enjoyed this game.
+
+_(source: HFF-authored.)_
+
+### Card 83 — A film or TV programme you enjoyed
+
+> Describe a film or TV programme you have recently enjoyed.
+> You should say:
+>   what it was
+>   when you watched it
+>   what it was about
+> and explain why you enjoyed it.
+
+_(source: HFF-authored.)_
+
+### Card 84 — A piece of music you like
+
+> Describe a piece of music you like.
+> You should say:
+>   what it is
+>   when you first heard it
+>   when you usually listen to it
+> and explain why you like this piece of music.
+
+_(source: HFF-authored.)_
+
+### Card 85 — A holiday tradition you keep
+
+> Describe a holiday or seasonal tradition that you keep.
+> You should say:
+>   what the tradition is
+>   when you do it
+>   who you do it with
+> and explain why you keep this tradition.
+
+_(source: HFF-authored.)_
+
+### Card 86 — Something you do to relax
+
+> Describe something you do to relax.
+> You should say:
+>   what it is
+>   how often you do it
+>   when you usually do it
+> and explain why it helps you relax.
+
+_(source: HFF-authored.)_
+
+### Card 87 — An activity you do for exercise
+
+> Describe an activity you do to keep fit.
+> You should say:
+>   what the activity is
+>   how often you do it
+>   when you started doing it
+> and explain why this activity is good for your health.
+
+_(source: HFF-authored.)_
+
+### Card 88 — A way you have helped your community
+
+> Describe a way you have helped your community or local area.
+> You should say:
+>   what you did
+>   when you did it
+>   who else was involved
+> and explain why this kind of activity is important.
+
+_(source: HFF-authored.)_
+
+---
+
+## Coaching cheat sheet — Part 2 monologue structure
+
+| Bullet position | Time | Content type | Common failure | Tutor cue |
+|----------------|------|--------------|----------------|-----------|
+| 1 | ~20 sec | Identification / context | Skipped — candidate launches into the "explain" bullet | "Open with a single sentence that names the [person/place/object]." |
+| 2 | ~30 sec | Concrete detail | One word answer | "Add a sentence of detail — what it looked like / when it was." |
+| 3 | ~30 sec | Further concrete detail | Same content as bullet 2 | "Move on to a new piece of information." |
+| "and explain ..." | ~40–60 sec | Reasoning / significance | Treated as another factual bullet | "This is the bullet that gets you to Band 7. Use 'because', 'the reason is', 'what I value about ...'." |
+| Buffer | ~10 sec | Optional reflection | Cuts short at 1:20 | "Add one closing sentence: how it has changed you, or why it still matters now." |
+
+Total target: 1:50–2:00. The examiner will stop the candidate at 2:00.
+
+---
+
+## Sources
+
+- *IELTS Speaking Sample Tasks (2023)* — `speaking-sample-tasks-2023.pdf` (in this folder), pages 5–6.
+- ielts.org — "Speaking Part 2 sample task". https://www.ielts.org (accessed 2026-05-08).
+- takeielts.britishcouncil.org — "Free IELTS Speaking practice tests Part 2". https://takeielts.britishcouncil.org/take-ielts/prepare/free-ielts-practice-tests/speaking (accessed 2026-05-08).
+- ielts.idp.com — "IELTS Speaking Part 2 sample". https://ielts.idp.com (accessed 2026-05-08).
+- *IELTS Guide for Teachers* — `ielts-guide-for-teachers.pdf` (in this folder), Speaking section.
+- Cambridge IELTS volumes 1–19 — published past papers (referenced as a pattern source; not reproduced verbatim).
+- All HFF-authored cards above are written in the style of the published Part 2 frames and are original content; they are not reproduced from copyrighted Cambridge IELTS exam material.

--- a/docs/courses/ielts-speaking/source-3-part3-theme-library.md
+++ b/docs/courses/ielts-speaking/source-3-part3-theme-library.md
@@ -1,0 +1,866 @@
+---
+hf-template-version: "5.1"
+hf-document-type: QUESTION_BANK
+hf-default-category: practice_prompts
+hf-audience: tutor-only
+hf-source-format: theme-pool
+hf-source-slug: ielts-speaking-part3-theme-library-v1
+---
+
+# IELTS Speaking Question Bank — Part 3
+
+> **Document type:** QUESTION_BANK · **Intended classification:** practice prompts for the Part 3 module · **Question type:** TUTOR_QUESTION · **Assessment use:** FORMATIVE · **Bloom:** ANALYZE/EVALUATE
+
+Source: HFF-authored discussion question sets in the style of published IELTS Part 3 frames. Question patterns and themes are modelled on published IELTS Part 3 samples and Cambridge IELTS volumes 1–19.
+
+This bank contains 64 discussion question sets, each with 4–6 abstract questions, organised by 13 themes. Sets follow seven Part 3 patterns: opinion, advantages/disadvantages, comparison, hypothetical, prediction, causes-and-effects, and problem-solution. Sets are HFF-authored to mirror the style and difficulty of published Cambridge tasks without reproducing copyrighted exam content. See `tutor-briefing.md` for the Part 3 format definition.
+
+**Format note:** Each set is introduced by a signposting line ("Let's consider ...") and follows the typical Part 3 progression — the examiner moves from concrete probes to abstract or future-oriented ones over 4–6 questions.
+
+**Coaching note:** Part 3 is where Band 6 candidates plateau. The discriminator is the candidate's ability to (1) generalise beyond personal experience, (2) hedge with "tend to", "in many cases", "to some extent", (3) speculate using conditional structures, (4) concede a counter-argument before reasserting.
+
+---
+
+## Theme: Society and generations
+
+### Set 1 — Possessions and status (linked to Part 2 "Object" cards)
+
+_Let's consider how people's values have changed._
+
+1. What kind of things give status to people in your country?
+2. Have things changed since your parents' time?
+3. Do you think material possessions are more important to people now than they used to be?
+4. Why do some people place a high value on owning expensive things?
+5. Will the things that give status change in the future, do you think?
+
+_(source: HFF-authored, modelled on `speaking-sample-tasks-2023.pdf`, p. 6.)_
+
+### Set 2 — Generational differences
+
+_Let's discuss differences between generations._
+
+1. In what ways are young people in your country different from older generations?
+2. Why do you think those differences exist?
+3. Do older and younger people generally get on well in your culture?
+4. What can each generation learn from the other?
+5. Do you think the gap between generations is widening or narrowing?
+
+_(source: HFF-authored.)_
+
+### Set 3 — Changing lifestyles
+
+_Let's talk about how lifestyles have changed._
+
+1. How has daily life changed in your country in the last twenty years?
+2. Are people busier now than they used to be?
+3. What are the benefits of a slower pace of life?
+4. Why do people often say they don't have enough time?
+5. Will the pace of life continue to speed up, in your opinion?
+
+_(source: HFF-authored.)_
+
+### Set 4 — Tradition and modern life
+
+_Let's consider traditions._
+
+1. How important are traditions in your country?
+2. Are some traditions disappearing in modern life?
+3. Why do some people want to preserve old traditions?
+4. Are there any traditions that should change?
+5. What new traditions have appeared in recent years?
+
+_(source: HFF-authored.)_
+
+### Set 5 — Community and individualism
+
+_Let's talk about community._
+
+1. Do people in your country feel a strong sense of community?
+2. Has the importance of community changed over the years?
+3. What can be done to bring communities closer together?
+4. Are there any disadvantages to a strong community?
+5. Do you think people prefer to focus on themselves or their community?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Technology
+
+### Set 6 — Communication technology (linked to Part 2 "Person you contact" / "Device" cards)
+
+_Let's discuss how technology has changed communication._
+
+1. How has the way people communicate changed in recent years?
+2. Are face-to-face conversations still important in the age of messaging?
+3. What are the disadvantages of communicating mostly through technology?
+4. Do you think children today communicate differently from their parents?
+5. How might communication change in the future?
+
+_(source: HFF-authored.)_
+
+### Set 7 — Information and the internet
+
+_Let's consider information access._
+
+1. Do people have more or less reliable information than they used to?
+2. How can people decide what information to trust?
+3. Has the internet changed the way people learn?
+4. What are the dangers of misinformation online?
+5. Should the spread of false information be regulated?
+
+_(source: HFF-authored.)_
+
+### Set 8 — Automation and work
+
+_Let's talk about machines and work._
+
+1. What kinds of work are now being done by machines that used to be done by people?
+2. What are the benefits of automation?
+3. What jobs do you think will disappear in the future?
+4. Should governments help workers whose jobs are replaced by machines?
+5. Are there any jobs that should never be done by machines?
+
+_(source: HFF-authored.)_
+
+### Set 9 — Children and screens
+
+_Let's discuss children's use of screens._
+
+1. How much time do children spend using screens these days?
+2. What effect does screen time have on children?
+3. At what age do you think children should be allowed to use the internet?
+4. Whose responsibility is it to manage children's screen time?
+5. Will today's children use technology differently when they grow up?
+
+_(source: HFF-authored.)_
+
+### Set 10 — Social media
+
+_Let's talk about social media._
+
+1. Why do people use social media?
+2. What are the advantages and disadvantages of social media for young people?
+3. Has social media changed the way people form friendships?
+4. Should social media companies be more strictly regulated?
+5. Is it possible for people to live without social media now?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Environment
+
+### Set 11 — Natural environment (linked to Part 2 "Beautiful natural place")
+
+_Let's consider the natural environment._
+
+1. How important is it to protect the natural environment?
+2. What environmental problems is your country facing?
+3. Whose responsibility is it to look after the environment?
+4. Should individuals or governments do more to protect nature?
+5. Will future generations enjoy the same natural environment as we do?
+
+_(source: HFF-authored.)_
+
+### Set 12 — Climate
+
+_Let's discuss climate._
+
+1. Has the climate in your country changed in recent years?
+2. How does climate change affect daily life?
+3. What can ordinary people do about climate change?
+4. Should countries that produce more pollution do more to fix the problem?
+5. Will climate change get better or worse in the future?
+
+_(source: HFF-authored.)_
+
+### Set 13 — Urban living
+
+_Let's talk about cities._
+
+1. What are the advantages of living in a big city?
+2. What problems do big cities often face?
+3. How could cities be made more pleasant places to live?
+4. Will cities keep growing in the future?
+5. Should governments encourage people to move to smaller towns?
+
+_(source: HFF-authored.)_
+
+### Set 14 — Public spaces (linked to Part 2 "Park" / "Place where many people gather")
+
+_Let's consider public spaces._
+
+1. How important are public spaces like parks in a city?
+2. Are there enough public spaces where you live?
+3. What kinds of public spaces do people use most?
+4. Should public spaces be free for everyone to use?
+5. Will the way people use public spaces change in the future?
+
+_(source: HFF-authored.)_
+
+### Set 15 — Animals and wildlife (linked to Part 2 "Pets" / "Animals")
+
+_Let's talk about animals._
+
+1. How has people's attitude to animals changed in recent years?
+2. Should wild animals be kept in zoos?
+3. What can be done to protect endangered species?
+4. Why do some people keep unusual animals as pets?
+5. Should there be stricter laws about how people treat animals?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Education
+
+### Set 16 — Schools (linked to Part 2 "School" / "Teacher" cards)
+
+_Let's consider schools._
+
+1. What makes a good school?
+2. Are schools in your country mostly the same or quite different from each other?
+3. Should children all learn the same subjects?
+4. How has school education changed since you were a child?
+5. What changes would you like to see in schools in the future?
+
+_(source: HFF-authored.)_
+
+### Set 17 — Teachers
+
+_Let's discuss teachers._
+
+1. What qualities make a good teacher?
+2. Is teaching a respected profession in your country?
+3. What's the most important thing teachers do for their students?
+4. Should teachers be paid more than they are now?
+5. Will the role of the teacher change in the future?
+
+_(source: HFF-authored.)_
+
+### Set 18 — Learning approaches (linked to Part 2 "A skill you would like to learn")
+
+_Let's consider how people learn._
+
+1. Do you think children learn best in a classroom or through their own experience?
+2. What's the best way to learn a new skill?
+3. Is it ever too late to learn something new?
+4. How has the way people learn changed because of technology?
+5. Will traditional classrooms still exist in the future?
+
+_(source: HFF-authored.)_
+
+### Set 19 — Higher education
+
+_Let's talk about university._
+
+1. Is going to university becoming more or less important in your country?
+2. What are the benefits of studying at university?
+3. Are there any drawbacks to spending years at university?
+4. Should university education be free?
+5. What kinds of careers will need a university degree in the future?
+
+_(source: HFF-authored.)_
+
+### Set 20 — Lifelong learning
+
+_Let's consider learning as adults._
+
+1. Why do some adults choose to keep studying after they have left school or university?
+2. What are the benefits of learning new things later in life?
+3. What can stop adults from learning new skills?
+4. Do you think governments should support adult education?
+5. Will lifelong learning become more common in the future?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Work
+
+### Set 21 — Job satisfaction (linked to Part 2 "Colleague" / "Work")
+
+_Let's talk about job satisfaction._
+
+1. What makes a job satisfying?
+2. Is salary the most important thing about a job?
+3. Why do some people change jobs often while others stay in one job for a long time?
+4. Do people in your country talk about their work much?
+5. Will the things that make a job satisfying change in the future?
+
+_(source: HFF-authored.)_
+
+### Set 22 — Work-life balance
+
+_Let's consider work-life balance._
+
+1. What does work-life balance mean to you?
+2. Do people in your country generally have a good balance between work and personal life?
+3. What can employers do to help people maintain this balance?
+4. How has remote working changed work-life balance?
+5. Will people work fewer hours in the future?
+
+_(source: HFF-authored.)_
+
+### Set 23 — Remote working
+
+_Let's talk about working from home._
+
+1. Has remote working become common in your country?
+2. What are the advantages of working from home?
+3. Are there any disadvantages to remote working?
+4. Should employers let workers choose where they work?
+5. Will most office work be done remotely in the future?
+
+_(source: HFF-authored.)_
+
+### Set 24 — Career change
+
+_Let's consider changing careers._
+
+1. Is it common for people in your country to change career?
+2. Why might someone decide to change career mid-life?
+3. What difficulties does someone face when changing career?
+4. Should employers encourage workers to develop new skills?
+5. Will career change become more or less common in the future?
+
+_(source: HFF-authored.)_
+
+### Set 25 — Volunteering and community work (linked to Part 2 "Helping the community")
+
+_Let's discuss volunteering._
+
+1. Why do people choose to volunteer?
+2. What are the benefits of volunteering for the volunteer themselves?
+3. Should schools encourage students to do volunteer work?
+4. Are there situations where paid workers should be used instead of volunteers?
+5. Is volunteering more or less common than it used to be?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Media
+
+### Set 26 — Advertising (linked to `speaking-sample-tasks-2023.pdf` Part 3 frame)
+
+_Let's talk about the role of advertising._
+
+1. Do you think advertising influences what people buy?
+2. Where do most advertisements appear these days?
+3. Should advertising directed at children be regulated?
+4. Are there any kinds of products that should not be advertised?
+5. Will the way companies advertise change in the future?
+
+_(source: HFF-authored, modelled on `speaking-sample-tasks-2023.pdf`, p. 6.)_
+
+### Set 27 — News and journalism
+
+_Let's consider the news._
+
+1. Do people in your country trust the news?
+2. How has the way people get the news changed?
+3. Are there any disadvantages to reading news only online?
+4. Should news organisations be regulated by the government?
+5. Will printed newspapers still exist in twenty years' time?
+
+_(source: HFF-authored.)_
+
+### Set 28 — Films and television (linked to Part 2 "Film or TV programme")
+
+_Let's discuss films and TV._
+
+1. What kinds of films and TV programmes are popular in your country?
+2. Do films from your country ever become popular abroad?
+3. How has the way people watch films and TV changed?
+4. Are streaming services replacing cinema?
+5. Should governments support local film-making?
+
+_(source: HFF-authored.)_
+
+### Set 29 — Books and reading (linked to Part 2 "Book that influenced you")
+
+_Let's consider reading habits._
+
+1. Do people in your country read as much as they used to?
+2. What are the benefits of reading regularly?
+3. Are some kinds of books more valuable than others?
+4. How can children be encouraged to read?
+5. Will printed books survive in the digital age?
+
+_(source: HFF-authored.)_
+
+### Set 30 — Privacy and the media
+
+_Let's discuss privacy._
+
+1. Do public figures have a right to privacy?
+2. How much information should the media publish about famous people?
+3. Has social media changed what counts as private life?
+4. Should there be stronger laws to protect privacy online?
+5. Will privacy be possible in the future, in your opinion?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Culture
+
+### Set 31 — Festivals (linked to Part 2 "Festival" cards)
+
+_Let's talk about festivals._
+
+1. Why are festivals important in many cultures?
+2. Have festivals in your country changed in recent years?
+3. Are some traditional festivals losing their meaning?
+4. Should new festivals be created for modern life?
+5. Will festivals be celebrated differently in the future?
+
+_(source: HFF-authored.)_
+
+### Set 32 — Art and creativity (linked to Part 2 "Art")
+
+_Let's consider art._
+
+1. What role does art play in modern society?
+2. Should art be taught in schools?
+3. How has technology changed the way art is made and shared?
+4. Is some art more valuable than other art?
+5. Will the kinds of art people enjoy change in the future?
+
+_(source: HFF-authored.)_
+
+### Set 33 — Music (linked to Part 2 "Piece of music" / "Concert")
+
+_Let's discuss music._
+
+1. Why is music such an important part of human life?
+2. Does music affect people's mood?
+3. Should children be encouraged to learn an instrument?
+4. How has the way people listen to music changed?
+5. Will live music remain popular in the future?
+
+_(source: HFF-authored.)_
+
+### Set 34 — The role of the past
+
+_Let's talk about history._
+
+1. Why is it important to remember the past?
+2. Should children learn the history of their country at school?
+3. Are there any aspects of the past it might be better to forget?
+4. How can a country preserve its history for future generations?
+5. Do you think people are interested in history nowadays?
+
+_(source: HFF-authored.)_
+
+### Set 35 — Cultural exchange and travel (linked to Part 2 "Foreign country")
+
+_Let's consider cultural exchange._
+
+1. How does international travel affect cultural exchange?
+2. Are people more interested in other cultures now than they used to be?
+3. Are there any disadvantages to mixing cultures?
+4. Should tourists try to learn about local culture before visiting a country?
+5. Will cultures become more similar in the future?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Family
+
+### Set 36 — Family relationships (linked to Part 2 "Family member you admire")
+
+_Let's discuss families._
+
+1. Have family relationships changed in your country in recent years?
+2. Do families in your country usually live close together?
+3. What are the advantages of growing up in a large family?
+4. Is it harder to keep families close in modern life?
+5. Will the structure of families continue to change?
+
+_(source: HFF-authored.)_
+
+### Set 37 — Raising children
+
+_Let's consider how children are raised._
+
+1. Are parents stricter or more relaxed than they used to be?
+2. What's the most important thing parents can teach their children?
+3. Should both parents share child-care equally?
+4. Do parents in your country spend enough time with their children?
+5. How might child-raising change in the future?
+
+_(source: HFF-authored.)_
+
+### Set 38 — Caring for older people
+
+_Let's discuss caring for older relatives._
+
+1. Whose responsibility is it to care for elderly relatives?
+2. How are older people generally treated in your country?
+3. Are there enough services to support older people?
+4. Should governments do more for older citizens?
+5. How will the care of older people change as populations age?
+
+_(source: HFF-authored.)_
+
+### Set 39 — Childhood (linked to Part 2 "Childhood")
+
+_Let's talk about childhood._
+
+1. Has childhood changed since you were young?
+2. Do children today have more freedom than children did in the past?
+3. What experiences are important for a happy childhood?
+4. Should children have more or less responsibility?
+5. Are children today more aware of the wider world than children used to be?
+
+_(source: HFF-authored.)_
+
+### Set 40 — Family meals (linked to Part 2 "Special meal")
+
+_Let's discuss eating together._
+
+1. Do families in your country usually eat meals together?
+2. Why do some families not eat together?
+3. What are the benefits of sharing meals as a family?
+4. Has the way families eat changed in recent decades?
+5. Will the family meal still exist in twenty years' time?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Health
+
+### Set 41 — Healthy lifestyles (linked to Part 2 "Activity for exercise")
+
+_Let's consider health._
+
+1. Are people in your country generally healthy?
+2. What can people do to stay healthy?
+3. Are people more health-conscious than they used to be?
+4. Why do some people find it hard to live a healthy lifestyle?
+5. Will people be healthier in the future?
+
+_(source: HFF-authored.)_
+
+### Set 42 — Sport and fitness (linked to Part 2 "Sport you enjoy")
+
+_Let's discuss sport._
+
+1. Why is sport important in many countries?
+2. Do you think children should be made to play sports at school?
+3. Are professional athletes paid too much?
+4. Do international sporting events bring countries together?
+5. Will the popularity of sport change in the future?
+
+_(source: HFF-authored.)_
+
+### Set 43 — Mental health
+
+_Let's talk about mental health._
+
+1. Are people in your country comfortable talking about mental health?
+2. What kinds of pressures affect people's mental health today?
+3. What can workplaces do to support employees' mental health?
+4. Should mental health be taught in schools?
+5. Will attitudes to mental health change in the future?
+
+_(source: HFF-authored.)_
+
+### Set 44 — Public health and government
+
+_Let's consider the government's role in health._
+
+1. What is the government's responsibility for people's health?
+2. Should healthcare be free for everyone?
+3. Should governments tax unhealthy products like sugary drinks?
+4. How can governments encourage people to live more healthily?
+5. Will public health continue to improve in the future?
+
+_(source: HFF-authored.)_
+
+### Set 45 — Sleep and rest (linked to Part 1 "Sleep" frame)
+
+_Let's discuss sleep._
+
+1. Why do many adults not get enough sleep?
+2. Has the way people sleep changed because of modern life?
+3. What are the consequences of poor sleep?
+4. Should employers care about how well their staff sleep?
+5. Will people sleep more or less in the future?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Money
+
+### Set 46 — Money and happiness (linked to Part 2 "Expensive thing you bought")
+
+_Let's consider the role of money._
+
+1. Does money make people happy?
+2. Why do some people place a high value on owning expensive things?
+3. Is it better to spend money on things or experiences?
+4. Are people in your country more or less concerned with money than in the past?
+5. Will money be as important in the future as it is now?
+
+_(source: HFF-authored.)_
+
+### Set 47 — Saving and spending
+
+_Let's discuss saving and spending._
+
+1. Are people in your country generally good at saving money?
+2. Should children be taught about money at school?
+3. What's the best way to teach a child about saving?
+4. Why do some people find it hard to save?
+5. Will the way people save change as cash disappears?
+
+_(source: HFF-authored.)_
+
+### Set 48 — Cashless society
+
+_Let's consider digital payments._
+
+1. How has the way people pay for things changed in recent years?
+2. What are the advantages of a cashless society?
+3. Are there any disadvantages to going cashless?
+4. Should cash be kept available even as digital payments grow?
+5. Will physical money disappear completely?
+
+_(source: HFF-authored.)_
+
+### Set 49 — Inequality
+
+_Let's talk about wealth inequality._
+
+1. Is wealth distributed fairly in your country?
+2. What problems can large wealth gaps cause?
+3. Should governments do more to reduce inequality?
+4. Why do some countries have less inequality than others?
+5. Will inequality grow or shrink in the future?
+
+_(source: HFF-authored.)_
+
+### Set 50 — Charitable giving
+
+_Let's consider donating to charity._
+
+1. Why do people give to charity?
+2. Should people be encouraged to give a fixed share of their income to charity?
+3. What kinds of causes do people in your country most often support?
+4. Is it better to donate money or time?
+5. Will charitable giving become more common in the future?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Future
+
+### Set 51 — Predictions about daily life
+
+_Let's discuss the future._
+
+1. How do you think daily life will change in the next twenty years?
+2. What aspects of life today will probably stay the same?
+3. Are people generally optimistic or pessimistic about the future?
+4. What's the biggest change you would like to see?
+5. Should people make long-term plans, given how uncertain the future is?
+
+_(source: HFF-authored.)_
+
+### Set 52 — What will be lost
+
+_Let's consider what may disappear._
+
+1. What things from today's world may not exist in the future?
+2. Why do some things disappear over time?
+3. Should we try to preserve traditional ways of doing things?
+4. Are there any losses we should accept?
+5. What kinds of jobs do you think will disappear soon?
+
+_(source: HFF-authored.)_
+
+### Set 53 — Future of work
+
+_Let's talk about future careers._
+
+1. What kinds of jobs will be most in demand in the future?
+2. How can young people prepare for jobs that don't exist yet?
+3. Will most people still have one main career, or many?
+4. Should schools teach skills for jobs that may exist in twenty years' time?
+5. How will people earn a living if machines do most of the work?
+
+_(source: HFF-authored.)_
+
+### Set 54 — Cities of the future
+
+_Let's consider future cities._
+
+1. What will cities look like in fifty years' time?
+2. How can cities be made more sustainable?
+3. Will most people still live in cities in the future?
+4. Should governments plan cities differently than they do now?
+5. What problems will future cities have to solve?
+
+_(source: HFF-authored.)_
+
+### Set 55 — Predictions about technology
+
+_Let's discuss future technology._
+
+1. Which new technologies are you most looking forward to?
+2. Are there any technologies you would prefer never to see?
+3. How will artificial intelligence affect daily life?
+4. Should governments slow down the development of certain technologies?
+5. Will technology make life easier in the future, do you think?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Government
+
+### Set 56 — Public services
+
+_Let's talk about public services._
+
+1. What are the most important services governments provide?
+2. Are public services well-run in your country?
+3. Should some public services be run by private companies?
+4. How can governments make sure public services reach everyone?
+5. Will the role of the government in providing services grow or shrink?
+
+_(source: HFF-authored.)_
+
+### Set 57 — Citizens' duties
+
+_Let's consider what citizens owe their country._
+
+1. What responsibilities do citizens have to their country?
+2. Should people be required to vote in elections?
+3. Should young people do a year of community service?
+4. Is paying taxes enough, or do citizens owe more?
+5. How can governments encourage active citizenship?
+
+_(source: HFF-authored.)_
+
+### Set 58 — Laws and rules
+
+_Let's discuss laws._
+
+1. Why do societies have laws?
+2. Are laws in your country generally fair?
+3. Should some laws be the same in every country?
+4. What happens when people stop following the rules?
+5. How should laws change as society changes?
+
+_(source: HFF-authored.)_
+
+### Set 59 — Punishment and rehabilitation
+
+_Let's consider how societies deal with crime._
+
+1. What's the main purpose of punishing people who break the law?
+2. Should rehabilitation be more important than punishment?
+3. Are prisons effective at reducing crime?
+4. What other ways are there to deal with people who break the law?
+5. Will attitudes to punishment change in the future?
+
+_(source: HFF-authored.)_
+
+### Set 60 — Government and the environment
+
+_Let's discuss government action on the environment._
+
+1. How much can a government do to protect the environment?
+2. Should governments place strict limits on pollution?
+3. Should governments cooperate internationally on environmental issues?
+4. Are environmental problems the responsibility of citizens or governments?
+5. Will environmental policy become more or less important in the future?
+
+_(source: HFF-authored.)_
+
+---
+
+## Theme: Globalisation
+
+### Set 61 — International travel (linked to Part 2 "Foreign country" / "Trip you took")
+
+_Let's consider international travel._
+
+1. Why do so many people travel abroad these days?
+2. Has international travel become too easy?
+3. What are the cultural benefits of travel?
+4. Should tourists do more to respect the places they visit?
+5. Will people travel more or less in the future?
+
+_(source: HFF-authored.)_
+
+### Set 62 — World languages (linked to Part 1 "Languages")
+
+_Let's discuss languages._
+
+1. Why is English so widely spoken around the world?
+2. Should children learn more than one foreign language at school?
+3. What can be done to keep small languages alive?
+4. Are some languages disappearing? Why?
+5. Will English remain the most widely-used international language?
+
+_(source: HFF-authored.)_
+
+### Set 63 — Cultural similarities
+
+_Let's consider how cultures are becoming more alike._
+
+1. Are cultures around the world becoming more similar?
+2. Why is this happening?
+3. Are there any benefits to a more global culture?
+4. What might be lost if cultures become too similar?
+5. Should countries try to protect their own cultural identity?
+
+_(source: HFF-authored.)_
+
+### Set 64 — International cooperation
+
+_Let's discuss international cooperation._
+
+1. In what areas do countries most need to work together?
+2. Why is international cooperation often difficult?
+3. Should richer countries help poorer countries more?
+4. Are international organisations effective?
+5. Will countries cooperate more or less in the future?
+
+_(source: HFF-authored.)_
+
+---
+
+## Coaching cheat sheet — Part 3 lifters
+
+| Move | What it sounds like | Why it lifts the band |
+|------|--------------------|-----------------------|
+| Generalise | "People in general tend to ..." / "In most countries ..." | Required to escape personal-anecdote cap (FC + LR) |
+| Hedge | "I would say ...", "to some extent ...", "in many cases ..." | Required at Band 7+ (LR — speaker's attitude) |
+| Concede + reassert | "It's true that ..., but on balance ..." | Required at Band 7+ (FC — coherence under complexity) |
+| Speculate (2nd conditional) | "If governments were to ..., people would ..." | Required at Band 7+ (GRA — complex structures) |
+| Speculate (3rd conditional) | "If they had done ..., we would have ..." | Band 8+ marker (GRA) |
+| Abstract noun phrase | "the role of ...", "the impact of ...", "the extent to which ..." | Required at Band 7+ (LR — less common items) |
+| Compare across time | "Whereas in the past ..., today ..." | Required at Band 7+ (FC — discourse markers) |
+
+---
+
+## Sources
+
+- *IELTS Speaking Sample Tasks (2023)* — `speaking-sample-tasks-2023.pdf` (in this folder), pages 6–7.
+- ielts.org — "Speaking Part 3 sample task". https://www.ielts.org (accessed 2026-05-08).
+- takeielts.britishcouncil.org — "Free IELTS Speaking practice tests Part 3". https://takeielts.britishcouncil.org/take-ielts/prepare/free-ielts-practice-tests/speaking (accessed 2026-05-08).
+- ielts.idp.com — "IELTS Speaking Part 3 sample". https://ielts.idp.com (accessed 2026-05-08).
+- *IELTS Guide for Teachers* — `ielts-guide-for-teachers.pdf` (in this folder), Speaking section.
+- Cambridge IELTS volumes 1–19 — published past papers (referenced as a pattern source; not reproduced verbatim).
+- All HFF-authored question sets above are written in the style of the published Part 3 frames and are original content; they are not reproduced from copyrighted Cambridge IELTS exam material.

--- a/docs/courses/ielts-speaking/source-4-baseline-topic-pool.md
+++ b/docs/courses/ielts-speaking/source-4-baseline-topic-pool.md
@@ -1,0 +1,161 @@
+---
+hf-template-version: "5.1"
+hf-document-type: QUESTION_BANK
+hf-default-category: practice_prompts
+hf-audience: tutor-only
+hf-source-format: cueCardBank
+hf-source-slug: ielts-speaking-baseline-topic-pool-v1
+---
+
+# IELTS Speaking Baseline Assessment — Topic Pool
+
+> **Document type:** QUESTION_BANK · **Intended classification:** practice prompts for the Baseline Assessment module · **Question type:** TUTOR_QUESTION · **Assessment use:** SUMMATIVE · **Bloom:** APPLY/EVALUATE
+
+Source: HFF-authored cue cards in the style of published IELTS Part 2 tasks. Cards are intentionally distinct from the Part 2 practice bank (`source-2-cue-card-bank.md`) so Baseline content is not practised before the student takes their Baseline. Card structure mirrors the official IELTS Part 2 template.
+
+This pool contains 10 cue cards in the standard four-bullet form, sampling across the six Part 2 frames (Person, Place, Object, Event, Experience, Activity). The pool is sized to support a meaningful number of student onboardings without repeating Baseline content within a cohort.
+
+**Format note:** Every card uses the official template:
+
+```
+Describe ...
+You should say:
+   [bullet 1]
+   [bullet 2]
+   [bullet 3]
+and explain ...
+```
+
+**Pool sizing rationale:** A 10-card pool gives the runtime ~5 distinct one-cohort draws before collisions become likely (birthday-paradox). Adequate for early adoption; expandable as cohort size grows.
+
+---
+
+## Baseline cue cards
+
+### Card 1 — A relative you spent time with as a child
+
+> Describe a relative you spent time with when you were a child.
+> You should say:
+>   who this person is
+>   what you did together
+>   how often you saw them
+> and explain how this relationship shaped you.
+
+_Rounding-off: Do you still see this person now?_
+
+_(source: HFF-authored for Baseline Assessment pool.)_
+
+### Card 2 — A mentor or guide from outside your family
+
+> Describe someone outside your family who has guided you.
+> You should say:
+>   who they are
+>   how you came to know them
+>   what kind of guidance they gave you
+> and explain how their guidance has affected your choices.
+
+_(source: HFF-authored for Baseline Assessment pool.)_
+
+### Card 3 — A market or shopping area you remember
+
+> Describe a market or shopping area you have visited.
+> You should say:
+>   where it is
+>   what kinds of things were sold there
+>   when you last went
+> and explain what makes it memorable.
+
+_(source: HFF-authored for Baseline Assessment pool.)_
+
+### Card 4 — A workplace or study space you enjoyed
+
+> Describe a workplace or study space you have enjoyed using.
+> You should say:
+>   where it was
+>   what you did there
+>   what made the space pleasant
+> and explain why you remember it well.
+
+_(source: HFF-authored for Baseline Assessment pool.)_
+
+### Card 5 — A small but useful object you carry
+
+> Describe a small but useful object that you carry with you.
+> You should say:
+>   what it is
+>   when you started carrying it
+>   how you use it
+> and explain why you find it useful.
+
+_(source: HFF-authored for Baseline Assessment pool.)_
+
+### Card 6 — A handwritten letter or note that mattered
+
+> Describe a handwritten letter or note you received that mattered to you.
+> You should say:
+>   who it was from
+>   what it was about
+>   when you received it
+> and explain why it was important to you.
+
+_(source: HFF-authored for Baseline Assessment pool.)_
+
+### Card 7 — A community event you took part in
+
+> Describe a community event you took part in.
+> You should say:
+>   what kind of event it was
+>   when it happened
+>   what your role was
+> and explain how you felt about taking part.
+
+_(source: HFF-authored for Baseline Assessment pool.)_
+
+### Card 8 — A time you had to wait for something important
+
+> Describe a time when you had to wait a long time for something important.
+> You should say:
+>   what you were waiting for
+>   how long the wait was
+>   how you spent the waiting time
+> and explain how you felt when the wait ended.
+
+_(source: HFF-authored for Baseline Assessment pool.)_
+
+### Card 9 — A daily routine that helps you focus
+
+> Describe a daily routine that helps you focus.
+> You should say:
+>   what the routine involves
+>   when you do it
+>   how long you have done it
+> and explain why it helps you focus.
+
+_(source: HFF-authored for Baseline Assessment pool.)_
+
+### Card 10 — A skill you picked up by watching others
+
+> Describe a skill you picked up by watching other people do it.
+> You should say:
+>   what the skill is
+>   whom you watched
+>   how you practised it
+> and explain how confident you now feel using it.
+
+_(source: HFF-authored for Baseline Assessment pool.)_
+
+---
+
+## Coaching note
+
+Baseline cards are intentionally pitched at mid-band difficulty (Band 5–7 range) — they invite both concrete narrative and reflective elaboration, so the Baseline can read fluency, lexical resource, coherence, and pronunciation across a representative spread of candidate ability. Cards do not deliberately skew toward any single grammatical structure.
+
+## Pool maintenance
+
+When this pool falls below ~8 distinct cards (after retiring overused entries or surfacing memorisation patterns), add 3–5 fresh cards following the same HFF-authored convention. Bump the source slug minor version when the pool changes.
+
+## Sources
+
+- HFF-authored cards in the style of published Cambridge IELTS Part 2 frames.
+- ielts.org — "Speaking Part 2 sample tasks". https://www.ielts.org (accessed 2026-05-08).
+- All HFF-authored cards above are original content; they are not reproduced from copyrighted Cambridge IELTS exam material.

--- a/docs/courses/ielts-speaking/source-5-mock-topic-pool.md
+++ b/docs/courses/ielts-speaking/source-5-mock-topic-pool.md
@@ -1,0 +1,404 @@
+---
+hf-template-version: "5.1"
+hf-document-type: QUESTION_BANK
+hf-default-category: practice_prompts
+hf-audience: tutor-only
+hf-source-format: cueCardBank
+hf-source-slug: ielts-speaking-mock-topic-pool-v1
+---
+
+# IELTS Speaking Mock Exam — Topic Pool
+
+> **Document type:** QUESTION_BANK · **Intended classification:** practice prompts for the Mock Exam module · **Question type:** TUTOR_QUESTION · **Assessment use:** SUMMATIVE · **Bloom:** APPLY/EVALUATE
+
+Source: HFF-authored cue cards in the style of published IELTS Part 2 tasks. Cards are intentionally distinct from the Part 2 practice bank (`source-2-cue-card-bank.md`) and the Baseline pool (`source-4-baseline-topic-pool.md`) so Mock Exam content stays fresh and representative of real test difficulty. Card structure mirrors the official IELTS Part 2 template.
+
+This pool contains 30 cue cards in the standard four-bullet form, evenly distributed across the six Part 2 frames (Person, Place, Object, Event, Experience, Activity — five per frame). Cards are tuned to mid-to-upper test difficulty (Band 6–8 range) and chosen to reward the candidate's ability to sustain a 2-minute monologue with extension, contrast, and considered reasoning.
+
+**Format note:** Every card uses the official template:
+
+```
+Describe ...
+You should say:
+   [bullet 1]
+   [bullet 2]
+   [bullet 3]
+and explain ...
+```
+
+**Pool sizing rationale:** A 30-card pool gives the runtime ~5 distinct months of weekly Mock Exams per student before any repetition, supporting the v2.3 constraint "the tutor avoids repeating a Mock Exam scenario for the same student within a fixed window."
+
+---
+
+## Person frame (cards 1–5)
+
+### Card 1 — A person whose advice you value
+
+> Describe a person whose advice you value.
+> You should say:
+>   who this person is
+>   when you usually ask them for advice
+>   what kind of advice they give
+> and explain why their advice carries weight with you.
+
+_Rounding-off: Has their advice ever turned out to be wrong?_
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 2 — A relative you have grown closer to as an adult
+
+> Describe a relative you have grown closer to since becoming an adult.
+> You should say:
+>   who this person is
+>   how the relationship has changed
+>   what you now share with them
+> and explain what brought you closer together.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 3 — A colleague who taught you something unexpected
+
+> Describe a colleague who taught you something unexpected.
+> You should say:
+>   who this person is
+>   what they taught you
+>   how the lesson came about
+> and explain why it stuck with you.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 4 — A person you disagree with but respect
+
+> Describe a person you often disagree with but still respect.
+> You should say:
+>   who they are
+>   what you tend to disagree about
+>   what you respect about them
+> and explain why disagreement does not weaken the respect.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 5 — A public figure whose work you follow
+
+> Describe a public figure whose work you follow.
+> You should say:
+>   who they are
+>   what kind of work they do
+>   how you follow their work
+> and explain what you find valuable in it.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+---
+
+## Place frame (cards 6–10)
+
+### Card 6 — A place that has changed since you first knew it
+
+> Describe a place that has changed significantly since you first knew it.
+> You should say:
+>   what the place is
+>   what it used to be like
+>   what it is like now
+> and explain how you feel about the change.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 7 — A quiet place you go to think
+
+> Describe a quiet place you go to when you want to think.
+> You should say:
+>   where it is
+>   how often you go there
+>   what makes it suitable for thinking
+> and explain what you usually think about when you are there.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 8 — A place from another country you would like to live in
+
+> Describe a place from another country that you would like to live in for a while.
+> You should say:
+>   where it is
+>   what you know about it
+>   what daily life there would be like
+> and explain why living there appeals to you.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 9 — A workplace you would like to visit
+
+> Describe a workplace you would like to visit out of curiosity.
+> You should say:
+>   what kind of workplace it is
+>   why it interests you
+>   what you would want to see there
+> and explain what you think you would learn from the visit.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 10 — A natural landscape you find impressive
+
+> Describe a natural landscape you find impressive.
+> You should say:
+>   what kind of landscape it is
+>   where it can be found
+>   when you first saw it (in person or in pictures)
+> and explain what you find impressive about it.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+---
+
+## Object frame (cards 11–15)
+
+### Card 11 — A tool you use for a hobby
+
+> Describe a tool you use for a hobby.
+> You should say:
+>   what the tool is
+>   what the hobby is
+>   how you use the tool
+> and explain why this particular tool is well suited to the hobby.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 12 — A piece of equipment you would like to learn to use
+
+> Describe a piece of equipment you would like to learn to use.
+> You should say:
+>   what it is
+>   what it can do
+>   how you might learn to use it
+> and explain why learning to use it appeals to you.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 13 — A photograph that captures a moment
+
+> Describe a photograph that captures a moment from your past.
+> You should say:
+>   what the photograph shows
+>   when and where it was taken
+>   why you still have it
+> and explain why this particular moment matters to you.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 14 — A book you would recommend to a friend
+
+> Describe a book you would recommend to a friend.
+> You should say:
+>   what the book is about
+>   who wrote it
+>   why you read it
+> and explain why you would recommend it to a friend in particular.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 15 — An item from your home that has a story
+
+> Describe an item from your home that has a story behind it.
+> You should say:
+>   what the item is
+>   where it came from
+>   how it came to be in your home
+> and explain why the story behind it matters to you.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+---
+
+## Event frame (cards 16–20)
+
+### Card 16 — A celebration that surprised you
+
+> Describe a celebration that surprised you.
+> You should say:
+>   what kind of celebration it was
+>   when it took place
+>   who was there
+> and explain what made it surprising.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 17 — A traditional event you would like to attend
+
+> Describe a traditional event you would like to attend.
+> You should say:
+>   what the event is
+>   where and when it is held
+>   what people typically do there
+> and explain why you would like to attend it.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 18 — A small gathering that meant a lot
+
+> Describe a small gathering that meant a lot to you.
+> You should say:
+>   when it happened
+>   who was there
+>   what you did together
+> and explain why it meant a lot despite being small.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 19 — A formal occasion you took part in
+
+> Describe a formal occasion you took part in.
+> You should say:
+>   what the occasion was
+>   what your role was
+>   how the occasion was organised
+> and explain what you remember most clearly from it.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 20 — An anniversary you marked
+
+> Describe an anniversary that you marked recently.
+> You should say:
+>   what the anniversary was for
+>   how you marked it
+>   who was involved
+> and explain why marking it mattered.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+---
+
+## Experience frame (cards 21–25)
+
+### Card 21 — A time you took an unfamiliar form of transport
+
+> Describe a time you took a form of transport you were not used to.
+> You should say:
+>   what the transport was
+>   where you were going
+>   how the journey went
+> and explain how you felt about taking this form of transport.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 22 — A time a piece of news affected you
+
+> Describe a time when a piece of news affected you strongly.
+> You should say:
+>   what the news was about
+>   when you heard it
+>   how you reacted
+> and explain why it had such a strong effect on you.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 23 — A time you made a difficult decision quickly
+
+> Describe a time you made a difficult decision quickly.
+> You should say:
+>   what the decision was about
+>   what your options were
+>   how you decided
+> and explain whether you would make the same decision again.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 24 — A time you changed your mind about a person
+
+> Describe a time you changed your mind about a person.
+> You should say:
+>   who the person is
+>   what your first impression was
+>   what changed your mind
+> and explain what this experience taught you.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 25 — A time you worked closely with someone you did not know well
+
+> Describe a time you worked closely with someone you did not know well.
+> You should say:
+>   who the person was
+>   what you worked on together
+>   how the collaboration developed
+> and explain what you took away from working with them.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+---
+
+## Activity frame (cards 26–30)
+
+### Card 26 — An activity you do that takes patience
+
+> Describe an activity you do that takes patience.
+> You should say:
+>   what the activity is
+>   how often you do it
+>   what stage requires the most patience
+> and explain what you enjoy about doing something patient.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 27 — A team activity you have taken part in
+
+> Describe a team activity you have taken part in.
+> You should say:
+>   what the activity was
+>   who you did it with
+>   what your role was
+> and explain what you enjoyed about doing it as a team.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 28 — A learning activity you find rewarding
+
+> Describe a learning activity you find rewarding.
+> You should say:
+>   what kind of learning it involves
+>   how often you do it
+>   what you have learned from it
+> and explain what makes it rewarding compared with other kinds of learning.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 29 — A creative activity you would like to try
+
+> Describe a creative activity you would like to try.
+> You should say:
+>   what the activity is
+>   why it interests you
+>   how you might begin
+> and explain what you would hope to gain from trying it.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+### Card 30 — An activity you have done for many years
+
+> Describe an activity you have done for many years.
+> You should say:
+>   what the activity is
+>   when you started doing it
+>   how your involvement has changed over time
+> and explain why you have kept doing it for so long.
+
+_(source: HFF-authored for Mock Exam pool.)_
+
+---
+
+## Coaching cheat sheet — Mock Exam difficulty calibration
+
+Mock cards are pitched at Band 6–8 difficulty: they invite contrast (then vs now), reasoning (why this particular thing), and considered reflection (what you took away from it). Cards deliberately avoid asking for opinion-only structures — Mock candidates should be able to demonstrate the full range of Part 2 features (narrative, description, comparison, reasoning) in a single 2-minute turn.
+
+When matching a Mock Exam card to a Part 3 theme, prefer thematic continuity over surface-word match — a Place card should naturally lead to a Place-themed Part 3 set; an Experience card should lead to an Experience-themed Part 3 set.
+
+## Pool maintenance
+
+Refresh ~5 cards per quarter to prevent memorisation patterns. Retire any card that surfaces in candidate feedback as having become too well-known. Bump the source slug minor version when the pool changes.
+
+## Sources
+
+- HFF-authored cards in the style of published Cambridge IELTS Part 2 frames.
+- ielts.org — "Speaking Part 2 sample tasks". https://www.ielts.org (accessed 2026-05-08).
+- takeielts.britishcouncil.org — "Free IELTS Speaking practice tests Part 2". https://takeielts.britishcouncil.org/take-ielts/prepare/free-ielts-practice-tests/speaking (accessed 2026-05-08).
+- All HFF-authored cards above are original content; they are not reproduced from copyrighted Cambridge IELTS exam material.


### PR DESCRIPTION
## Summary

Authors 5 standalone source markdown files under `docs/courses/ielts-speaking/` implementing Sources 1-5 of the IELTS v2.3 Course Reference (§Content Sources). Closes the partner-blocker fingerprint from #2167: IELTS Speaking Practice has 0 ContentQuestion rows and 5 modules pointing at non-existent "Source 1-5" content (hf_sandbox 2026-06-21 live evidence).

This PR is **content-only** — no code, no DB, no migrations. The operator (or follow-on agent) uploads each file via the wizard's Source Upload flow post-merge.

## Counts

| File | Format | Parser | Items |
|---|---|---|---|
| `source-1-part1-topic-library.md` | `topic-pool` | `parseTopicPool` | **52 frames** |
| `source-2-cue-card-bank.md` | `cueCardBank` | `parseCueCardBank` | **88 cards** ← matches v2.3 §Source 2 exactly |
| `source-3-part3-theme-library.md` | `theme-pool` | `parseTopicPool` | **64 sets** across 13 themes |
| `source-4-baseline-topic-pool.md` | `cueCardBank` | `parseCueCardBank` | **10 cards** (small separate Baseline pool) |
| `source-5-mock-topic-pool.md` | `cueCardBank` | `parseCueCardBank` | **30 cards** (larger Mock Exam pool) |

Sources 1-3 mirror the existing `docs/external/ielts/ielts-speaking/Upload Docs/` authored corpus (parser already proven on these). Sources 4 and 5 are HFF-authored fresh, intentionally distinct from Source 2 per v2.3 §Source 4 / §Source 5 design intent: *"Keeping this pool separate prevents Baseline content from being practised before the student takes their Baseline"* / *"constructed to be representative of real test difficulty."*

Each file carries YAML front-matter with `hf-template-version: "5.1"`, `hf-source-format`, and `hf-source-slug` so downstream upload/extract can resolve the right parser dispatch.

## Follow-on operator action (post-merge)

1. **S2 — upload via wizard**: upload each of the 5 source markdowns through the wizard's Source Upload flow for the IELTS Speaking Practice playbook. Each upload triggers the Extract pass → `ContentSource` + `ContentAssertion` (+ `ContentQuestion` for the cue-card / topic-pool formats) + `PlaybookSource` link.
2. **S3 — slug refs**: re-project IELTS Speaking Practice module config from name-based `contentSourceRef: "Source 2 — Cue card bank"` to slug-based `settings.cueCardPool: "source:ielts-speaking-cue-card-bank-v1"` (etc.). Separate PR.
3. **S4 — live verify**: SQL confirms 5 new `ContentSource` rows + `PlaybookSource` links; `selectPinnedCardForModule` for Part 2 / Mock P2 / Baseline P2 returns a real cue card.
4. **S5 — promote gate** (epic #2166): once IELTS ratchet drops from 5 to 0, promote source-ref Coverage gate from WARN to ERROR severity.

## Test plan

- [ ] Operator uploads Source 1 via wizard → IELTS Speaking Practice has +1 `ContentSource` row + ContentAssertion rows
- [ ] Operator uploads Source 2 via wizard → +88 `ContentQuestion` rows expected (one per cue card)
- [ ] Operator uploads Sources 3, 4, 5 → similar
- [ ] `selectPinnedCardForModule` resolves Part 2 module → returns a cue card with non-empty topic + bullets
- [ ] Mock Exam P2 returns a cue card (from Source 5 pool)
- [ ] Baseline P2 returns a cue card (from Source 4 pool)
- [ ] Source-ref Coverage gate (#2166) fires green for IELTS modules

## Verified by

- **Parser cross-check** — vitest scratch run (not shipped) on the 5 files using `parseCueCardBank` + `parseTopicPool` from `lib/wizard/parse-source-content.ts`. All 5 sources parse with expected item counts: 52 / 88 / 64 / 10 / 30. [verified]
- **v2.3 spec match** — Source 2 declared "88 cue cards" in `apps/admin/lib/wizard/__tests__/fixtures/course-reference-ielts-v2.3.md:1074` matches Source 2's 88-card count exactly. [verified]
- **No code touched** — `git diff main..HEAD --stat` shows only `docs/courses/ielts-speaking/*` files changed; no code, no DB, no Lattice gates affected. [verified]
- **Front-matter consistency** — all 5 source files carry the same front-matter shape (`hf-template-version: "5.1"` + `hf-document-type: QUESTION_BANK` + `hf-source-format` + `hf-source-slug`). [verified]
- **courses-template-version-coverage gate** — matches `*.course-ref.md` only; these 5 files do not match the pattern so the gate is unaffected. The marker is added for forward-compat consistency. [verified]
- **README** — orientation file mirrors the pattern at `docs/courses/cio-cto-standard/README.md`. [verified]

## Out of scope

- S2 wizard upload + Extract (operator action post-merge)
- S3 module-config slug refs (separate PR)
- Backfilling other broken courses (Introduction to Psychology has 0 questions — separate concern)
- Rewriting any v2.3 content (Sources 1-3 mirror the authored corpus verbatim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)