### PR TITLE
feat(registry): #2196 — amend canonical registry with 4 IELTS skill + 4 prosody_raw_* params (closes #2139 honest finding)

### DIFF
--- a/apps/admin/docs-archive/bdd-specs/behavior-parameters.registry.json
+++ b/apps/admin/docs-archive/bdd-specs/behavior-parameters.registry.json
@@ -2713,6 +2713,150 @@
           "specSlug": "INIT-001-caller-onboarding"
         }
       }
+    },
+    {
+      "parameterId": "skill_fluency_and_coherence_fc",
+      "name": "IELTS — Fluency & Coherence",
+      "definition": "IELTS Fluency & Coherence — sustained speaking without breakdown, connected discourse with logical organisation. LLM-judged from transcript by IELTS-MEASURE-001 using the IELTS Public Band Descriptors; score is `ielts_band(fc) / 9` clamped to [0, 1]. Sibling prosody-raw signal (prosody_raw_fc) MAY augment confidence post-MVP via tool-use, but the LLM transcript score remains authoritative.",
+      "domainGroup": "learner-model",
+      "defaultTarget": 0.611,
+      "aliases": [
+        "fluency_and_coherence",
+        "skill_fc"
+      ],
+      "interpretationHigh": "Speaks fluently with only occasional repetition or self-correction; develops topics coherently and appropriately; uses a range of connectives and discourse markers with flexibility.",
+      "interpretationLow": "Long pauses, frequent breakdowns; only basic connectives ('and', 'but'); responses often single words or short phrases with little topic development.",
+      "usage": {
+        "compose": "semantics-block",
+        "measurement": {
+          "specSlug": "IELTS-MEASURE-001-ielts-speaking-criteria"
+        }
+      }
+    },
+    {
+      "parameterId": "skill_lexical_resource_lr",
+      "name": "IELTS — Lexical Resource",
+      "definition": "IELTS Lexical Resource — vocabulary range, precision of word choice, paraphrase flexibility, idiomatic appropriacy. TRANSCRIPT-ONLY — vendor audio cannot judge. LLM-judged from transcript by IELTS-MEASURE-001 using the IELTS Public Band Descriptors; score is `ielts_band(lr) / 9` clamped to [0, 1]. prosody_raw_lr exists for completeness but is NOT consumed — the LLM is authoritative.",
+      "domainGroup": "learner-model",
+      "defaultTarget": 0.611,
+      "aliases": [
+        "lexical_resource",
+        "skill_lr"
+      ],
+      "interpretationHigh": "Wide range of vocabulary used fluently and precisely; skilful use of less common and idiomatic vocabulary; paraphrases effectively when needed.",
+      "interpretationLow": "Very basic vocabulary; cannot discuss most topics; meaning often opaque; relies on memorised phrases with no paraphrase attempted.",
+      "usage": {
+        "compose": "semantics-block",
+        "measurement": {
+          "specSlug": "IELTS-MEASURE-001-ielts-speaking-criteria"
+        }
+      }
+    },
+    {
+      "parameterId": "skill_grammatical_range_and_accuracy_gra",
+      "name": "IELTS — Grammatical Range & Accuracy",
+      "definition": "IELTS Grammatical Range & Accuracy — variety of sentence structures, complexity (subordination, conditionals, modals), and error frequency/gravity. TRANSCRIPT-ONLY — vendor audio cannot judge grammar. LLM-judged from transcript by IELTS-MEASURE-001 using the IELTS Public Band Descriptors; score is `ielts_band(gra) / 9` clamped to [0, 1]. prosody_raw_gra exists for completeness but is NOT consumed — the LLM is authoritative.",
+      "domainGroup": "learner-model",
+      "defaultTarget": 0.611,
+      "aliases": [
+        "grammatical_range_and_accuracy",
+        "skill_gra"
+      ],
+      "interpretationHigh": "Wide range of structures used flexibly; the majority of sentences are error-free, with only occasional inappropriacies; complex forms (subordination, conditionals, modals) appear naturally.",
+      "interpretationLow": "Basic sentence forms with limited accuracy; rarely produces subordinate clauses; persistent errors that frequently impede meaning.",
+      "usage": {
+        "compose": "semantics-block",
+        "measurement": {
+          "specSlug": "IELTS-MEASURE-001-ielts-speaking-criteria"
+        }
+      }
+    },
+    {
+      "parameterId": "skill_pronunciation_p",
+      "name": "IELTS — Pronunciation",
+      "definition": "IELTS Pronunciation — phoneme accuracy, stress, rhythm, intonation, intelligibility. Dual-confidence scoring: LLM-judged from transcript cues (self-corrections, tutor pronunciation feedback, repair patterns, hesitations, long-turn cleanliness) at medium confidence; when prosody vendor is wired (epic #2135 S3), prosody_raw_p MAY augment via tool-use and raise confidence to high. Score is `ielts_band(p) / 9` clamped to [0, 1].",
+      "domainGroup": "learner-model",
+      "defaultTarget": 0.611,
+      "aliases": [
+        "pronunciation",
+        "skill_p"
+      ],
+      "interpretationHigh": "Uses a wide range of pronunciation features with precision and subtlety; sustained flexible use of features; easy to understand throughout with first-language accent having minimal effect.",
+      "interpretationLow": "Pronunciation requires frequent listener effort; some or much speech may be unintelligible; limited control of stress, rhythm, and intonation.",
+      "usage": {
+        "compose": "semantics-block",
+        "measurement": {
+          "specSlug": "IELTS-MEASURE-001-ielts-speaking-criteria"
+        }
+      }
+    },
+    {
+      "parameterId": "prosody_raw_fc",
+      "name": "Prosody — Fluency & Coherence raw signal",
+      "definition": "Vendor-measured Fluency & Coherence band signal (band 0–9 normalised to 0–1). Written by lib/pipeline/prosody-consumer.ts during AGGREGATE when the prosody envelope mode is 'ielts'. Distinct from skill_fluency_and_coherence_fc (which is the LLM-judged transcript score from IELTS-MEASURE-001 via SCORE_AGENT). Audio fluency features are reasonably observable from vendor signal, so vendor confidence is 0.9. Optionally consumed by IELTS-MEASURE-001 via tool-use (post-MVP) to augment LLM judgment; not consumed by any AGGREGATE/ADAPT/REWARD spec — see parameter-loop-closure ratchet note.",
+      "domainGroup": "voice-delivery",
+      "defaultTarget": 0.5,
+      "aliases": [],
+      "interpretationHigh": "Vendor audio analysis reports strong fluency band (sustained speech, low hesitation rate, low filler density).",
+      "interpretationLow": "Vendor audio analysis reports weak fluency band (frequent long pauses, high hesitation, broken speech rhythm).",
+      "usage": {
+        "compose": "transform-direct",
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Vendor-derived audio-feature signal produced by lib/pipeline/prosody-consumer.ts (computedBy: prosody-vendor seed); written to CallScore directly by the adapter, not by an AnalysisSpec measure stage. Not transcript-derivable — the LLM cannot reproduce vendor audio-feature outputs from transcript content. Optionally consumed by IELTS-MEASURE-001 via tool-use (post-MVP) to augment FC confidence, but the LLM transcript score on skill_fluency_and_coherence_fc remains authoritative."
+        }
+      }
+    },
+    {
+      "parameterId": "prosody_raw_p",
+      "name": "Prosody — Pronunciation raw signal",
+      "definition": "Vendor-measured Pronunciation band signal (band 0–9 normalised to 0–1). Written by lib/pipeline/prosody-consumer.ts during AGGREGATE when the prosody envelope mode is 'ielts'. Distinct from skill_pronunciation_p (which is the LLM-judged transcript score from IELTS-MEASURE-001). Phoneme accuracy is the vendor's strongest signal — vendor confidence is 0.9. Optionally consumed by IELTS-MEASURE-001 via tool-use (post-MVP) to augment LLM judgment and raise the LLM's transcript-only confidence from medium to high; not consumed by any AGGREGATE/ADAPT/REWARD spec — see parameter-loop-closure ratchet note.",
+      "domainGroup": "voice-delivery",
+      "defaultTarget": 0.5,
+      "aliases": [],
+      "interpretationHigh": "Vendor audio analysis reports strong pronunciation band (precise phoneme accuracy, controlled stress and intonation, high intelligibility).",
+      "interpretationLow": "Vendor audio analysis reports weak pronunciation band (frequent phoneme errors, limited prosodic control, low intelligibility).",
+      "usage": {
+        "compose": "transform-direct",
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Vendor-derived audio-feature signal produced by lib/pipeline/prosody-consumer.ts (computedBy: prosody-vendor seed); written to CallScore directly by the adapter, not by an AnalysisSpec measure stage. Not transcript-derivable — phoneme accuracy and prosodic control are the vendor's strongest signal class, fundamentally not reproducible from transcript text. Optionally consumed by IELTS-MEASURE-001 via tool-use (post-MVP) to lift skill_pronunciation_p confidence from medium to high."
+        }
+      }
+    },
+    {
+      "parameterId": "prosody_raw_lr",
+      "name": "Prosody — Lexical Resource raw signal",
+      "definition": "Vendor-measured Lexical Resource band signal (band 0–9 normalised to 0–1). Written by lib/pipeline/prosody-consumer.ts during AGGREGATE when the prosody envelope mode is 'ielts'. Distinct from skill_lexical_resource_lr (which is the LLM-judged transcript score from IELTS-MEASURE-001 — the authoritative LR score). The vendor cannot reliably score vocabulary from audio features alone; this row is an audio-feature approximation only, vendor confidence 0.7. NOT consumed by IELTS-MEASURE-001 — kept for completeness + forensics; not consumed by any AGGREGATE/ADAPT/REWARD spec.",
+      "domainGroup": "voice-delivery",
+      "defaultTarget": 0.5,
+      "aliases": [],
+      "interpretationHigh": "Vendor audio-feature approximation suggests rich lexical signal; treat as weak corroboration only — the LLM transcript score is authoritative.",
+      "interpretationLow": "Vendor audio-feature approximation suggests sparse lexical signal; treat as weak corroboration only — the LLM transcript score is authoritative.",
+      "usage": {
+        "compose": "transform-direct",
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Vendor-derived audio-feature signal produced by lib/pipeline/prosody-consumer.ts (computedBy: prosody-vendor seed); written to CallScore directly by the adapter, not by an AnalysisSpec measure stage. Not transcript-derivable AND vendor cannot reliably score vocabulary from audio features alone — kept for forensics + completeness; the LLM-judged skill_lexical_resource_lr from IELTS-MEASURE-001 is the authoritative LR score."
+        }
+      }
+    },
+    {
+      "parameterId": "prosody_raw_gra",
+      "name": "Prosody — Grammatical Range & Accuracy raw signal",
+      "definition": "Vendor-measured Grammatical Range & Accuracy band signal (band 0–9 normalised to 0–1). Written by lib/pipeline/prosody-consumer.ts during AGGREGATE when the prosody envelope mode is 'ielts'. Distinct from skill_grammatical_range_and_accuracy_gra (which is the LLM-judged transcript score from IELTS-MEASURE-001 — the authoritative GRA score). The vendor cannot reliably score grammar from audio features alone; this row is an audio-feature approximation only, vendor confidence 0.7. NOT consumed by IELTS-MEASURE-001 — kept for completeness + forensics; not consumed by any AGGREGATE/ADAPT/REWARD spec.",
+      "domainGroup": "voice-delivery",
+      "defaultTarget": 0.5,
+      "aliases": [],
+      "interpretationHigh": "Vendor audio-feature approximation suggests grammatical complexity signal; treat as weak corroboration only — the LLM transcript score is authoritative.",
+      "interpretationLow": "Vendor audio-feature approximation suggests limited grammatical signal; treat as weak corroboration only — the LLM transcript score is authoritative.",
+      "usage": {
+        "compose": "transform-direct",
+        "measurement": {
+          "kind": "operator-only",
+          "reason": "Vendor-derived audio-feature signal produced by lib/pipeline/prosody-consumer.ts (computedBy: prosody-vendor seed); written to CallScore directly by the adapter, not by an AnalysisSpec measure stage. Not transcript-derivable AND vendor cannot reliably score grammar from audio features alone — kept for forensics + completeness; the LLM-judged skill_grammatical_range_and_accuracy_gra from IELTS-MEASURE-001 is the authoritative GRA score."
+        }
+      }
     }
   ]
 }

--- a/apps/admin/tests/lib/registry/parameter-domain-group-taxonomy.test.ts
+++ b/apps/admin/tests/lib/registry/parameter-domain-group-taxonomy.test.ts
@@ -110,10 +110,13 @@ describe("#1948 — domainGroup canonical taxonomy", () => {
     ).toEqual([]);
   });
 
-  it("parameter count is 155 (registry sanity check)", () => {
+  it("parameter count is 163 (registry sanity check)", () => {
     // 2026-06-21 — #2151 added BEH-INTERNAL-LEAK (supervision) — SUPERVISE-alarm
     // signal for LEAK-SCAN-001 runtime gate. Bump 154 → 155.
-    expect(registry.parameters.length).toBe(155);
+    // 2026-06-21 — #2196 added 4 IELTS skill_* (learner-model) + 4 prosody_raw_*
+    // (voice-delivery) — closes the canonical-registry coverage gap surfaced by
+    // PR #2195 #2139. Bump 155 → 163.
+    expect(registry.parameters.length).toBe(163);
   });
 
   it("distribution matches docs/PARAMETER-TAXONOMY.md after migration", () => {
@@ -132,25 +135,49 @@ describe("#1948 — domainGroup canonical taxonomy", () => {
       "behavior-core": 6,
       reinforcement: 6,
       onboarding: 5,
-      // voice-delivery omitted — empty placeholder for #1952 / S5
+      // 2026-06-21 — #2196 unblocks two pedagogy-review placeholders that were
+      // empty at the #1948 v1.0 baseline. The 4 IELTS skill_* params measure
+      // learner-state language ability — they ARE the learner-model.
+      "learner-model": 4,
+      // 2026-06-21 — #2196. The 4 prosody_raw_* params are vendor-derived
+      // audio-feature signals (computedBy: prosody-vendor seed); their natural
+      // home is voice-delivery per the canonical 12-tuple in
+      // lib/registry/canonical-domain-group.ts.
+      "voice-delivery": 4,
     });
   });
 
-  it("`voice-delivery` is declared in canonical groups even though empty (S5 placeholder)", () => {
+  it("`voice-delivery` carries the 4 prosody_raw_* vendor signals (#2196)", () => {
     expect(CANONICAL_GROUPS).toContain("voice-delivery");
     const voiceDelivery = registry.parameters.filter(
       (p) => p.domainGroup === "voice-delivery",
     );
-    // Until #1952 / S5 ships, voice-delivery is intentionally empty.
-    expect(voiceDelivery).toEqual([]);
+    // #2196 — populated by the 4 prosody_raw_* (FC/P/LR/GRA) vendor-derived
+    // audio-feature signals; lib/pipeline/prosody-consumer.ts writes them at
+    // AGGREGATE when the prosody envelope mode is 'ielts'. Optionally
+    // consumed by IELTS-MEASURE-001 via tool-use (post-MVP).
+    expect(voiceDelivery.map((p) => p.parameterId).sort()).toEqual([
+      "prosody_raw_fc",
+      "prosody_raw_gra",
+      "prosody_raw_lr",
+      "prosody_raw_p",
+    ]);
   });
 
-  it("`learner-model` is declared per pedagogy review (placeholder, empty at v1.0)", () => {
+  it("`learner-model` carries the 4 IELTS skill_* per-criterion scores (#2196)", () => {
     expect(CANONICAL_GROUPS).toContain("learner-model");
     const learnerModel = registry.parameters.filter(
       (p) => p.domainGroup === "learner-model",
     );
-    expect(learnerModel).toEqual([]);
+    // #2196 — populated by the 4 IELTS skill_* (FC/LR/GRA/P) LLM-judged
+    // per-criterion band scores measured by IELTS-MEASURE-001 from transcript.
+    // SKILL-AGG-001 closes the M2 loop via sourceParameterPattern: "skill_*".
+    expect(learnerModel.map((p) => p.parameterId).sort()).toEqual([
+      "skill_fluency_and_coherence_fc",
+      "skill_grammatical_range_and_accuracy_gra",
+      "skill_lexical_resource_lr",
+      "skill_pronunciation_p",
+    ]);
   });
 
   it("`affect-motivation` is declared per pedagogy review (placeholder, empty at v1.0)", () => {


### PR DESCRIPTION
## Summary

Closes #2196.

- Adds 8 missing canonical-registry entries to `apps/admin/docs-archive/bdd-specs/behavior-parameters.registry.json` (155 → 163):
  - 4 IELTS `skill_*` parameters (FC/LR/GRA/P) — `domainGroup: learner-model`, measured by `IELTS-MEASURE-001-ielts-speaking-criteria` via `compose: semantics-block`
  - 4 `prosody_raw_*` parameters (FC/P/LR/GRA) — `domainGroup: voice-delivery`, vendor-derived audio-feature signals via `compose: transform-direct`
- Updates `parameter-domain-group-taxonomy.test.ts` ratchets — count 155 → 163, learner-model placeholder → exact `skill_*` assertion, voice-delivery placeholder → exact `prosody_raw_*` assertion.

## Background

Live evidence (verified pre-edit): the canonical registry tracked 155 of the 163 actually-active parameters. The 4 IELTS `skill_*` IDs existed only in `IELTS-MEASURE-001-ielts-speaking-criteria.spec.json::parameters[]` (PR #2143); the 4 `prosody_raw_*` IDs only in `prisma/seed-prosody-parameters.ts` (PR #2157). M1/M2 Lattice ratchets walk only the JSON registry — the 8 params were structurally invisible to the gate. PR #2195 (#2139) surfaced this honestly and skipped the registry edit per "no fabrication".

## domainGroup choices

| Group | Pre-#2196 | Post-#2196 | Rationale |
|---|---|---|---|
| `learner-model` | empty placeholder (#1948 v1.0) | 4 IELTS skill_* | IELTS criteria measure learner-state language ability — they ARE the learner-model |
| `voice-delivery` | empty placeholder (#1948 v1.0) | 4 prosody_raw_* | Vendor-derived audio-feature signals match the prosody-vendor seed's `computedBy` semantic |

Both placeholders are now populated, unblocking v1.0 pedagogy-review staging.

## Lattice classification

| Param family | M1 (measurement coverage) | M2 (loop closure) |
|---|---|---|
| `skill_*` | `measured` via `IELTS-MEASURE-001` cite (cross-checks against spec body) | `closed-pattern` via SKILL-AGG-001 `sourceParameterPattern: "skill_*"` |
| `prosody_raw_*` | `operator-only` with substantive `reason` (vendor-derived signal, not an AnalysisSpec measure stage; not transcript-derivable) | excluded (operator-only kind isn't M2-tracked) |

M2 `EXPECTED_GAP_COUNT` unchanged at 0. M1 distribution sanity unchanged.

## Verified by

- All 7 ratchet vitests green in worktree (45/45 passing):
  - `tests/lib/measurement/parameter-measurement-coverage.test.ts`
  - `tests/lib/measurement/parameter-loop-closure.test.ts`
  - `tests/lib/measurement/parameter-coverage.test.ts`
  - `tests/lib/registry/parameter-usage-coverage.test.ts`
  - `tests/lib/registry/parameter-domain-group-taxonomy.test.ts`
  - `tests/lib/registry/parameter-interpretation-coverage.test.ts`
  - `tests/lib/lattice-self-maintenance.test.ts`
- IELTS spec `parameters[]` body — 4 `skill_*` definitions sourced from `apps/admin/docs-archive/bdd-specs/IELTS-MEASURE-001-ielts-speaking-criteria.spec.json` description + interpretationScale (Band 3 vs Band 8+ implications)
- Prosody seed body — 4 `prosody_raw_*` definitions sourced from `apps/admin/prisma/seed-prosody-parameters.ts` definition strings (cited verbatim where it strengthens the registry entry's semantic)
- Lattice survey — Coverage pillar (M1 + M2 ratchets) + Data Presence (#2168 umbrella; this is a Data Presence instance). No sibling-writer drift on the registry (single JSON file, append-only edit). Canonical 12-tuple in `lib/registry/canonical-domain-group.ts` consulted before choosing `learner-model` + `voice-delivery`.
- Pre-existing failure in `tests/lib/measurement/supv-rew-consumer-manifest.test.ts` (BEH-INTERNAL-LEAK from #2151 not in SUPV manifest) reproduces on baseline without my edits — not introduced by this PR. `[inverse-probe:` stashed my 2 file edits, re-ran failing test on clean baseline, still red `]`
- Spec-readonly boundary (`.claude/rules/spec-readonly-boundary.md`) respected — registry is an HF-canonical seed file edited via the authorised path; no customer-driven code path involved.

## Test plan

- [ ] Re-run the 7 ratchet vitests in CI; all 45 tests pass.
- [ ] Confirm M2 ratchet `EXPECTED_GAP_COUNT` remains 0 (no new gaps from the 4 skill_* via SKILL-AGG-001 pattern; prosody_raw_* don't enter M2 walk).
- [ ] Future work: when IELTS-MEASURE-001 wires tool-use consumption of `prosody_raw_*` signals (post-MVP per epic #2135 S3), reclassify those 4 from `operator-only` to `measured` and bump the M2 ratchet to add the appropriate consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)