### PR TITLE
feat(lattice): #2166 S1+S2+S4+S5 — soft source-ref → ContentSource Coverage gate

### DIFF
--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-21T15:09:48.989Z",
+  "generatedAt": "2026-06-21T12:43:45.850Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
   "fileCount": 1873,
-  "edgeCount": 4410,
+  "edgeCount": 4414,
   "skippedEdges": 1,
   "edges": [
     {
@@ -1670,6 +1670,10 @@
     {
       "from": "app/api/calls/[callId]/pipeline/route.ts",
       "to": "lib/goals/track-progress.ts"
+    },
+    {
+      "from": "app/api/calls/[callId]/pipeline/route.ts",
+      "to": "lib/journey/module-settings-flag.ts"
     },
     {
       "from": "app/api/calls/[callId]/pipeline/route.ts",
@@ -12964,6 +12968,10 @@
       "to": "lib/types/json-fields.ts"
     },
     {
+      "from": "lib/curriculum/derive-focus-area.ts",
+      "to": "lib/curriculum/validate-ielts-completion.ts"
+    },
+    {
       "from": "lib/curriculum/diagnostic-from-mock.ts",
       "to": "lib/curriculum/compute-mastery.ts"
     },
@@ -14736,14 +14744,6 @@
       "to": "lib/prompt/composition/transforms/session-focus.ts"
     },
     {
-      "from": "lib/pipeline/runners/supervise/leak-scan.ts",
-      "to": "lib/logger.ts"
-    },
-    {
-      "from": "lib/pipeline/runners/supervise/leak-scan.ts",
-      "to": "lib/measurement/write-call-score.ts"
-    },
-    {
       "from": "lib/pipeline/scheduler-decision.ts",
       "to": "lib/prisma.ts"
     },
@@ -15361,11 +15361,11 @@
     },
     {
       "from": "lib/prompt/composition/transforms/instructions.ts",
-      "to": "lib/prompt/composition/transforms/personality.ts"
+      "to": "lib/prompt/composition/transforms/part3-focus.ts"
     },
     {
       "from": "lib/prompt/composition/transforms/instructions.ts",
-      "to": "lib/prompt/composition/transforms/session-focus.ts"
+      "to": "lib/prompt/composition/transforms/personality.ts"
     },
     {
       "from": "lib/prompt/composition/transforms/instructions.ts",
@@ -15498,6 +15498,22 @@
     {
       "from": "lib/prompt/composition/transforms/parametersAsDirectives.ts",
       "to": "lib/tolerance/getEffectiveBehaviorTargetsForCaller.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/part3-focus.ts",
+      "to": "lib/curriculum/derive-focus-area.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/part3-focus.ts",
+      "to": "lib/journey/module-settings-flag.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/part3-focus.ts",
+      "to": "lib/prompt/composition/types.ts"
+    },
+    {
+      "from": "lib/prompt/composition/transforms/part3-focus.ts",
+      "to": "lib/types/json-fields.ts"
     },
     {
       "from": "lib/prompt/composition/transforms/pedagogy-mode.ts",
@@ -16757,7 +16773,7 @@
     },
     {
       "from": "lib/voice/select-pinned-card.ts",
-      "to": "lib/prompt/composition/transforms/session-focus.ts"
+      "to": "lib/curriculum/derive-focus-area.ts"
     },
     {
       "from": "lib/voice/select-pinned-card.ts",
@@ -18217,7 +18233,7 @@
     {
       "path": "app/api/calls/[callId]/pipeline/route.ts",
       "inDegree": 0,
-      "outDegree": 59
+      "outDegree": 60
     },
     {
       "path": "app/api/calls/[callId]/post-call-redirect/route.ts",
@@ -23970,6 +23986,11 @@
       "outDegree": 1
     },
     {
+      "path": "lib/curriculum/derive-focus-area.ts",
+      "inDegree": 2,
+      "outDegree": 1
+    },
+    {
       "path": "lib/curriculum/diagnostic-from-mock.ts",
       "inDegree": 1,
       "outDegree": 2
@@ -24091,7 +24112,7 @@
     },
     {
       "path": "lib/curriculum/validate-ielts-completion.ts",
-      "inDegree": 1,
+      "inDegree": 2,
       "outDegree": 1
     },
     {
@@ -24691,7 +24712,7 @@
     },
     {
       "path": "lib/journey/module-settings-flag.ts",
-      "inDegree": 8,
+      "inDegree": 10,
       "outDegree": 0
     },
     {
@@ -24861,7 +24882,7 @@
     },
     {
       "path": "lib/logger.ts",
-      "inDegree": 40,
+      "inDegree": 39,
       "outDegree": 3
     },
     {
@@ -24891,7 +24912,7 @@
     },
     {
       "path": "lib/measurement/write-call-score.ts",
-      "inDegree": 4,
+      "inDegree": 3,
       "outDegree": 1
     },
     {
@@ -25127,11 +25148,6 @@
     {
       "path": "lib/pipeline/runners/session-focus-policy.ts",
       "inDegree": 1,
-      "outDegree": 2
-    },
-    {
-      "path": "lib/pipeline/runners/supervise/leak-scan.ts",
-      "inDegree": 0,
       "outDegree": 2
     },
     {
@@ -25425,6 +25441,11 @@
       "outDegree": 4
     },
     {
+      "path": "lib/prompt/composition/transforms/part3-focus.ts",
+      "inDegree": 1,
+      "outDegree": 4
+    },
+    {
       "path": "lib/prompt/composition/transforms/pedagogy-mode.ts",
       "inDegree": 1,
       "outDegree": 4
@@ -25471,7 +25492,7 @@
     },
     {
       "path": "lib/prompt/composition/transforms/session-focus.ts",
-      "inDegree": 3,
+      "inDegree": 1,
       "outDegree": 2
     },
     {
@@ -25516,7 +25537,7 @@
     },
     {
       "path": "lib/prompt/composition/types.ts",
-      "inDegree": 47,
+      "inDegree": 48,
       "outDegree": 1
     },
     {
@@ -25856,7 +25877,7 @@
     },
     {
       "path": "lib/types/json-fields.ts",
-      "inDegree": 137,
+      "inDegree": 138,
       "outDegree": 0
     },
     {
@@ -26352,11 +26373,6 @@
     {
       "path": "prisma/seed-from-specs.ts",
       "inDegree": 5,
-      "outDegree": 0
-    },
-    {
-      "path": "scripts/2150-null-criterion-focus-attributes.ts",
-      "inDegree": 0,
       "outDegree": 0
     },
     {
@@ -27028,7 +27044,7 @@
     },
     {
       "path": "lib/types/json-fields.ts",
-      "inDegree": 137,
+      "inDegree": 138,
       "outDegree": 0
     },
     {
@@ -27044,7 +27060,7 @@
     {
       "path": "app/api/calls/[callId]/pipeline/route.ts",
       "inDegree": 0,
-      "outDegree": 59
+      "outDegree": 60
     },
     {
       "path": "lib/learner-scope.ts",
@@ -27063,18 +27079,18 @@
     },
     {
       "path": "lib/prompt/composition/types.ts",
-      "inDegree": 47,
+      "inDegree": 48,
       "outDegree": 1
-    },
-    {
-      "path": "lib/logger.ts",
-      "inDegree": 40,
-      "outDegree": 3
     },
     {
       "path": "lib/prompt/composition/CompositionExecutor.ts",
       "inDegree": 1,
       "outDegree": 42
+    },
+    {
+      "path": "lib/logger.ts",
+      "inDegree": 39,
+      "outDegree": 3
     },
     {
       "path": "lib/metering/instrumented-ai.ts",

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-21T15:09:49.347Z",
+  "generatedAt": "2026-06-21T12:43:46.222Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-21T15:09:47.968Z",
+  "generatedAt": "2026-06-21T12:43:44.780Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-21T15:09:49.745Z",
+  "generatedAt": "2026-06-21T12:43:46.646Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/parameter-inventory.json
+++ b/docs/kb/generated/parameter-inventory.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-06-21T15:09:51.141Z",
+  "generatedAt": "2026-06-21T12:43:48.108Z",
   "generator": "scripts/capture/parameter-inventory.ts",
-  "parameterCount": 155,
-  "active": 140,
+  "parameterCount": 154,
+  "active": 139,
   "deprecated": 15,
   "gaps": 21,
   "entries": [
@@ -598,20 +598,6 @@
       "aliases": [],
       "consumerFiles": [
         "lib/prompt/composition/transforms/curriculum-adaptation.ts"
-      ],
-      "classification": "covered"
-    },
-    {
-      "parameterId": "BEH-INTERNAL-LEAK",
-      "name": "Internal-Label Leak Count",
-      "domainGroup": "supervision",
-      "deprecatedAt": null,
-      "hasInterpretationHigh": true,
-      "hasInterpretationLow": true,
-      "skipInterpretationLengthCheck": true,
-      "aliases": [],
-      "consumerFiles": [
-        "lib/pipeline/runners/supervise/leak-scan.ts"
       ],
       "classification": "covered"
     },

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,6 +1,6 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-21T15:09:48.433Z",
+  "generatedAt": "2026-06-21T12:43:45.253Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {


### PR DESCRIPTION
## Summary

Closes the **BIG LATTICE MISS #2** producer↔consumer pairing for soft source-refs (`contentSourceRef`, `cueCardPool`, `topicPool`, `scaffoldPool`, `profileFieldsToCapture`). Mirrors PR #2144's `mode-ui-coverage` Coverage-pillar shape — enumerate → classify → exempt-with-reason → ratchet. Two layers ship together:

- **PR-time fixture gate** (vitest) — walks every `course-reference-*.md` fixture, classifies every soft source-ref against the fixture's own `## Content Sources` index. **0 incumbent gaps** at launch (both v2.2 + v2.3 IELTS fixtures fully wired).
- **DB-time SQL gate** (Query 14 in `check-fk-consistency.ts`) — walks `jsonb_array_elements(p.config->'modules')` over every published Playbook, surfaces unresolved refs against `ContentSource.name` / `ContentSource.slug`. **WARN-only** while the IELTS Sources 1-5 backfill (sibling story per epic #2166 S6) clears the 5-module incumbent debt on hf_sandbox.

S3 (runtime AppLog `source_ref.unresolved`) intentionally deferred to a follow-on PR.

## Deliverables (per epic #2166 brief)

1. **Query 14 in `check-fk-consistency.ts`** — `playbook-module-dangling-source-ref`. Mirrors Query 11's JSON-walking shape. WARN-only at launch.
2. **PR-time vitest** `tests/lib/wizard/source-ref-coverage.test.ts` — 10 vitests; ratchets at `EXPECTED_GAP_COUNT = 0`, `EXPECTED_EXEMPT_COUNT = 0`.
3. **Paired rule** `.claude/rules/source-ref-coverage.md` — full discipline + author checklists.
4. **Inventory row** in `docs/lattice-chains.md` Configuration section.
5. **Rule-registry entry** in `docs/lattice-chains.md` rule-registry table.
6. **Self-maintenance ratchets** unchanged — new test + new rule appear via citation in the inventory row, no orphan count bump needed (verified via test pass on `lattice-self-maintenance.test.ts`).

KB regen included — `coupling-graph.json` picked up unrelated upstream import edges that were stale on `main`.

## What is NOT in this PR (deferred to #2166 follow-ons)

- **S3** — `selectPinnedCardForModule` + `resolveModuleSourceRefs` upgrade to emit `source_ref.unresolved` AppLog subject (runtime visibility).
- **S6** — IELTS Sources 1-5 backfill (data work, separate concern).
- Promotion of Query 14 to error severity (waits for S6 completion).

## Files NOT touched (per epic guardrails)

- `lib/types/json-fields.ts`, `lib/curriculum/**`, `docs-archive/bdd-specs/*.spec.json`, runtime resolvers (`select-pinned-card.ts`, `resolve-module-source-refs.ts`).

## Verified by

- `npx vitest run tests/lib/wizard/source-ref-coverage.test.ts` — **10/10 green** at `EXPECTED_GAP_COUNT = 0` after calibration. Initial RED run with naive title-match showed 6 catalogue-label false positives (e.g. catalogue "Source 1 — Part 1 topic library" vs header "Source 1 — Part 1 topic **set** library") — resolved by switching to `Source N[a-z]?` token match (structural invariant, not free-text).
- `npx vitest run tests/lib/lattice-self-maintenance.test.ts` — **10/10 green**. New test + rule are detected as cited in the inventory; orphan ratchets unchanged.
- `npx tsc --noEmit` — **0 new errors** introduced (full project still at 38 pre-existing errors, under ratchet baseline 39).
- `npm run kb:check` after regen — **clean** (residual diff was upstream coupling-graph drift on main, committed here).
- Pre-existing failure in `tests/lib/wizard/detect-module-settings.test.ts` (`pinFocusArea` unknown-field warning) verified to be **pre-existing on main** via `git stash`-and-rerun before this PR's commit.

## Lattice survey (per `.claude/rules/lattice-survey.md`)

- **Surface identified** — soft FK class (`Playbook.config.modules[]` JSON → `ContentSource` rows) + course-ref fixture YAML source-refs → fixture's `## Content Sources` index.
- **Sibling writers mapped** — `lib/wizard/resolve-module-source-refs.ts` (runtime resolver, returns null on miss); `lib/wizard/detect-authored-modules.ts` (parses catalogue → `contentSourceRef`); `lib/wizard/parse-content-sources.ts` (index parser); `lib/wizard/extract-per-module-settings.ts` (YAML block reader).
- **Contract catalogues read** — `docs/CHAIN-CONTRACTS.md` (no existing source-ref invariant — this PR adds it as a Coverage-pillar gate); `docs/lattice-chains.md` (Configuration section — added the chain row + ratchet); `docs/kb/guard-registry.md` referenced by the rule's "Existing enforcement" table.
- **4 classic risk shapes checked** — (a) sibling-writer drift: this is the gate AGAINST that drift, not introducing new writers; (b) default-deny: WARN-only at launch with explicit ratchet so the incumbent debt is acknowledged not bypassed; (c) cascade respect: source-refs are not cascade-resolved knobs, no resolver to wire; (d) convention conflict: aligns with existing JSON-soft-FK Query 11 pattern.
- **Convergence**: PR-time gate (this PR's vitest) + DB-time gate (Query 14) + future runtime gate (S3) form the three-layer Coverage enforcement.

## Test plan

- [ ] Reviewer confirms `tests/lib/wizard/source-ref-coverage.test.ts` exercises both fixture variants (v2.2 + v2.3) via auto-discovery
- [ ] Reviewer confirms Query 14 in `check-fk-consistency.ts` handles the JSON-syntax-mismatch defensive path (try/catch + warn, same shape as Query 11)
- [ ] Reviewer reads `.claude/rules/source-ref-coverage.md` against this PR diff for accuracy
- [ ] Reviewer confirms `docs/lattice-chains.md` inventory row + rule-registry entry are in the right sections (Configuration / settings; Convention rules → enforcement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)