### PR TITLE
feat(cascade): #2174 S3 — promote 4 scoring knobs to Domain→Course cascade

### DIFF
--- a/apps/admin/lib/cascade/effective-value.ts
+++ b/apps/admin/lib/cascade/effective-value.ts
@@ -113,6 +113,38 @@ const FAMILIES: readonly KnobFamily[] = [
     match: (k) => k === "skillTierMapping" || k === "skillScoringEmaHalfLifeDays",
     resolve: (scope, knobKey) => resolveMasteryPolicyKnob(scope, knobKey),
   },
+  // ── #2174 S3 (2026-06-21) — 4 scoring knobs promoted to Domain → Course
+  // cascade per Q2 + Q3 in docs/SCORING-EDITABILITY.md. All four reuse the
+  // mastery-policy resolver (same `Domain.config[knobKey]` →
+  // `Playbook.config[knobKey]` shape). Each lands as its own FAMILIES
+  // entry so the diagnostic `name` is specific in error messages and the
+  // cascade-resolve route's cache stats. Resolver function unchanged —
+  // SUPPORTED_KEYS in mastery-policy.ts widened by 4 to accept them.
+  {
+    name: "tier-preset",
+    match: (k) => k === "tierPresetId",
+    resolve: (scope, knobKey) => resolveMasteryPolicyKnob(scope, knobKey),
+  },
+  {
+    name: "lo-mastery-threshold",
+    match: (k) => k === "loMasteryThreshold",
+    resolve: (scope, knobKey) => resolveMasteryPolicyKnob(scope, knobKey),
+  },
+  {
+    name: "assessment-readiness-threshold",
+    match: (k) => k === "assessmentReadinessThreshold",
+    resolve: (scope, knobKey) => resolveMasteryPolicyKnob(scope, knobKey),
+  },
+  {
+    // Object-valued knob (`{lowWater?, highWater?}`). Resolver returns the
+    // winning layer's object untouched — NO per-field merging across
+    // layers (consistent with the existing object-valued `skillTierMapping`
+    // behaviour). Consumers cherry-pick `lowWater`/`highWater` from the
+    // resolved value.
+    name: "progress-signals",
+    match: (k) => k === "progressSignals",
+    resolve: (scope, knobKey) => resolveMasteryPolicyKnob(scope, knobKey),
+  },
 ];
 
 function pickResolver(knobKey: string): AnyResolver {

--- a/apps/admin/lib/cascade/resolvers/mastery-policy.ts
+++ b/apps/admin/lib/cascade/resolvers/mastery-policy.ts
@@ -1,23 +1,46 @@
 /**
- * Mastery-policy cascade resolver — covers the two genuinely cascade-eligible
- * mastery knobs (Sprint 1 SP1-D, post-investigation 2026-06-13):
+ * Mastery-policy cascade resolver — covers the genuinely cascade-eligible
+ * mastery + scoring knobs:
  *
- *   - `skillTierMapping` — full tier-threshold + tierBands override
- *     (IELTS-style 9-band vs CEFR vs custom). Institution may want a
- *     domain-wide default so individual courses inherit a single rubric
- *     style across the institution.
+ *   - `skillTierMapping` (Sprint 1 SP1-D, 2026-06-13) — full tier-threshold +
+ *     tierBands override (IELTS-style 9-band vs CEFR vs custom). Institution
+ *     may want a domain-wide default so individual courses inherit a single
+ *     rubric style across the institution.
  *
- *   - `skillScoringEmaHalfLifeDays` — mastery responsiveness in days
- *     (default 14). Short-demo institutions may want 4d at the Domain
- *     level; year-long programmes may want 30d. Per-course override stays
- *     available.
+ *   - `skillScoringEmaHalfLifeDays` (Sprint 1 SP1-D, 2026-06-13) — mastery
+ *     responsiveness in days (default 14). Short-demo institutions may want
+ *     4d at the Domain level; year-long programmes may want 30d. Per-course
+ *     override stays available.
  *
- * These two knobs are READ today from `Playbook.config` only — by
- * `lib/banding/presets.ts`, `lib/pipeline/aggregate-runner.ts:204-206`,
- * `lib/goals/track-progress.ts::getSkillTierMapping`. The cascade layer
- * adds Domain → Playbook resolution + provenance for the educator UI
- * (Rubric Calibration lens in SP3-A). The underlying readers can stay
- * Playbook-only until SP3-A is ready to wire them through this resolver.
+ *   - `tierPresetId` (#2174 S3, 2026-06-21) — banding preset id
+ *     (`generic` / `ielts-speaking` / `cefr` / `5-level` / `custom`). Per
+ *     Q2 in `docs/SCORING-EDITABILITY.md`: a Domain that hosts many courses
+ *     sharing one preset (e.g. a CEFR-shaped Domain with 6 CEFR courses)
+ *     should be able to set the preset once at Domain level.
+ *
+ *   - `loMasteryThreshold` (#2174 S3 / #2052 sub-epic C) — mastery score
+ *     required to mark a Learning Objective as passed. Range [0,1].
+ *     Read by `lib/prompt/composition/scoring-config.ts::resolveScoringConfig`.
+ *
+ *   - `assessmentReadinessThreshold` (#2174 S3 / #2052) — mastery the
+ *     learner must reach before a post-test/assessment stop fires. Read by
+ *     `transforms/instructions.ts` for the assessment_readiness_directive.
+ *
+ *   - `progressSignals` (#2174 S3 / #2052) — `{lowWater?, highWater?}`
+ *     watermarks on engagement-mastery rollup. Object-valued knob — the
+ *     resolver treats it as `unknown` and returns the winning layer's
+ *     blob untouched; consumers cherry-pick `lowWater`/`highWater` from
+ *     the resolved value. NO per-field merging across layers (consistent
+ *     with `skillTierMapping`, which is also object-valued and "last
+ *     non-null layer wins").
+ *
+ * These knobs are READ today from `Playbook.config` only — by
+ * `lib/banding/presets.ts`, `lib/pipeline/aggregate-runner.ts`,
+ * `lib/goals/track-progress.ts`, `lib/prompt/composition/scoring-config.ts`,
+ * `transforms/instructions.ts`. The cascade layer adds Domain → Playbook
+ * resolution + provenance for the educator UI. The underlying readers can
+ * stay Playbook-only until a follow-on slice wires them through this
+ * resolver.
  *
  * The other three mastery knobs are NOT cascade-eligible by design:
  *   - `useFreshMastery` — variant-preset intrinsic ("Exam Assessment" identity)
@@ -48,7 +71,16 @@ import { prisma } from "@/lib/prisma";
 import type { Effective, LayerHit } from "../layer-types";
 import type { ScopeChain } from "../effective-value";
 
-const SUPPORTED_KEYS = ["skillTierMapping", "skillScoringEmaHalfLifeDays"] as const;
+const SUPPORTED_KEYS = [
+  "skillTierMapping",
+  "skillScoringEmaHalfLifeDays",
+  // #2174 S3 — 4 additional scoring knobs promoted to Domain → Course
+  // cascade (Q2 + Q3 from docs/SCORING-EDITABILITY.md).
+  "tierPresetId",
+  "loMasteryThreshold",
+  "assessmentReadinessThreshold",
+  "progressSignals",
+] as const;
 type MasteryPolicyKey = (typeof SUPPORTED_KEYS)[number];
 
 function isMasteryPolicyKey(k: string): k is MasteryPolicyKey {

--- a/apps/admin/tests/lib/cascade/effective-value.test.ts
+++ b/apps/admin/tests/lib/cascade/effective-value.test.ts
@@ -18,6 +18,7 @@ const resolveSessionFlowKnob = vi.fn();
 const resolveWelcomeMessage = vi.fn();
 const resolveVoiceConfigKnob = vi.fn();
 const resolveIdentitySpec = vi.fn();
+const resolveMasteryPolicyKnob = vi.fn();
 
 vi.mock("@/lib/cascade/resolvers/behavior-target", () => ({
   resolveBehaviorTarget,
@@ -33,6 +34,9 @@ vi.mock("@/lib/cascade/resolvers/voice-config", () => ({
 }));
 vi.mock("@/lib/cascade/resolvers/identity-spec", () => ({
   resolveIdentitySpec,
+}));
+vi.mock("@/lib/cascade/resolvers/mastery-policy", () => ({
+  resolveMasteryPolicyKnob,
 }));
 
 const FAKE_ENVELOPE = {
@@ -52,6 +56,7 @@ beforeEach(async () => {
   resolveWelcomeMessage.mockResolvedValue(FAKE_ENVELOPE);
   resolveVoiceConfigKnob.mockResolvedValue(FAKE_ENVELOPE);
   resolveIdentitySpec.mockResolvedValue(FAKE_ENVELOPE);
+  resolveMasteryPolicyKnob.mockResolvedValue(FAKE_ENVELOPE);
 });
 
 describe("resolveEffective dispatch", () => {
@@ -103,6 +108,26 @@ describe("resolveEffective dispatch", () => {
       scopeChain: { playbookId: "pb1" },
     });
     expect(resolveIdentitySpec).toHaveBeenCalledOnce();
+  });
+
+  it("routes the 2 original + 4 #2174-S3-promoted scoring knobs to mastery-policy resolver", async () => {
+    const { resolveEffective } = await import("@/lib/cascade/effective-value");
+    // 2 original (SP1-D 2026-06-13) + 4 promoted (#2174 S3 2026-06-21).
+    const knobs = [
+      "skillTierMapping",
+      "skillScoringEmaHalfLifeDays",
+      "tierPresetId",
+      "loMasteryThreshold",
+      "assessmentReadinessThreshold",
+      "progressSignals",
+    ];
+    for (const k of knobs) {
+      await resolveEffective({
+        knobKey: k,
+        scopeChain: { playbookId: "pb1" },
+      });
+    }
+    expect(resolveMasteryPolicyKnob).toHaveBeenCalledTimes(6);
   });
 
   it("throws on unknown knob key", async () => {
@@ -221,6 +246,17 @@ describe("isResolvableKnob", () => {
     expect(isResolvableKnob("intake")).toBe(true);
     expect(isResolvableKnob("stops")).toBe(true);
     expect(isResolvableKnob("offboarding")).toBe(true);
+  });
+
+  it("mastery-policy + #2174-S3-promoted scoring knobs resolve", async () => {
+    const { isResolvableKnob } = await import("@/lib/cascade/effective-value");
+    // 2 original (SP1-D 2026-06-13) + 4 promoted (#2174 S3 2026-06-21).
+    expect(isResolvableKnob("skillTierMapping")).toBe(true);
+    expect(isResolvableKnob("skillScoringEmaHalfLifeDays")).toBe(true);
+    expect(isResolvableKnob("tierPresetId")).toBe(true);
+    expect(isResolvableKnob("loMasteryThreshold")).toBe(true);
+    expect(isResolvableKnob("assessmentReadinessThreshold")).toBe(true);
+    expect(isResolvableKnob("progressSignals")).toBe(true);
   });
 
   it("returns false for skill_* and other non-cascade parameter ids", async () => {

--- a/apps/admin/tests/lib/cascade/mastery-policy-resolver.test.ts
+++ b/apps/admin/tests/lib/cascade/mastery-policy-resolver.test.ts
@@ -180,6 +180,98 @@ describe("resolveMasteryPolicyKnob — skillTierMapping", () => {
   });
 });
 
+describe("resolveMasteryPolicyKnob — #2174 S3 promoted scoring knobs", () => {
+  // 4 new knobs added 2026-06-21 per Q2 + Q3 in docs/SCORING-EDITABILITY.md.
+  // Same `Domain.config[knobKey]` → `Playbook.config[knobKey]` shape as
+  // skillTierMapping + skillScoringEmaHalfLifeDays.
+
+  it("tierPresetId — DOMAIN default for a CEFR-shaped Domain (Q2 fingerprint)", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb-1",
+      name: "Spanish A2",
+      config: {},
+      domainId: "dom-cefr",
+    });
+    mockPrisma.domain.findUnique.mockResolvedValueOnce({
+      id: "dom-cefr",
+      name: "CEFR Language School",
+      config: { tierPresetId: "cefr" },
+    });
+    const result = await resolveMasteryPolicyKnob(
+      { playbookId: "pb-1" },
+      "tierPresetId",
+    );
+    expect(result.value).toBe("cefr");
+    expect(result.source).toBe("DOMAIN");
+    expect(result.isInherited).toBe(true);
+  });
+
+  it("loMasteryThreshold — PLAYBOOK overrides DOMAIN", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb-1",
+      name: "IELTS Mock",
+      config: { loMasteryThreshold: 0.75 },
+      domainId: "dom-1",
+    });
+    mockPrisma.domain.findUnique.mockResolvedValueOnce({
+      id: "dom-1",
+      name: "Test Prep Co",
+      config: { loMasteryThreshold: 0.6 },
+    });
+    const result = await resolveMasteryPolicyKnob(
+      { playbookId: "pb-1" },
+      "loMasteryThreshold",
+    );
+    expect(result.value).toBe(0.75);
+    expect(result.source).toBe("PLAYBOOK");
+  });
+
+  it("assessmentReadinessThreshold — DOMAIN-only inheritance flags isInherited:true", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb-1",
+      name: "OCEAN",
+      config: {},
+      domainId: "dom-1",
+    });
+    mockPrisma.domain.findUnique.mockResolvedValueOnce({
+      id: "dom-1",
+      name: "Acme",
+      config: { assessmentReadinessThreshold: 0.8 },
+    });
+    const result = await resolveMasteryPolicyKnob(
+      { playbookId: "pb-1" },
+      "assessmentReadinessThreshold",
+    );
+    expect(result.value).toBe(0.8);
+    expect(result.source).toBe("DOMAIN");
+    expect(result.isInherited).toBe(true);
+  });
+
+  it("progressSignals — object-valued knob returned untouched (no per-field merge)", async () => {
+    const domainSignals = { lowWater: 0.3, highWater: 0.7 };
+    const playbookSignals = { lowWater: 0.25, highWater: 0.85 };
+    mockPrisma.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb-1",
+      name: "Spot the Spin",
+      config: { progressSignals: playbookSignals },
+      domainId: "dom-1",
+    });
+    mockPrisma.domain.findUnique.mockResolvedValueOnce({
+      id: "dom-1",
+      name: "Acme",
+      config: { progressSignals: domainSignals },
+    });
+    const result = await resolveMasteryPolicyKnob(
+      { playbookId: "pb-1" },
+      "progressSignals",
+    );
+    // PLAYBOOK wins as a whole object — NOT a per-field merge across layers
+    // (consistent with skillTierMapping object-knob semantics).
+    expect(result.value).toEqual(playbookSignals);
+    expect(result.source).toBe("PLAYBOOK");
+  });
+});
+
 describe("resolveMasteryPolicyKnob — provenance TODO", () => {
   it("returns setAt: null + setBy: null until config authorship metadata lands", async () => {
     mockPrisma.playbook.findUnique.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

Promotes 4 `Playbook.config` scoring knobs to the Domain → Course cascade via a **data-only** edit to `lib/cascade/effective-value.ts::FAMILIES`. The generic `resolveMasteryPolicyKnob` resolver is reused — its function logic is unchanged; only the `SUPPORTED_KEYS` whitelist widens from 2 → 6.

| Knob | Type | Source | Audit question |
|---|---|---|---|
| `tierPresetId` | string enum | Playbook.config | Q2 (CEFR-shaped Domains share a preset across many courses) |
| `loMasteryThreshold` | number | Playbook.config (#2052) | Q3 |
| `assessmentReadinessThreshold` | number | Playbook.config (#2052) | Q3 |
| `progressSignals` | `{lowWater?, highWater?}` object | Playbook.config (#2052) | Q3 |

After this lands, `useEffectiveValue(knobKey, scope)` / `resolveEffective(...)` walks System → Domain → Course for these 4 knobs (no Segment/Caller layer — same shape as the existing `mastery-policy` family). Runtime consumers (`scoring-config.ts`, `transforms/instructions.ts`, `lib/banding/presets.ts`) continue reading Playbook-only until a follow-on slice wires them through the resolver.

## What this slice does NOT do

- Does NOT touch `lib/types/json-fields.ts::PlaybookConfig` (S2's job — avoids #2176 collision)
- Does NOT add `JourneySettingContract` rows with `cascadeKnobKey` (S2's job)
- Does NOT add UI editors (S2 — generic Inspector renders any contract)
- Does NOT modify the FAMILIES dispatcher logic (`pickResolver`) — only the table
- Does NOT add a 5th field — operator approved exactly these 4 via Q2 + Q3 in the audit doc

## Coordination

| In-flight peer | Surface | Risk |
|---|---|---|
| #2176 (CourseAssessmentPlan) | `lib/types/json-fields.ts` enums | Different file from this slice — SAFE |
| #2174 S5 (defensive ESLint constant) | new ESLint rule file | Different file — SAFE |
| #2174 S2 (contract rows) | `setting-contracts.entries.ts` + Inspector wiring | Runs AFTER this so contract rows can declare `cascadeKnobKey` |

## Verified by

**Lattice survey** (mandatory per `.claude/rules/lattice-survey.md`):

1. **Surface:** `FAMILIES` dispatch table at `apps/admin/lib/cascade/effective-value.ts:72-148` — adds 4 cascade-eligible knob keys, each delegating to the existing `resolveMasteryPolicyKnob`.
2. **Sibling writers/readers mapped (qmd + grep):**
   - `apps/admin/lib/cascade/resolvers/mastery-policy.ts::resolveMasteryPolicyKnob` — generic `Domain.config[knobKey]` → `Playbook.config[knobKey]` reader; the 4 new keys widen `SUPPORTED_KEYS` only (data, not function logic).
   - `apps/admin/lib/cascade/knob-keys.ts::LISTED_KNOBS` — paired doc catalogue; one-way invariant only (every listed knob is resolvable; not every resolvable knob need be listed). The 2 existing `mastery-policy` knobs are absent from `LISTED_KNOBS`; the 4 new ones stay absent for the same reason — these aren't demo-preset knobs.
   - Runtime consumers (`apps/admin/lib/prompt/composition/scoring-config.ts`, `transforms/instructions.ts`, `lib/banding/presets.ts`, `apps/admin/components/shared/BandingPicker.tsx`) read `Playbook.config` directly today; promotion is read-side resolver only — no consumer change in this slice.
3. **Contracts read:**
   - `docs/CHAIN-CONTRACTS.md` — no cascade-stage row affected (FAMILIES is a read-side dispatch, not a chain stage)
   - `docs/kb/guard-registry.md` — no new guard required; the existing `hf-cascade/no-bare-resolve` policy intentionally does NOT block direct reads from composition transforms (per `lib/cascade/effective-value.ts:12-16`)
   - `.claude/rules/spec-readonly-boundary.md` — none of the 4 fields are HF-CANONICAL; all are classified TUNABLE in `docs/SCORING-EDITABILITY.md` §C
4. **Risk cross-check (4 classic shapes):**
   - **Sibling-writer drift:** none — the resolver only READS Domain.config + Playbook.config; no writers in this surface.
   - **Default-deny gates:** none on FAMILIES dispatch — `pickResolver` matches by `match()` predicate, no guard preconditions.
   - **Cascade respect:** the change IS adding cascade respect at the read-side resolver layer.
   - **Convention conflict:** `progressSignals` is object-valued (`{lowWater?, highWater?}`); other 3 are scalars. The resolver treats values as `unknown` with null-check only — object-valued knobs work identically (winning layer's object returned untouched; NO per-field merging across layers, consistent with existing `skillTierMapping` object-knob semantics).

**Test counts:**

| Test file | Before | After | Δ |
|---|---|---|---|
| `tests/lib/cascade/effective-value.test.ts` | 14 | 16 | +2 (dispatch + isResolvableKnob for the 6 mastery-policy knobs) |
| `tests/lib/cascade/mastery-policy-resolver.test.ts` | 9 | 13 | +4 (one per new knob — `tierPresetId` DOMAIN-default, `loMasteryThreshold` PLAYBOOK-override, `assessmentReadinessThreshold` DOMAIN-only inheritance, `progressSignals` object-knob no-merge) |
| Total cascade tests | 104 | 110 | +6 |

**Ratchets:**
- tsc errors: 38 (baseline 39, -1 — no regression)
- lint: clean

**References:**
- Story: #2174 S3
- Audit doc: `docs/SCORING-EDITABILITY.md` (landed via PR #2179, commit `126b569d`) §C + Q2/Q3
- Process rule: `feedback_data_first_lattice_planning.md` (data edits first, code edits only when data is insufficient)
- Operator approval: Q2 + Q3 approved on #2174 comment thread
- Sister rule: `.claude/rules/cascade-reuse.md`

## Test plan

- [x] `npx vitest run tests/lib/cascade/` — 110 passing (was 104)
- [x] `npx tsc --noEmit` — 38 errors (baseline 39, -1)
- [x] `npx eslint <touched files>` — clean
- [ ] After merge: S2 can wire `JourneySettingContract` rows with `cascadeKnobKey` for these 4 knobs and the Inspector will auto-render them as cascade-aware

🤖 Generated with [Claude Code](https://claude.com/claude-code)