### PR TITLE
docs(scoring): #2174 S2 — verify 5 PlaybookConfig knobs already wired; split BehaviorTarget editor to #2186

### DIFF
--- a/docs/SCORING-EDITABILITY.md
+++ b/docs/SCORING-EDITABILITY.md
@@ -117,15 +117,40 @@ the editable + cascade-aware surface and which must stay HF-canonical.
 | Per-caller targets editor | `PATCH /api/callers/[callerId]/behavior-targets` | §B `BehaviorTarget.targetValue` (CALLER scope) |
 | Parameter PUT (SUPERADMIN) | `PUT /api/parameters/[id]` (auth raised in #1947) | §A `Parameter.definition` / `interpretationHigh` / `interpretationLow` / `name` / etc. — **HF-IP override surface**, not customer-tunable |
 
-### TUNABLE classifications not yet reachable via UI (= the #2174 S2-S4 backlog)
+### TUNABLE classifications — registry-row status (post-#2174 S2 verification)
 
-| Row | Field | Why reach for it next |
-|---|---|---|
-| §C | `Playbook.config.skillMinCallsToFull` | Already TUNABLE shape; just no editor. Cheapest first reach. |
-| §C | `Playbook.config.loMasteryThreshold` | Read-side wired (#2052); editor pending. |
-| §C | `Playbook.config.assessmentReadinessThreshold` | Read-side wired (#2052); editor pending. |
-| §C | `Playbook.config.progressSignals.{lowWater, highWater}` | Read-side wired (#2052); editor pending. |
-| §B | `BehaviorTarget.targetValue` at **per-skill** granularity inside Rubric Calibration lens | The lens shows the target tier today (`tierLabelForTarget(skill)` at `CourseSkillsTab.tsx:963-965`) but no editor — the AgentTuner does the work elsewhere. Co-locating the editor with the rubric closes a UX loop. |
+This table is the **#2174 S2 result**. The story's premise was that the
+5 PlaybookConfig-rooted scoring knobs needed registry rows wired so the
+generic `JourneyInspectorPanel` auto-renders them. The S2 verification
+(this PR) found the 5 contract rows ALREADY exist in
+`lib/journey/setting-contracts.entries.ts` — they were landed earlier
+by prior epics (Slice C1 of #1721 for `progressSignal*`; #2052 sub-epic
+C for the rest; #2105 for `loMasteryThreshold`). All 5 also satisfy
+`EXPECTED_SCHEMA_PATHS` in `tests/lib/journey/registry-schema-coverage.test.ts`
+and pass `registry-consumer-coverage.test.ts`.
+
+| Row | Field | Contract row | Type field | Schema-coverage path | Runtime consumer | UI today |
+|---|---|---|---|---|---|---|
+| §C | `Playbook.config.skillMinCallsToFull` | ✅ `G4_SKILL_MIN_CALLS_TO_FULL` (`setting-contracts.entries.ts:805`, id `skillMinCallsToFull`, `menuGroupKey: "I_scoring"`) | ✅ `json-fields.ts:547` | ✅ test L102 | ✅ `lib/pipeline/aggregate-runner.ts:208` + `compute-mastery.ts` + `diagnostic-from-mock.ts` | Generic Inspector renders via menuGroupKey `I_scoring` |
+| §C | `Playbook.config.loMasteryThreshold` | ✅ `G7_LO_MASTERY_THRESHOLD` (`setting-contracts.entries.ts:1793`, id `loMasteryThreshold`, `menuGroupKey: "I_scoring"`) | ✅ `json-fields.ts:687` | ✅ test L154 | ✅ `lib/prompt/composition/scoring-config.ts:78` + `transforms/modules.ts` | Generic Inspector renders via menuGroupKey `I_scoring` |
+| §C | `Playbook.config.assessmentReadinessThreshold` | ✅ `G7_ASSESSMENT_READINESS_THRESHOLD` (`setting-contracts.entries.ts:1869`, id `assessmentReadinessThreshold`, `menuGroupKey: "K_between_calls"`) | ✅ `json-fields.ts:696` | ✅ test L158 | ✅ `lib/prompt/composition/scoring-config.ts:79` + `transforms/instructions.ts::assessment_readiness_directive` | Generic Inspector renders via menuGroupKey `K_between_calls` |
+| §C | `Playbook.config.progressSignals.lowWater` | ✅ `G4_PROGRESS_SIGNAL_LOW_WATER` (`setting-contracts.entries.ts:1196`, id `progressSignalLowWater`, `menuGroupKey: "J_feedback"`) | ✅ `json-fields.ts:709-712` | ✅ test L120 | ✅ `lib/prompt/composition/scoring-config.ts:80` + `transforms/instructions.ts::progress_signal_directive` | Generic Inspector renders via menuGroupKey `J_feedback` |
+| §C | `Playbook.config.progressSignals.highWater` | ✅ `G4_PROGRESS_SIGNAL_HIGH_WATER` (`setting-contracts.entries.ts:1213`, id `progressSignalHighWater`, `menuGroupKey: "J_feedback"`) | ✅ `json-fields.ts:709-712` | ✅ test L121 | ✅ `lib/prompt/composition/scoring-config.ts:81` + `transforms/instructions.ts::progress_signal_directive` | Generic Inspector renders via menuGroupKey `J_feedback` |
+| §B | `BehaviorTarget.targetValue` at **per-skill** granularity inside Rubric Calibration lens | ❌ **NOT wireable through the generic journey-setting PATCH route** — the route at `app/api/courses/[courseId]/journey-setting/route.ts:200-208` returns `compoundOwnedSave: true` for the `behaviorTargets` storage root and delegates to `FirstSessionSettings`. A per-skill targetValue editor co-located in Rubric Calibration is genuinely new UI + write-path work (NOT a registry row). | n/a | n/a | ✅ already canonical TUNABLE surface (cascade-resolved) | AgentTuner sliders + per-playbook/per-caller PUT routes (no Rubric-tab inline editor) |
+
+**S2 outcome:** no new contract rows needed. The 5 PlaybookConfig scoring
+knobs are structurally complete — `JourneyInspectorPanel` already renders
+them in their respective buckets (`I_scoring`, `J_feedback`,
+`K_between_calls`). An operator visiting the Inspector for any of those
+buckets sees the slider/number control today; the journey-setting PATCH
+route writes; cascade promotion is S3.
+
+**Item §B (BehaviorTarget per-skill targetValue in Rubric Calibration
+lens) is split as follow-on story
+[#2186](https://github.com/WANDERCOLTD/HF/issues/2186)** — it requires a
+new UI component co-located in `CourseSkillsTab.tsx` + reuse of the
+existing `/api/playbooks/[id]/targets` PUT (no new route needed) and is
+materially different work from "wire registry rows."
 
 ### Cascade-eligible but not yet cascade-aware (= candidate S3 promotions)
 


### PR DESCRIPTION
## Summary

S2 of [#2174](https://github.com/WANDERCOLTD/HF/issues/2174) was framed
as "wire 6 scoring knobs as ROWS in existing Lattice infrastructure" —
6 `JourneySettingContract` entries + 6 type fields + 6 coverage paths,
zero new components/routes/rules.

**Verification finding:** 5 of 6 fields are ALREADY fully wired by
prior PRs. Item 6 (per-skill `BehaviorTarget.targetValue` editor) is
structurally NOT addable through the generic journey-setting PATCH
route. Split as follow-on [#2186](https://github.com/WANDERCOLTD/HF/issues/2186).

This PR is **pure documentation** — updates `docs/SCORING-EDITABILITY.md`
§"TUNABLE classifications not yet reachable via UI" to reflect the live
registry state with file:line citations.

## What was found wired (no new work needed)

| Field | Contract row | menuGroupKey | Type field | Schema-coverage path | Runtime consumer |
|---|---|---|---|---|---|
| `skillMinCallsToFull` | `setting-contracts.entries.ts:805` `G4_SKILL_MIN_CALLS_TO_FULL` | `I_scoring` | `json-fields.ts:547` | test L102 | `aggregate-runner.ts:208` |
| `loMasteryThreshold` | `setting-contracts.entries.ts:1793` `G7_LO_MASTERY_THRESHOLD` | `I_scoring` | `json-fields.ts:687` | test L154 | `scoring-config.ts:78` + `transforms/modules.ts` |
| `assessmentReadinessThreshold` | `setting-contracts.entries.ts:1869` `G7_ASSESSMENT_READINESS_THRESHOLD` | `K_between_calls` | `json-fields.ts:696` | test L158 | `scoring-config.ts:79` + `transforms/instructions.ts::assessment_readiness_directive` |
| `progressSignals.lowWater` | `setting-contracts.entries.ts:1196` `G4_PROGRESS_SIGNAL_LOW_WATER` (id `progressSignalLowWater`) | `J_feedback` | `json-fields.ts:709-712` | test L120 | `scoring-config.ts:80` + `transforms/instructions.ts::progress_signal_directive` |
| `progressSignals.highWater` | `setting-contracts.entries.ts:1213` `G4_PROGRESS_SIGNAL_HIGH_WATER` (id `progressSignalHighWater`) | `J_feedback` | `json-fields.ts:709-712` | test L121 | same as above |

Landed by prior PRs:
- Slice C1 of #1721 (a0a40437) — `progressSignal{Low,High}Water` contracts
- #2052 sub-epic C — type fields + runtime consumers; declared "Producer-only debt closed" in `json-fields.ts:672-673`
- #2105 (4bc4c788) — `loMasteryThreshold` + `assessmentReadinessThreshold` contracts

`JourneyInspectorPanel` already auto-renders all 5 in their buckets
(`I_scoring`, `J_feedback`, `K_between_calls`). Cascade promotion is S3
(separate slice).

## Why item 6 split

The journey-setting PATCH route at
`app/api/courses/[courseId]/journey-setting/route.ts:200-208` returns
`compoundOwnedSave: true` for the `behaviorTargets` storage root and
delegates writes to `FirstSessionSettings`. A
`JourneySettingContract` with `storagePath: "behaviorTarget.<X>.targetValue"`
would round-trip 200 OK and write nothing.

Filed as #2186 — small UI co-location (~0.5d) that reuses the existing
`PUT /api/playbooks/[playbookId]/targets` writer.

## Files changed

- `docs/SCORING-EDITABILITY.md` — replaced stale "editor pending" rows with verified live registry citations + pointer to #2186 for §B. **+34 / -9** (one file).

## What this PR did NOT do (per operator instructions)

- No new contract rows (already exist)
- No new type fields (already exist)
- No `EXPECTED_SCHEMA_PATHS` additions (already present)
- No new component
- No new API route
- No `JourneyInspectorPanel` modifications
- No new ESLint rule (S5 owns that)
- No new cascade resolver (S3 owns that)

## Test counts before / after

Both runs from this branch's tip on top of `main` (no source changes — docs only):

| Test file | Before | After |
|---|---|---|
| `tests/lib/journey/registry-schema-coverage.test.ts` | 6 passed | 6 passed |
| `tests/lib/journey/registry-consumer-coverage.test.ts` | 6 passed | 6 passed |
| `tests/lib/journey/registry-completeness.test.ts` | 14 passed | 14 passed |
| `tests/lib/journey/registry-options-coverage.test.ts` | 7 passed | 7 passed |
| `tests/lib/journey/gated-by-coverage.test.ts` | 6 passed | 6 passed |
| `tests/lib/journey/arraykey-writer-coverage.test.ts` | 7 passed | 7 passed |
| `tests/lib/lattice-self-maintenance.test.ts` | 10 passed | 10 passed |

## Coordination

No collisions to report — pure docs change.

- **#2176 (json-fields.ts enum reshape):** N/A — this PR does not touch `lib/types/json-fields.ts`.
- **#2174 S3 (cascade promotion):** independent — touches `lib/cascade/effective-value.ts::FAMILIES`, not the registry.
- **#2174 S5 (defensive ESLint coverage):** independent — touches `lib/cascade/spec-readonly-fields.ts`, not the registry.

## Verified by

**Lattice survey** (per `.claude/rules/lattice-survey.md`):
- Surface: `Playbook.config.{loMasteryThreshold, assessmentReadinessThreshold, progressSignals.{lowWater,highWater}, skillMinCallsToFull}` + sibling `BehaviorTarget.targetValue`.
- Sibling writers: `setting-contracts.entries.ts` (registry rows), `journey-setting/route.ts` (PATCH writer for PlaybookConfig roots), `FirstSessionSettings` (compound writer for behaviorTargets root).
- 4 risk shapes cross-checked:
  - sibling-writer drift: N/A — only one writer per `PlaybookConfig` path.
  - default-deny gates: N/A — no precondition guards.
  - cascade respect: registered families honoured (S3 work).
  - convention conflict: N/A — scalar tunables.
- Convergence: no new writers introduced; this PR is docs-only.

**File:line citations** verified via grep on
`apps/admin/lib/journey/setting-contracts.entries.ts`:
- `805:const G4_SKILL_MIN_CALLS_TO_FULL`
- `1196:const G4_PROGRESS_SIGNAL_LOW_WATER`
- `1213:const G4_PROGRESS_SIGNAL_HIGH_WATER`
- `1793:const G7_LO_MASTERY_THRESHOLD`
- `1869:const G7_ASSESSMENT_READINESS_THRESHOLD`

**Vitest results** (`apps/admin` at this branch tip):
```
$ npx vitest run tests/lib/journey/registry-schema-coverage.test.ts tests/lib/journey/registry-consumer-coverage.test.ts tests/lib/journey/registry-completeness.test.ts tests/lib/journey/registry-options-coverage.test.ts
Test Files  4 passed (4)
     Tests  33 passed (33)

$ npx vitest run tests/lib/lattice-self-maintenance.test.ts
Test Files  1 passed (1)
     Tests  10 passed (10)
```

**Structural reason for splitting item 6** verified at
`app/api/courses/[courseId]/journey-setting/route.ts:200-208`:
```ts
if (resolved.root === "behaviorTargets") {
  return NextResponse.json({
    ok: true,
    effectiveValue: value,
    autoEnabled: [],
    bumpedSections: [],
    compoundOwnedSave: true,
  });
}
```
The PATCH writer is intentionally narrow to `PlaybookConfig` roots. A
contract row pointing at `behaviorTarget.*.targetValue` would silently
no-op. [verified]

## Test plan

- [x] Run `npx vitest run tests/lib/journey/registry-schema-coverage.test.ts` — green (6/6)
- [x] Run `npx vitest run tests/lib/journey/registry-consumer-coverage.test.ts` — green (6/6)
- [x] Run `npx vitest run tests/lib/journey/registry-completeness.test.ts` — green (14/14)
- [x] Run `npx vitest run tests/lib/journey/registry-options-coverage.test.ts` — green (7/7)
- [x] Run `npx vitest run tests/lib/lattice-self-maintenance.test.ts` — green (10/10)
- [ ] Operator visits `/x/courses/[courseId]` → Journey tab → `I_scoring` bucket and confirms `skillMinCallsToFull` + `loMasteryThreshold` sliders render via generic Inspector
- [ ] Operator confirms `J_feedback` bucket shows `progressSignal{Low,High}Water` sliders
- [ ] Operator confirms `K_between_calls` bucket shows `assessmentReadinessThreshold` slider

🤖 Generated with [Claude Code](https://claude.com/claude-code)
