### PR TITLE
feat(admin): #2204 — Content tab skeleton (bi-pane, read-only browse of typed teaching content) (U2 of #2185)

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/typed-content/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/typed-content/route.ts
@@ -1,0 +1,257 @@
+/**
+ * Typed teaching-content browse — Admin gap A1 closure (U2 of #2185, story #2204).
+ *
+ * Aggregates typed teaching content for the Course Content tab's bi-pane
+ * skeleton. Returns 5 groups of items keyed by intent kind:
+ *
+ *   - mcqs            — ContentQuestion rows (`questionType = MCQ`) for sources
+ *                       linked to this Playbook via PlaybookSource.
+ *   - cueCards        — `Playbook.config.modules[].settings.cueCardPool` rows
+ *                       (Part-2 monologue framings: { topic, bullets }).
+ *   - topicPrompts    — `Playbook.config.modules[].settings.topicPool` rows
+ *                       (per-topic question pools: { topic, questions[] }).
+ *   - scenarioProbes  — Reserved for future authoring. Empty list today —
+ *                       no DB shape on hf_sandbox / hf_staging carries these.
+ *   - reflectionPrompts — Reserved for future authoring. Empty list today.
+ *
+ * Provenance metadata is preserved per item so the RH detail pane can
+ * surface module-level / source-level filter chips and cascade-aware
+ * badges (e.g. "from module Mock", "from source CII R04 Syllabus").
+ *
+ * Skeleton scope (#2204): READ-ONLY. Editing actions live in follow-on
+ * stories.
+ *
+ * @api OPERATOR
+ */
+
+import { NextResponse } from "next/server";
+
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import { prisma } from "@/lib/prisma";
+import type { AuthoredModule, PlaybookConfig } from "@/lib/types/json-fields";
+
+export const runtime = "nodejs";
+
+export interface ModuleProvenance {
+  moduleId: string;
+  moduleLabel: string;
+}
+
+export interface SourceProvenance {
+  sourceId: string;
+  sourceName: string;
+}
+
+export interface McqItem {
+  id: string;
+  questionText: string;
+  source: SourceProvenance;
+  learningOutcomeRef: string | null;
+  difficulty: number | null;
+}
+
+export interface CueCardItem {
+  /** Synthetic id — `${moduleId}:cue:${index}` so the UI can key the row. */
+  id: string;
+  topic: string;
+  bullets: string[];
+  module: ModuleProvenance;
+}
+
+export interface TopicPromptItem {
+  id: string;
+  topic: string;
+  questions: string[];
+  module: ModuleProvenance;
+}
+
+export interface ScenarioProbeItem {
+  id: string;
+  prompt: string;
+  module: ModuleProvenance | null;
+}
+
+export interface ReflectionPromptItem {
+  id: string;
+  prompt: string;
+  module: ModuleProvenance | null;
+}
+
+export interface TypedContentResponse {
+  ok: true;
+  courseId: string;
+  groups: {
+    mcqs: McqItem[];
+    cueCards: CueCardItem[];
+    topicPrompts: TopicPromptItem[];
+    scenarioProbes: ScenarioProbeItem[];
+    reflectionPrompts: ReflectionPromptItem[];
+  };
+  modules: ModuleProvenance[];
+  sources: SourceProvenance[];
+}
+
+interface TypedContentError {
+  ok: false;
+  error: string;
+}
+
+/**
+ * @api GET /api/courses/:courseId/typed-content
+ * @visibility internal
+ * @scope courses:read
+ * @auth session (OPERATOR+)
+ * @description Aggregates typed teaching content (MCQs, cue cards, topic
+ *   prompts, scenario probes, reflection prompts) scoped to this Playbook.
+ *   Used by the Content tab's bi-pane skeleton (Admin gap A1 / #2204).
+ * @response 200 { ok: true, courseId, groups, modules, sources }
+ * @response 403 { ok: false, error: "Unauthorized" }
+ * @response 404 { ok: false, error: "Course not found" }
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ courseId: string }> },
+): Promise<NextResponse<TypedContentResponse | TypedContentError>> {
+  try {
+    const auth = await requireAuth("OPERATOR");
+    if (isAuthError(auth)) {
+      return auth.error as NextResponse<TypedContentError>;
+    }
+
+    const { courseId } = await params;
+    if (!courseId) {
+      return NextResponse.json(
+        { ok: false, error: "courseId is required" },
+        { status: 400 },
+      );
+    }
+
+    const playbook = await prisma.playbook.findUnique({
+      where: { id: courseId },
+      select: { id: true, config: true },
+    });
+    if (!playbook) {
+      return NextResponse.json(
+        { ok: false, error: "Course not found" },
+        { status: 404 },
+      );
+    }
+
+    const config = (playbook.config ?? {}) as PlaybookConfig;
+    const authoredModules: AuthoredModule[] = Array.isArray(config.modules)
+      ? (config.modules as AuthoredModule[])
+      : [];
+
+    const moduleProvenance: ModuleProvenance[] = authoredModules.map((m) => ({
+      moduleId: m.id,
+      moduleLabel: m.label ?? m.id,
+    }));
+
+    // Cue cards (Part-2 monologue framings) — drawn from each module's
+    // settings.cueCardPool. Synthetic id is module:cue:index.
+    const cueCards: CueCardItem[] = [];
+    for (const mod of authoredModules) {
+      const pool = mod.settings?.cueCardPool ?? [];
+      pool.forEach((card, idx) => {
+        cueCards.push({
+          id: `${mod.id}:cue:${idx}`,
+          topic: card.topic,
+          bullets: Array.isArray(card.bullets) ? card.bullets : [],
+          module: { moduleId: mod.id, moduleLabel: mod.label ?? mod.id },
+        });
+      });
+    }
+
+    // Topic prompts (Part-1 / Part-3 student-led drills) — drawn from each
+    // module's settings.topicPool.
+    const topicPrompts: TopicPromptItem[] = [];
+    for (const mod of authoredModules) {
+      const pool = mod.settings?.topicPool ?? [];
+      pool.forEach((row, idx) => {
+        topicPrompts.push({
+          id: `${mod.id}:topic:${idx}`,
+          topic: row.topic,
+          questions: Array.isArray(row.questions) ? row.questions : [],
+          module: { moduleId: mod.id, moduleLabel: mod.label ?? mod.id },
+        });
+      });
+    }
+
+    // Sources linked to this Playbook via PlaybookSource — used to scope
+    // ContentQuestion rows + populate the source-filter chip set.
+    const playbookSources = await prisma.playbookSource.findMany({
+      where: { playbookId: courseId },
+      select: {
+        sourceId: true,
+        source: { select: { id: true, name: true } },
+      },
+    });
+    const sourceIds = playbookSources
+      .map((ps) => ps.sourceId)
+      .filter((id): id is string => Boolean(id));
+    const sourceProvenance: SourceProvenance[] = playbookSources
+      .filter((ps) => ps.source != null)
+      .map((ps) => ({
+        sourceId: ps.source!.id,
+        sourceName: ps.source!.name,
+      }));
+
+    // MCQs scoped to this Playbook's linked sources.
+    const mcqs: McqItem[] =
+      sourceIds.length > 0
+        ? (
+            await prisma.contentQuestion.findMany({
+              where: {
+                sourceId: { in: sourceIds },
+                questionType: "MCQ",
+              },
+              select: {
+                id: true,
+                questionText: true,
+                learningOutcomeRef: true,
+                difficulty: true,
+                source: { select: { id: true, name: true } },
+              },
+              orderBy: { sortOrder: "asc" },
+              take: 500, // Skeleton cap — pagination is a follow-on story
+            })
+          ).map((q) => ({
+            id: q.id,
+            questionText: q.questionText,
+            learningOutcomeRef: q.learningOutcomeRef,
+            difficulty: q.difficulty,
+            source: {
+              sourceId: q.source.id,
+              sourceName: q.source.name,
+            },
+          }))
+        : [];
+
+    // Scenario probes + reflection prompts — reserved kinds with no DB
+    // shape today. Returning empty arrays keeps the contract stable
+    // when the future typed primitives land (#2009 / #2145 follow-ons).
+    const scenarioProbes: ScenarioProbeItem[] = [];
+    const reflectionPrompts: ReflectionPromptItem[] = [];
+
+    const response: TypedContentResponse = {
+      ok: true,
+      courseId,
+      groups: {
+        mcqs,
+        cueCards,
+        topicPrompts,
+        scenarioProbes,
+        reflectionPrompts,
+      },
+      modules: moduleProvenance,
+      sources: sourceProvenance,
+    };
+    return NextResponse.json(response);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/admin/app/x/courses/[courseId]/CourseContentTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseContentTab.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+/**
+ * CourseContentTab — Admin gap A1 closure (U2 of #2185, story #2204).
+ *
+ * Bi-pane operator surface for browsing the TYPED teaching content of a
+ * course — MCQ Bank / Cue Cards / Topic Prompts / Scenario Probes /
+ * Reflection Prompts. Mirrors the Modules tab's bi-pane pattern
+ * (LH intent groups → RHS detail) using `DesignerShell`.
+ *
+ * Distinct from the older `intelligence` tab, which surfaces flat
+ * source uploads + content breakdowns. This tab is intent-grouped by
+ * teaching-content kind, scoped to the typed primitives the Lattice
+ * has standardised on (ContentQuestion rows + AuthoredModule.settings
+ * sub-objects).
+ *
+ * Skeleton scope (#2204): READ-ONLY browse. Editing actions
+ * (add MCQ, edit cue card, regenerate topic pool) are out of scope and
+ * tracked under sibling stories in epic #2185.
+ *
+ * Data-driven: reads ContentQuestion (MCQ rows) + Playbook.config.modules
+ * cueCardPool/topicPool sub-objects via
+ * `/api/courses/[courseId]/typed-content`. No per-course hardcoding;
+ * adding a new course exercises this tab without UI changes.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { ContentDetailPanel } from "@/components/content-tab/ContentDetailPanel";
+import { ContentLhPicker } from "@/components/content-tab/ContentLhPicker";
+import "@/components/content-tab/content-tab.css";
+import {
+  CONTENT_KINDS,
+  type ContentKind,
+  type TypedContentPayload,
+} from "@/components/content-tab/types";
+import { DesignerShell } from "@/components/shared/designer-shell/DesignerShell";
+
+interface CourseContentTabProps {
+  courseId: string;
+}
+
+const FIRST_KIND: ContentKind = CONTENT_KINDS[0]?.kind ?? "mcqs";
+
+export function CourseContentTab({ courseId }: CourseContentTabProps) {
+  const [payload, setPayload] = useState<TypedContentPayload | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedKind, setSelectedKind] = useState<ContentKind>(FIRST_KIND);
+
+  useEffect(() => {
+    if (!courseId) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(`/api/courses/${courseId}/typed-content`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled) return;
+        if (data?.ok) {
+          setPayload({
+            courseId: data.courseId,
+            groups: data.groups,
+            modules: data.modules,
+            sources: data.sources,
+          });
+        } else {
+          setError(data?.error || "Failed to load content");
+          setPayload(null);
+        }
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : "Network error");
+        setPayload(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId]);
+
+  const handleSelect = useCallback((kind: ContentKind) => {
+    setSelectedKind(kind);
+  }, []);
+
+  const navContent = useMemo(() => {
+    if (loading || !payload) {
+      return (
+        <div className="hf-journey-lh" data-testid="hf-content-lh-loading">
+          <div className="hf-journey-lh-groups">
+            <div className="hf-card hf-card-compact">Loading content…</div>
+          </div>
+        </div>
+      );
+    }
+    return (
+      <ContentLhPicker
+        groups={payload.groups}
+        selectedKind={selectedKind}
+        onSelect={handleSelect}
+      />
+    );
+  }, [loading, payload, selectedKind, handleSelect]);
+
+  const canvasContent = useMemo(() => {
+    if (loading) {
+      return (
+        <div className="hf-empty" data-testid="hf-content-loading">
+          <h2 className="hf-section-title">Loading content…</h2>
+          <p className="hf-section-desc">
+            Reading typed teaching content from this course.
+          </p>
+        </div>
+      );
+    }
+    if (error) {
+      return (
+        <div
+          className="hf-banner hf-banner-error"
+          data-testid="hf-content-error"
+        >
+          Could not load content. {error}
+        </div>
+      );
+    }
+    if (!payload) {
+      return (
+        <div className="hf-empty" data-testid="hf-content-empty-payload">
+          <h2 className="hf-section-title">No content loaded</h2>
+          <p className="hf-section-desc">
+            The course has no readable content payload.
+          </p>
+        </div>
+      );
+    }
+    return (
+      <ContentDetailPanel
+        selectedKind={selectedKind}
+        groups={payload.groups}
+        modules={payload.modules}
+        sources={payload.sources}
+      />
+    );
+  }, [loading, error, payload, selectedKind]);
+
+  return (
+    <div data-testid="hf-course-content-tab">
+      <DesignerShell nav={navContent} canvas={canvasContent} />
+    </div>
+  );
+}

--- a/apps/admin/app/x/courses/[courseId]/_lib/tab-redirects.ts
+++ b/apps/admin/app/x/courses/[courseId]/_lib/tab-redirects.ts
@@ -57,7 +57,10 @@ export const LEGACY_TAB_REDIRECTS: Record<string, string> = {
   'session-flow': 'journey',
   // Pre-P5 aliases retained from CourseDesignTab era.
   genome: 'intelligence',
-  content: 'intelligence',
+  // NOTE: 'content' was previously redirected → 'intelligence' (Sources).
+  // As of #2204 (U2 of #2185) 'content' is a real tab id (Teaching Content
+  // skeleton). The redirect is removed so the new tab is reachable via the
+  // canonical ?tab=content URL.
 };
 
 /**

--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -28,6 +28,7 @@ import { CourseJourneyTab } from '@/components/journey-tab/CourseJourneyTab';
 import { CourseTeachingTab } from '@/components/teaching-tab/CourseTeachingTab';
 import { CourseScoringTab } from '@/components/scoring-tab/CourseScoringTab';
 import { CourseModulesTab } from '@/components/modules-tab/CourseModulesTab';
+import { CourseContentTab } from './CourseContentTab';
 import { CourseLearnersTab } from './CourseLearnersTab';
 import { CourseProofTab } from './CourseProofTab';
 import { SessionDetailPanel } from '@/components/shared/SessionDetailPanel';
@@ -454,7 +455,11 @@ export default function CourseDetailPage() {
     { id: 'teaching', label: <TabWithHelp tabId="teaching">Teaching</TabWithHelp>, icon: <Sliders size={14} /> },
     { id: 'scoring', label: <TabWithHelp tabId="scoring">Scoring</TabWithHelp>, icon: <Calculator size={14} /> },
     { id: 'modules', label: <TabWithHelp tabId="modules">Modules</TabWithHelp>, icon: <Layers size={14} /> },
-    { id: 'intelligence', label: <TabWithHelp tabId="intelligence">Content</TabWithHelp>, icon: <BookMarked size={14} />, count: totalSources || null },
+    // #2204 (U2 of #2185): Teaching Content tab — bi-pane browse of typed
+    // teaching content (MCQ Bank / Cue Cards / Topic Prompts / Scenario
+    // Probes / Reflection Prompts). Position AFTER Modules per the story.
+    { id: 'content', label: <TabWithHelp tabId="content">Teaching Content</TabWithHelp>, icon: <BookMarked size={14} /> },
+    { id: 'intelligence', label: <TabWithHelp tabId="intelligence">Sources</TabWithHelp>, icon: <BookMarked size={14} />, count: totalSources || null },
     // P5 (#1850): Design tab retired — every lens now lives on Journey /
     // Teaching / Scoring / Voice / Modules tabs. Legacy deep links flow
     // through `LEGACY_TAB_REDIRECTS` → 'journey'.
@@ -1833,6 +1838,13 @@ export default function CourseDetailPage() {
           onTabSwitch={handleCrossTabSwitch}
           playbookConfig={detail?.config as Record<string, unknown> | null | undefined}
         />
+      )}
+
+      {/* ═══════════════════════════════════════════════ */}
+      {/* TEACHING CONTENT TAB — #2204 (U2 of #2185)     */}
+      {/* ═══════════════════════════════════════════════ */}
+      {activeTab === 'content' && (
+        <CourseContentTab courseId={courseId!} />
       )}
 
       {/* ═══════════════════════════════════════════════ */}

--- a/apps/admin/components/content-tab/ContentDetailPanel.tsx
+++ b/apps/admin/components/content-tab/ContentDetailPanel.tsx
@@ -1,0 +1,438 @@
+"use client";
+
+/**
+ * ContentDetailPanel — RHS list of items for the selected ContentKind.
+ *
+ * Filter chips (per-Module, per-Source) narrow the list; cascade chips
+ * are surfaced inline so the operator can see provenance per row.
+ *
+ * Skeleton scope (#2204): read-only browse. Edit actions are out of
+ * scope (separate PR per umbrella #2185).
+ */
+
+import { useMemo, useState } from "react";
+
+import {
+  CONTENT_KINDS,
+  type ContentKind,
+  type CueCardItem,
+  type McqItem,
+  type ModuleProvenance,
+  type ReflectionPromptItem,
+  type ScenarioProbeItem,
+  type SourceProvenance,
+  type TopicPromptItem,
+  type TypedContentGroups,
+} from "./types";
+
+interface ContentDetailPanelProps {
+  selectedKind: ContentKind;
+  groups: TypedContentGroups;
+  modules: ModuleProvenance[];
+  sources: SourceProvenance[];
+}
+
+type ModuleFilter = string | null; // moduleId | null = all
+type SourceFilter = string | null; // sourceId | null = all
+
+export function ContentDetailPanel({
+  selectedKind,
+  groups,
+  modules,
+  sources,
+}: ContentDetailPanelProps) {
+  const [moduleFilter, setModuleFilter] = useState<ModuleFilter>(null);
+  const [sourceFilter, setSourceFilter] = useState<SourceFilter>(null);
+
+  const meta = CONTENT_KINDS.find((m) => m.kind === selectedKind);
+
+  // Per-kind filter axis — MCQs filter by source, the rest filter by module.
+  const filterAxis: "module" | "source" | "none" = useMemo(() => {
+    if (selectedKind === "mcqs") return "source";
+    if (selectedKind === "cueCards" || selectedKind === "topicPrompts") {
+      return "module";
+    }
+    return "none";
+  }, [selectedKind]);
+
+  // Derived filtered lists per kind.
+  const filteredMcqs = useMemo<McqItem[]>(() => {
+    if (selectedKind !== "mcqs") return [];
+    return groups.mcqs.filter(
+      (m) => sourceFilter == null || m.source.sourceId === sourceFilter,
+    );
+  }, [selectedKind, groups.mcqs, sourceFilter]);
+
+  const filteredCueCards = useMemo<CueCardItem[]>(() => {
+    if (selectedKind !== "cueCards") return [];
+    return groups.cueCards.filter(
+      (c) => moduleFilter == null || c.module.moduleId === moduleFilter,
+    );
+  }, [selectedKind, groups.cueCards, moduleFilter]);
+
+  const filteredTopicPrompts = useMemo<TopicPromptItem[]>(() => {
+    if (selectedKind !== "topicPrompts") return [];
+    return groups.topicPrompts.filter(
+      (t) => moduleFilter == null || t.module.moduleId === moduleFilter,
+    );
+  }, [selectedKind, groups.topicPrompts, moduleFilter]);
+
+  const filteredScenarioProbes = useMemo<ScenarioProbeItem[]>(
+    () => (selectedKind === "scenarioProbes" ? groups.scenarioProbes : []),
+    [selectedKind, groups.scenarioProbes],
+  );
+
+  const filteredReflectionPrompts = useMemo<ReflectionPromptItem[]>(
+    () =>
+      selectedKind === "reflectionPrompts" ? groups.reflectionPrompts : [],
+    [selectedKind, groups.reflectionPrompts],
+  );
+
+  const isEmpty = (() => {
+    switch (selectedKind) {
+      case "mcqs":
+        return filteredMcqs.length === 0;
+      case "cueCards":
+        return filteredCueCards.length === 0;
+      case "topicPrompts":
+        return filteredTopicPrompts.length === 0;
+      case "scenarioProbes":
+        return filteredScenarioProbes.length === 0;
+      case "reflectionPrompts":
+        return filteredReflectionPrompts.length === 0;
+    }
+  })();
+
+  const totalForKind = (() => {
+    switch (selectedKind) {
+      case "mcqs":
+        return groups.mcqs.length;
+      case "cueCards":
+        return groups.cueCards.length;
+      case "topicPrompts":
+        return groups.topicPrompts.length;
+      case "scenarioProbes":
+        return groups.scenarioProbes.length;
+      case "reflectionPrompts":
+        return groups.reflectionPrompts.length;
+    }
+  })();
+
+  return (
+    <div
+      className="hf-content-detail"
+      data-testid={`hf-content-detail-${selectedKind}`}
+    >
+      <header className="hf-content-detail-header">
+        <h2 className="hf-section-title">{meta?.label ?? selectedKind}</h2>
+        <p className="hf-section-desc">{meta?.description ?? ""}</p>
+      </header>
+
+      {filterAxis === "module" && modules.length > 0 ? (
+        <div
+          className="hf-content-filter-chips"
+          role="group"
+          aria-label="Filter by module"
+          data-testid="hf-content-filter-module"
+        >
+          <FilterChip
+            label="All modules"
+            isActive={moduleFilter == null}
+            onClick={() => setModuleFilter(null)}
+            testId="hf-content-chip-module-all"
+          />
+          {modules.map((m) => (
+            <FilterChip
+              key={m.moduleId}
+              label={m.moduleLabel}
+              isActive={moduleFilter === m.moduleId}
+              onClick={() => setModuleFilter(m.moduleId)}
+              testId={`hf-content-chip-module-${m.moduleId}`}
+            />
+          ))}
+        </div>
+      ) : null}
+
+      {filterAxis === "source" && sources.length > 0 ? (
+        <div
+          className="hf-content-filter-chips"
+          role="group"
+          aria-label="Filter by source"
+          data-testid="hf-content-filter-source"
+        >
+          <FilterChip
+            label="All sources"
+            isActive={sourceFilter == null}
+            onClick={() => setSourceFilter(null)}
+            testId="hf-content-chip-source-all"
+          />
+          {sources.map((s) => (
+            <FilterChip
+              key={s.sourceId}
+              label={s.sourceName}
+              isActive={sourceFilter === s.sourceId}
+              onClick={() => setSourceFilter(s.sourceId)}
+              testId={`hf-content-chip-source-${s.sourceId}`}
+            />
+          ))}
+        </div>
+      ) : null}
+
+      {isEmpty ? (
+        <EmptyState
+          kind={selectedKind}
+          totalForKind={totalForKind}
+          moduleFilter={moduleFilter}
+          sourceFilter={sourceFilter}
+          modules={modules}
+          sources={sources}
+        />
+      ) : (
+        <ul
+          className="hf-content-item-list"
+          data-testid="hf-content-item-list"
+        >
+          {selectedKind === "mcqs" &&
+            filteredMcqs.map((m) => (
+              <McqRow key={m.id} item={m} />
+            ))}
+          {selectedKind === "cueCards" &&
+            filteredCueCards.map((c) => (
+              <CueCardRow key={c.id} item={c} />
+            ))}
+          {selectedKind === "topicPrompts" &&
+            filteredTopicPrompts.map((t) => (
+              <TopicPromptRow key={t.id} item={t} />
+            ))}
+          {selectedKind === "scenarioProbes" &&
+            filteredScenarioProbes.map((s) => (
+              <ScenarioProbeRow key={s.id} item={s} />
+            ))}
+          {selectedKind === "reflectionPrompts" &&
+            filteredReflectionPrompts.map((r) => (
+              <ReflectionPromptRow key={r.id} item={r} />
+            ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+interface FilterChipProps {
+  label: string;
+  isActive: boolean;
+  onClick: () => void;
+  testId: string;
+}
+
+function FilterChip({ label, isActive, onClick, testId }: FilterChipProps) {
+  return (
+    <button
+      type="button"
+      className={`hf-content-chip ${isActive ? "hf-content-chip-active" : ""}`}
+      onClick={onClick}
+      data-testid={testId}
+      aria-pressed={isActive}
+    >
+      {label}
+    </button>
+  );
+}
+
+interface EmptyStateProps {
+  kind: ContentKind;
+  totalForKind: number;
+  moduleFilter: ModuleFilter;
+  sourceFilter: SourceFilter;
+  modules: ModuleProvenance[];
+  sources: SourceProvenance[];
+}
+
+function EmptyState({
+  kind,
+  totalForKind,
+  moduleFilter,
+  sourceFilter,
+  modules,
+  sources,
+}: EmptyStateProps) {
+  const meta = CONTENT_KINDS.find((m) => m.kind === kind);
+  // Distinguish "no data at all" from "filter hides everything".
+  const filterIsActive = moduleFilter != null || sourceFilter != null;
+  if (totalForKind === 0) {
+    return (
+      <div className="hf-empty" data-testid="hf-content-empty-no-data">
+        <h3 className="hf-section-title">No {meta?.label ?? "items"} yet</h3>
+        <p className="hf-section-desc">
+          No {meta?.label.toLowerCase() ?? "items"} have been authored for this
+          course. Author them via the course setup wizard, course-reference
+          upload, or the source authoring tools.
+        </p>
+      </div>
+    );
+  }
+  const filterLabel =
+    moduleFilter != null
+      ? modules.find((m) => m.moduleId === moduleFilter)?.moduleLabel
+      : sources.find((s) => s.sourceId === sourceFilter)?.sourceName;
+  return (
+    <div className="hf-empty" data-testid="hf-content-empty-filtered">
+      <h3 className="hf-section-title">Nothing in this filter</h3>
+      <p className="hf-section-desc">
+        {filterIsActive
+          ? `No ${meta?.label.toLowerCase() ?? "items"} match the filter "${filterLabel ?? "selected"}". Clear the filter to see all ${totalForKind} item${totalForKind === 1 ? "" : "s"}.`
+          : `No ${meta?.label.toLowerCase() ?? "items"} match.`}
+      </p>
+    </div>
+  );
+}
+
+function McqRow({ item }: { item: McqItem }) {
+  return (
+    <li className="hf-card hf-card-compact hf-content-row" data-testid={`hf-content-mcq-${item.id}`}>
+      <div className="hf-content-row-main">
+        <p className="hf-content-row-title">{item.questionText}</p>
+        <div className="hf-content-row-meta">
+          <ProvenanceChip
+            label="Source"
+            value={item.source.sourceName}
+            testId="hf-content-prov-source"
+          />
+          {item.learningOutcomeRef ? (
+            <ProvenanceChip
+              label="LO"
+              value={item.learningOutcomeRef}
+              testId="hf-content-prov-lo"
+            />
+          ) : null}
+          {item.difficulty != null ? (
+            <ProvenanceChip
+              label="Difficulty"
+              value={`L${item.difficulty}`}
+              testId="hf-content-prov-difficulty"
+            />
+          ) : null}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function CueCardRow({ item }: { item: CueCardItem }) {
+  return (
+    <li
+      className="hf-card hf-card-compact hf-content-row"
+      data-testid={`hf-content-cue-${item.id}`}
+    >
+      <div className="hf-content-row-main">
+        <p className="hf-content-row-title">{item.topic}</p>
+        {item.bullets.length > 0 ? (
+          <ul className="hf-content-bullets">
+            {item.bullets.map((b, i) => (
+              <li key={i}>{b}</li>
+            ))}
+          </ul>
+        ) : null}
+        <div className="hf-content-row-meta">
+          <ProvenanceChip
+            label="Module"
+            value={item.module.moduleLabel}
+            testId="hf-content-prov-module"
+          />
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function TopicPromptRow({ item }: { item: TopicPromptItem }) {
+  return (
+    <li
+      className="hf-card hf-card-compact hf-content-row"
+      data-testid={`hf-content-topic-${item.id}`}
+    >
+      <div className="hf-content-row-main">
+        <p className="hf-content-row-title">{item.topic}</p>
+        {item.questions.length > 0 ? (
+          <ul className="hf-content-bullets">
+            {item.questions.map((q, i) => (
+              <li key={i}>{q}</li>
+            ))}
+          </ul>
+        ) : null}
+        <div className="hf-content-row-meta">
+          <ProvenanceChip
+            label="Module"
+            value={item.module.moduleLabel}
+            testId="hf-content-prov-module"
+          />
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function ScenarioProbeRow({ item }: { item: ScenarioProbeItem }) {
+  return (
+    <li
+      className="hf-card hf-card-compact hf-content-row"
+      data-testid={`hf-content-scenario-${item.id}`}
+    >
+      <div className="hf-content-row-main">
+        <p className="hf-content-row-title">{item.prompt}</p>
+        {item.module ? (
+          <div className="hf-content-row-meta">
+            <ProvenanceChip
+              label="Module"
+              value={item.module.moduleLabel}
+              testId="hf-content-prov-module"
+            />
+          </div>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+function ReflectionPromptRow({ item }: { item: ReflectionPromptItem }) {
+  return (
+    <li
+      className="hf-card hf-card-compact hf-content-row"
+      data-testid={`hf-content-reflection-${item.id}`}
+    >
+      <div className="hf-content-row-main">
+        <p className="hf-content-row-title">{item.prompt}</p>
+        {item.module ? (
+          <div className="hf-content-row-meta">
+            <ProvenanceChip
+              label="Module"
+              value={item.module.moduleLabel}
+              testId="hf-content-prov-module"
+            />
+          </div>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+interface ProvenanceChipProps {
+  label: string;
+  value: string;
+  testId: string;
+}
+
+/**
+ * Inline provenance chip — surfaces the cascade source ("from Module",
+ * "from Source") on each row. Static styling today; future iterations
+ * can route through `<LayerBadge>` once the content kinds enter the
+ * cascade family registry.
+ */
+function ProvenanceChip({ label, value, testId }: ProvenanceChipProps) {
+  return (
+    <span className="hf-content-prov-chip" data-testid={testId}>
+      <span className="hf-content-prov-label">{label}</span>
+      <span className="hf-content-prov-value">{value}</span>
+    </span>
+  );
+}

--- a/apps/admin/components/content-tab/ContentLhPicker.tsx
+++ b/apps/admin/components/content-tab/ContentLhPicker.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+/**
+ * ContentLhPicker — LH intent-group picker for the Content tab.
+ *
+ * Renders one row per ContentKind (MCQ Bank / Cue Cards / Topic Prompts /
+ * Scenario Probes / Reflection Prompts) with a per-group item count.
+ * Click → setSelectedKind. Mirrors the ModulesLhPicker styling so the
+ * two tabs share a visual rhythm.
+ */
+
+import {
+  CONTENT_KINDS,
+  countItemsForKind,
+  type ContentKind,
+  type TypedContentGroups,
+} from "./types";
+
+interface ContentLhPickerProps {
+  groups: TypedContentGroups;
+  selectedKind: ContentKind;
+  onSelect: (kind: ContentKind) => void;
+}
+
+export function ContentLhPicker({
+  groups,
+  selectedKind,
+  onSelect,
+}: ContentLhPickerProps) {
+  return (
+    <div className="hf-journey-lh" data-testid="hf-content-lh-picker">
+      <div className="hf-journey-lh-groups">
+        {CONTENT_KINDS.map((meta) => {
+          const count = countItemsForKind(groups, meta.kind);
+          const isSelected = selectedKind === meta.kind;
+          return (
+            <button
+              key={meta.kind}
+              type="button"
+              className={`hf-content-lh-row ${isSelected ? "hf-selected" : ""}`}
+              onClick={() => onSelect(meta.kind)}
+              data-testid={`hf-content-lh-row-${meta.kind}`}
+              aria-pressed={isSelected}
+            >
+              <span className="hf-journey-bucket-label">{meta.label}</span>
+              <span className="hf-journey-bucket-count">{count}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/components/content-tab/content-tab.css
+++ b/apps/admin/components/content-tab/content-tab.css
@@ -1,0 +1,181 @@
+/* CourseContentTab — typed teaching-content browse (#2204 / U2 of #2185).
+ *
+ * Bi-pane shape: LH intent groups (mirrors `.hf-modules-lh-row`),
+ * RHS detail with filter chips + provenance chips per row.
+ * Tokens only — no hardcoded hex per `.claude/rules/ui-design-system.md`.
+ */
+
+.hf-content-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.hf-content-detail-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* LH intent-group rows. Mirrors `.hf-modules-lh-row` so the two
+ * sibling tabs share a rhythm. */
+.hf-content-lh-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 14px;
+  margin-bottom: 6px;
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 10px;
+  font-size: 13px;
+  text-align: left;
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease, transform 80ms ease;
+  position: relative;
+}
+.hf-content-lh-row:hover {
+  background: color-mix(in srgb, var(--accent-primary) 6%, var(--surface-primary));
+  border-color: color-mix(in srgb, var(--accent-primary) 28%, var(--border-default));
+}
+.hf-content-lh-row:active {
+  transform: translateY(1px);
+}
+.hf-content-lh-row.hf-selected {
+  background: color-mix(in srgb, var(--accent-primary) 10%, var(--surface-primary));
+  border-color: var(--accent-primary);
+  font-weight: 600;
+}
+.hf-content-lh-row.hf-selected::before {
+  content: "";
+  position: absolute;
+  left: -1px;
+  top: 8px;
+  bottom: 8px;
+  width: 3px;
+  background: var(--accent-primary);
+  border-radius: 2px;
+}
+.hf-content-lh-row .hf-journey-bucket-label {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.hf-content-lh-row .hf-journey-bucket-count {
+  font-size: 11px;
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--surface-secondary) 80%, transparent);
+  padding: 2px 8px;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+.hf-content-lh-row.hf-selected .hf-journey-bucket-count {
+  background: color-mix(in srgb, var(--accent-primary) 14%, var(--surface-primary));
+  color: var(--accent-primary);
+}
+
+/* Filter chip row — per-Module / per-Source chips above the item list. */
+.hf-content-filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.hf-content-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  font-size: 12px;
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+.hf-content-chip:hover {
+  background: color-mix(in srgb, var(--accent-primary) 6%, var(--surface-primary));
+}
+.hf-content-chip-active {
+  background: color-mix(in srgb, var(--accent-primary) 12%, var(--surface-primary));
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+  font-weight: 600;
+}
+
+/* Item list — stacked cards. */
+.hf-content-item-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.hf-content-row {
+  display: flex;
+  gap: 12px;
+}
+
+.hf-content-row-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.hf-content-row-title {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+  margin: 0;
+  word-break: break-word;
+}
+
+.hf-content-bullets {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--text-muted);
+  font-size: 13px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.hf-content-row-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+/* Provenance chip — inline metadata badge (Module / Source / LO / …).
+ * Visually distinct from the filter chip — sits inside each row card. */
+.hf-content-prov-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 10px;
+  border-radius: 999px;
+  background: var(--surface-secondary);
+  border: 1px solid var(--border-default);
+  font-size: 11px;
+  color: var(--text-primary);
+}
+
+.hf-content-prov-label {
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 10px;
+}
+
+.hf-content-prov-value {
+  font-weight: 500;
+}

--- a/apps/admin/components/content-tab/types.ts
+++ b/apps/admin/components/content-tab/types.ts
@@ -1,0 +1,127 @@
+/**
+ * Shared types for the Content tab skeleton (#2204 / U2 of #2185).
+ *
+ * Mirrors the response shape of GET /api/courses/[courseId]/typed-content.
+ * Kept in a sibling file so the tab + LH picker + detail panel + vitest
+ * all read the same definition without importing from the route module
+ * (server-only).
+ */
+
+export type ContentKind =
+  | "mcqs"
+  | "cueCards"
+  | "topicPrompts"
+  | "scenarioProbes"
+  | "reflectionPrompts";
+
+export interface ModuleProvenance {
+  moduleId: string;
+  moduleLabel: string;
+}
+
+export interface SourceProvenance {
+  sourceId: string;
+  sourceName: string;
+}
+
+export interface McqItem {
+  id: string;
+  questionText: string;
+  source: SourceProvenance;
+  learningOutcomeRef: string | null;
+  difficulty: number | null;
+}
+
+export interface CueCardItem {
+  id: string;
+  topic: string;
+  bullets: string[];
+  module: ModuleProvenance;
+}
+
+export interface TopicPromptItem {
+  id: string;
+  topic: string;
+  questions: string[];
+  module: ModuleProvenance;
+}
+
+export interface ScenarioProbeItem {
+  id: string;
+  prompt: string;
+  module: ModuleProvenance | null;
+}
+
+export interface ReflectionPromptItem {
+  id: string;
+  prompt: string;
+  module: ModuleProvenance | null;
+}
+
+export interface TypedContentGroups {
+  mcqs: McqItem[];
+  cueCards: CueCardItem[];
+  topicPrompts: TopicPromptItem[];
+  scenarioProbes: ScenarioProbeItem[];
+  reflectionPrompts: ReflectionPromptItem[];
+}
+
+export interface TypedContentPayload {
+  courseId: string;
+  groups: TypedContentGroups;
+  modules: ModuleProvenance[];
+  sources: SourceProvenance[];
+}
+
+/** Display metadata for the LH intent groups. Source-of-truth for labels. */
+export interface ContentKindMeta {
+  kind: ContentKind;
+  label: string;
+  description: string;
+}
+
+export const CONTENT_KINDS: ContentKindMeta[] = [
+  {
+    kind: "mcqs",
+    label: "MCQ Bank",
+    description: "Multiple-choice items linked from course content sources.",
+  },
+  {
+    kind: "cueCards",
+    label: "Cue Cards",
+    description: "Part-2 monologue framings — topic + bullets per module.",
+  },
+  {
+    kind: "topicPrompts",
+    label: "Topic Prompts",
+    description: "Per-topic question pools for student-led practice.",
+  },
+  {
+    kind: "scenarioProbes",
+    label: "Scenario Probes",
+    description: "Reserved for future scenario-based teaching content.",
+  },
+  {
+    kind: "reflectionPrompts",
+    label: "Reflection Prompts",
+    description: "Reserved for future reflection-cue authoring.",
+  },
+];
+
+export function countItemsForKind(
+  groups: TypedContentGroups,
+  kind: ContentKind,
+): number {
+  switch (kind) {
+    case "mcqs":
+      return groups.mcqs.length;
+    case "cueCards":
+      return groups.cueCards.length;
+    case "topicPrompts":
+      return groups.topicPrompts.length;
+    case "scenarioProbes":
+      return groups.scenarioProbes.length;
+    case "reflectionPrompts":
+      return groups.reflectionPrompts.length;
+  }
+}

--- a/apps/admin/lib/help/page-help.ts
+++ b/apps/admin/lib/help/page-help.ts
@@ -151,8 +151,20 @@ export const PAGE_HELP_REGISTRY: readonly PageHelp[] = [
           "When you want to retune a specific module's behaviour without affecting the rest of the course.",
       },
       {
+        // #2204 (U2 of #2185) — bi-pane browse of typed teaching content.
+        id: "content",
+        label: "Teaching Content",
+        about:
+          "Browse the typed teaching content the AI tutor uses — MCQ bank, cue cards, topic prompts, scenario probes, reflection prompts — grouped by intent kind.",
+        whenToUse:
+          "When you want to see exactly what items the AI has available to draw from, filtered by module or source.",
+      },
+      {
         id: "intelligence",
-        label: "Content",
+        // #2204 — relabelled from "Content" to "Sources" to make space for
+        // the Teaching Content tab. Same underlying surface (uploads +
+        // extracted assertions); the label clarifies its scope.
+        label: "Sources",
         about: "Source files and the extracted assertions that drive what the AI teaches.",
         whenToUse: "When you want to add new material or check what the AI has actually learned from your uploads.",
       },

--- a/apps/admin/tests/components/admin/CourseContentTab.test.tsx
+++ b/apps/admin/tests/components/admin/CourseContentTab.test.tsx
@@ -1,0 +1,333 @@
+/**
+ * Tests for the Content tab skeleton (#2204 / U2 of #2185).
+ *
+ * Pins:
+ *  1. The tab mounts with mock typed-content data and renders the LH
+ *     intent groups (MCQ Bank / Cue Cards / Topic Prompts / Scenario
+ *     Probes / Reflection Prompts) with per-group counts.
+ *  2. Clicking an LH group switches the RHS detail to that kind's items.
+ *  3. Filter chips (module + source) narrow the RHS list.
+ *  4. Empty states render distinctly when (a) the kind has no data and
+ *     (b) the active filter hides every item.
+ */
+
+import React from "react";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import {
+  render,
+  screen,
+  waitFor,
+  fireEvent,
+  cleanup,
+} from "@testing-library/react";
+
+// jsdom doesn't ship matchMedia; the DesignerShell that CourseContentTab
+// composes relies on it for the narrow-viewport drawer behaviour. Stub
+// once for the whole file. Mirrors the pattern in
+// `tests/components/designer-shell.test.tsx`.
+beforeAll(() => {
+  if (typeof window !== "undefined" && !window.matchMedia) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: () => ({
+        matches: false,
+        media: "",
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+});
+
+import { CourseContentTab } from "@/app/x/courses/[courseId]/CourseContentTab";
+
+const COURSE_ID = "course-content-1";
+
+function makePayload() {
+  return {
+    ok: true,
+    courseId: COURSE_ID,
+    groups: {
+      mcqs: [
+        {
+          id: "mcq-1",
+          questionText: "What is the capital of France?",
+          source: { sourceId: "src-a", sourceName: "Source A" },
+          learningOutcomeRef: "LO-1",
+          difficulty: 2,
+        },
+        {
+          id: "mcq-2",
+          questionText: "What is 2 + 2?",
+          source: { sourceId: "src-b", sourceName: "Source B" },
+          learningOutcomeRef: null,
+          difficulty: 1,
+        },
+      ],
+      cueCards: [
+        {
+          id: "mod-1:cue:0",
+          topic: "Describe a memorable trip",
+          bullets: ["where you went", "who you were with", "what you did"],
+          module: { moduleId: "mod-1", moduleLabel: "Part 2 Monologue" },
+        },
+        {
+          id: "mod-2:cue:0",
+          topic: "Describe a hobby",
+          bullets: ["how you started", "why you enjoy it"],
+          module: { moduleId: "mod-2", moduleLabel: "Practice Set" },
+        },
+      ],
+      topicPrompts: [
+        {
+          id: "mod-1:topic:0",
+          topic: "Travel",
+          questions: ["How often do you travel?", "Where would you go next?"],
+          module: { moduleId: "mod-1", moduleLabel: "Part 2 Monologue" },
+        },
+      ],
+      scenarioProbes: [],
+      reflectionPrompts: [],
+    },
+    modules: [
+      { moduleId: "mod-1", moduleLabel: "Part 2 Monologue" },
+      { moduleId: "mod-2", moduleLabel: "Practice Set" },
+    ],
+    sources: [
+      { sourceId: "src-a", sourceName: "Source A" },
+      { sourceId: "src-b", sourceName: "Source B" },
+    ],
+  };
+}
+
+function makeEmptyPayload() {
+  return {
+    ok: true,
+    courseId: COURSE_ID,
+    groups: {
+      mcqs: [],
+      cueCards: [],
+      topicPrompts: [],
+      scenarioProbes: [],
+      reflectionPrompts: [],
+    },
+    modules: [],
+    sources: [],
+  };
+}
+
+describe("<CourseContentTab> — Content tab skeleton (#2204)", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    cleanup();
+  });
+
+  function mockFetch(payload: unknown) {
+    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      const u = url.toString();
+      if (u.includes("/typed-content")) {
+        return new Response(JSON.stringify(payload), { status: 200 });
+      }
+      throw new Error(`Unmocked fetch: ${u}`);
+    }) as unknown as typeof fetch;
+  }
+
+  it("mounts with mock data and renders all 5 LH intent groups with counts", async () => {
+    mockFetch(makePayload());
+    render(<CourseContentTab courseId={COURSE_ID} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hf-content-lh-picker")).toBeDefined();
+    });
+
+    // Five intent groups present.
+    expect(screen.getByTestId("hf-content-lh-row-mcqs")).toBeDefined();
+    expect(screen.getByTestId("hf-content-lh-row-cueCards")).toBeDefined();
+    expect(screen.getByTestId("hf-content-lh-row-topicPrompts")).toBeDefined();
+    expect(
+      screen.getByTestId("hf-content-lh-row-scenarioProbes"),
+    ).toBeDefined();
+    expect(
+      screen.getByTestId("hf-content-lh-row-reflectionPrompts"),
+    ).toBeDefined();
+
+    // Counts surface correctly.
+    const mcqRow = screen.getByTestId("hf-content-lh-row-mcqs");
+    expect(mcqRow.textContent).toContain("MCQ Bank");
+    expect(mcqRow.textContent).toContain("2");
+
+    const cueRow = screen.getByTestId("hf-content-lh-row-cueCards");
+    expect(cueRow.textContent).toContain("Cue Cards");
+    expect(cueRow.textContent).toContain("2");
+
+    const scenarioRow = screen.getByTestId("hf-content-lh-row-scenarioProbes");
+    expect(scenarioRow.textContent).toContain("0");
+  });
+
+  it("defaults to MCQ Bank on first mount", async () => {
+    mockFetch(makePayload());
+    render(<CourseContentTab courseId={COURSE_ID} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hf-content-detail-mcqs")).toBeDefined();
+    });
+
+    // First MCQ rendered.
+    expect(screen.getByTestId("hf-content-mcq-mcq-1")).toBeDefined();
+    expect(screen.getByTestId("hf-content-mcq-mcq-2")).toBeDefined();
+  });
+
+  it("clicking an LH group switches the RHS detail content", async () => {
+    mockFetch(makePayload());
+    render(<CourseContentTab courseId={COURSE_ID} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hf-content-detail-mcqs")).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByTestId("hf-content-lh-row-cueCards"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hf-content-detail-cueCards")).toBeDefined();
+    });
+
+    // RHS now shows cue-card rows, not MCQ rows.
+    expect(screen.getByTestId("hf-content-cue-mod-1:cue:0")).toBeDefined();
+    expect(screen.queryByTestId("hf-content-mcq-mcq-1")).toBeNull();
+  });
+
+  it("renders source filter chips on MCQ Bank and narrows the list when one is active", async () => {
+    mockFetch(makePayload());
+    render(<CourseContentTab courseId={COURSE_ID} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hf-content-detail-mcqs")).toBeDefined();
+    });
+
+    // Source chip group present.
+    expect(screen.getByTestId("hf-content-filter-source")).toBeDefined();
+    expect(screen.getByTestId("hf-content-chip-source-all")).toBeDefined();
+    expect(screen.getByTestId("hf-content-chip-source-src-a")).toBeDefined();
+
+    // Click Source A chip; only Source A MCQs should remain.
+    fireEvent.click(screen.getByTestId("hf-content-chip-source-src-a"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hf-content-mcq-mcq-1")).toBeDefined();
+    });
+    expect(screen.queryByTestId("hf-content-mcq-mcq-2")).toBeNull();
+  });
+
+  it("renders module filter chips on Cue Cards and narrows the list when one is active", async () => {
+    mockFetch(makePayload());
+    render(<CourseContentTab courseId={COURSE_ID} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hf-content-detail-mcqs")).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByTestId("hf-content-lh-row-cueCards"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hf-content-filter-module")).toBeDefined();
+    });
+
+    expect(screen.getByTestId("hf-content-chip-module-all")).toBeDefined();
+    expect(screen.getByTestId("hf-content-chip-module-mod-1")).toBeDefined();
+
+    // Filter to mod-1 only.
+    fireEvent.click(screen.getByTestId("hf-content-chip-module-mod-1"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hf-content-cue-mod-1:cue:0")).toBeDefined();
+    });
+    expect(screen.queryByTestId("hf-content-cue-mod-2:cue:0")).toBeNull();
+  });
+
+  it("renders the no-data empty state when no items exist for the selected kind", async () => {
+    mockFetch(makePayload());
+    render(<CourseContentTab courseId={COURSE_ID} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hf-content-lh-picker")).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByTestId("hf-content-lh-row-scenarioProbes"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hf-content-empty-no-data")).toBeDefined();
+    });
+  });
+
+  it("renders the filtered-empty state when an active filter hides every item", async () => {
+    // Payload: one MCQ tied to src-a only — filtering by src-b empties the list.
+    const payload = makePayload();
+    payload.groups.mcqs = [
+      {
+        id: "mcq-only-a",
+        questionText: "Source A only question",
+        source: { sourceId: "src-a", sourceName: "Source A" },
+        learningOutcomeRef: null,
+        // null here would type-narrow against the makePayload literal —
+        // use a real number so the array shape matches verbatim.
+        difficulty: 1,
+      },
+    ];
+    mockFetch(payload);
+    render(<CourseContentTab courseId={COURSE_ID} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hf-content-detail-mcqs")).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByTestId("hf-content-chip-source-src-b"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hf-content-empty-filtered")).toBeDefined();
+    });
+  });
+
+  it("renders an overall empty state when the course has zero content of any kind", async () => {
+    mockFetch(makeEmptyPayload());
+    render(<CourseContentTab courseId={COURSE_ID} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hf-content-detail-mcqs")).toBeDefined();
+    });
+
+    expect(screen.getByTestId("hf-content-empty-no-data")).toBeDefined();
+  });
+
+  it("renders the error banner when the route returns ok: false", async () => {
+    global.fetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({ ok: false, error: "Course not found" }),
+        { status: 404 },
+      );
+    }) as unknown as typeof fetch;
+
+    render(<CourseContentTab courseId={COURSE_ID} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hf-content-error")).toBeDefined();
+    });
+  });
+});

--- a/apps/admin/tests/components/courses/course-tab-redirects.test.ts
+++ b/apps/admin/tests/components/courses/course-tab-redirects.test.ts
@@ -37,9 +37,16 @@ describe('resolveInitialTab — P5 (#1850) Design tab retirement', () => {
     expect(resolveInitialTab('session-flow')).toBe('journey');
   });
 
-  it('legacy aliases genome / content land on Content (intelligence)', () => {
+  it('legacy alias genome lands on Sources (intelligence)', () => {
     expect(resolveInitialTab('genome')).toBe('intelligence');
-    expect(resolveInitialTab('content')).toBe('intelligence');
+  });
+
+  // #2204 (U2 of #2185) — 'content' is now a real tab id (Teaching
+  // Content skeleton). The legacy redirect ?tab=content → intelligence
+  // was removed; ?tab=content passes through to the new tab.
+  it("'content' is no longer a legacy alias — passes through to the Teaching Content tab", () => {
+    expect(LEGACY_TAB_REDIRECTS.content).toBeUndefined();
+    expect(resolveInitialTab('content')).toBe('content');
   });
 });
 

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -10181,6 +10181,29 @@ Aggregates prompt staleness across every demo caller
 
 ---
 
+### `GET` /api/courses/:courseId/typed-content
+
+Aggregates typed teaching content (MCQs, cue cards, topic
+
+**Auth**: session (OPERATOR+) · **Scope**: `courses:read`
+
+**Response** `200`
+```json
+{ ok: true, courseId, groups, modules, sources }
+```
+
+**Response** `403`
+```json
+{ ok: false, error: "Unauthorized" }
+```
+
+**Response** `404`
+```json
+{ ok: false, error: "Course not found" }
+```
+
+---
+
 ### `GET` /api/courses/[courseId]/classrooms
 
 List all classrooms (cohort groups) assigned to a course (playbook).
@@ -16364,8 +16387,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 542 |
-| Files with annotations | 528 |
+| Route files found | 543 |
+| Files with annotations | 529 |
 | Files missing annotations | 14 |
 | Coverage | 97.4% |
 

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-21T15:43:12.911Z",
+  "generatedAt": "2026-06-21T16:15:25.523Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1873,
-  "edgeCount": 4411,
+  "fileCount": 1880,
+  "edgeCount": 4419,
   "skippedEdges": 1,
   "edges": [
     {
@@ -3730,6 +3730,18 @@
     {
       "from": "app/api/courses/[courseId]/test-learner/route.ts",
       "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/typed-content/route.ts",
+      "to": "lib/permissions.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/typed-content/route.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
+      "from": "app/api/courses/[courseId]/typed-content/route.ts",
+      "to": "lib/types/json-fields.ts"
     },
     {
       "from": "app/api/courses/route.ts",
@@ -8832,6 +8844,26 @@
       "to": "app/x/courses/[courseId]/cohort-progress.css"
     },
     {
+      "from": "app/x/courses/[courseId]/CourseContentTab.tsx",
+      "to": "components/content-tab/content-tab.css"
+    },
+    {
+      "from": "app/x/courses/[courseId]/CourseContentTab.tsx",
+      "to": "components/content-tab/ContentDetailPanel.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/CourseContentTab.tsx",
+      "to": "components/content-tab/ContentLhPicker.tsx"
+    },
+    {
+      "from": "app/x/courses/[courseId]/CourseContentTab.tsx",
+      "to": "components/content-tab/types.ts"
+    },
+    {
+      "from": "app/x/courses/[courseId]/CourseContentTab.tsx",
+      "to": "components/shared/designer-shell/DesignerShell.tsx"
+    },
+    {
       "from": "app/x/courses/[courseId]/CourseCurriculumTab.tsx",
       "to": "app/x/courses/[courseId]/_components/AuthoredModulesPanel.tsx"
     },
@@ -9062,6 +9094,10 @@
     {
       "from": "app/x/courses/[courseId]/page.tsx",
       "to": "app/x/courses/[courseId]/course-learners.css"
+    },
+    {
+      "from": "app/x/courses/[courseId]/page.tsx",
+      "to": "app/x/courses/[courseId]/CourseContentTab.tsx"
     },
     {
       "from": "app/x/courses/[courseId]/page.tsx",
@@ -16984,10 +17020,6 @@
       "to": "lib/types/json-fields.ts"
     },
     {
-      "from": "lib/wizard/detect-module-settings.ts",
-      "to": "lib/types/json-fields.ts"
-    },
-    {
       "from": "lib/wizard/enum-sets.ts",
       "to": "lib/content-trust/resolve-config.ts"
     },
@@ -18820,6 +18852,11 @@
     },
     {
       "path": "app/api/courses/[courseId]/test-learner/route.ts",
+      "inDegree": 0,
+      "outDegree": 3
+    },
+    {
+      "path": "app/api/courses/[courseId]/typed-content/route.ts",
       "inDegree": 0,
       "outDegree": 3
     },
@@ -20839,6 +20876,11 @@
       "outDegree": 1
     },
     {
+      "path": "app/x/courses/[courseId]/CourseContentTab.tsx",
+      "inDegree": 1,
+      "outDegree": 5
+    },
+    {
       "path": "app/x/courses/[courseId]/CourseCurriculumTab.tsx",
       "inDegree": 1,
       "outDegree": 4
@@ -21026,7 +21068,7 @@
     {
       "path": "app/x/courses/[courseId]/page.tsx",
       "inDegree": 0,
-      "outDegree": 50
+      "outDegree": 51
     },
     {
       "path": "app/x/courses/[courseId]/sessions/[sessionNum]/page.tsx",
@@ -22129,6 +22171,26 @@
       "outDegree": 0
     },
     {
+      "path": "components/content-tab/ContentDetailPanel.tsx",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "components/content-tab/ContentLhPicker.tsx",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "components/content-tab/content-tab.css",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "components/content-tab/types.ts",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
       "path": "components/course-design/ModuleVisibilitySettings.tsx",
       "inDegree": 1,
       "outDegree": 0
@@ -22680,6 +22742,11 @@
     },
     {
       "path": "components/shared/category-treemap.css",
+      "inDegree": 1,
+      "outDegree": 0
+    },
+    {
+      "path": "components/shared/designer-shell/DesignerShell.tsx",
       "inDegree": 1,
       "outDegree": 0
     },
@@ -25020,7 +25087,7 @@
     },
     {
       "path": "lib/permissions.ts",
-      "inDegree": 473,
+      "inDegree": 474,
       "outDegree": 3
     },
     {
@@ -25205,7 +25272,7 @@
     },
     {
       "path": "lib/prisma.ts",
-      "inDegree": 678,
+      "inDegree": 679,
       "outDegree": 0
     },
     {
@@ -26261,7 +26328,7 @@
     {
       "path": "lib/wizard/detect-module-settings.ts",
       "inDegree": 2,
-      "outDegree": 2
+      "outDegree": 1
     },
     {
       "path": "lib/wizard/detect-pedagogy.ts",
@@ -27022,12 +27089,12 @@
   "highCoupling": [
     {
       "path": "lib/prisma.ts",
-      "inDegree": 678,
+      "inDegree": 679,
       "outDegree": 0
     },
     {
       "path": "lib/permissions.ts",
-      "inDegree": 473,
+      "inDegree": 474,
       "outDegree": 3
     },
     {
@@ -27063,7 +27130,7 @@
     {
       "path": "app/x/courses/[courseId]/page.tsx",
       "inDegree": 0,
-      "outDegree": 50
+      "outDegree": 51
     },
     {
       "path": "lib/prompt/composition/types.ts",

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-21T15:43:13.489Z",
+  "generatedAt": "2026-06-21T16:15:26.326Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-21T15:43:11.342Z",
+  "generatedAt": "2026-06-21T16:15:22.991Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-21T15:43:14.118Z",
+  "generatedAt": "2026-06-21T16:15:27.204Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/parameter-inventory.json
+++ b/docs/kb/generated/parameter-inventory.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-21T15:43:16.320Z",
+  "generatedAt": "2026-06-21T16:15:30.446Z",
   "generator": "scripts/capture/parameter-inventory.ts",
   "parameterCount": 155,
   "active": 140,

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,16 +1,16 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-21T15:43:12.018Z",
+  "generatedAt": "2026-06-21T16:15:24.117Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {
-    "routeCount": 542,
+    "routeCount": 543,
     "byAuthLevel": {
       "VIEWER": 127,
       "ADMIN": 81,
       "SUPERADMIN": 9,
       "VIEWER+ADMIN": 5,
-      "OPERATOR": 145,
+      "OPERATOR": 146,
       "OPERATOR+VIEWER": 8,
       "VIEWER+OPERATOR": 66,
       "auth-gate(non-role)": 53,
@@ -4652,6 +4652,26 @@
         "handlesInternalSecret": false,
         "rawPrisma": true,
         "possiblyUnscoped": true,
+        "noAuthGate": false
+      },
+      "reviewed": false
+    },
+    {
+      "route": "/api/courses/[courseId]/typed-content",
+      "file": "apps/admin/app/api/courses/[courseId]/typed-content/route.ts",
+      "methods": [
+        "GET"
+      ],
+      "authLevels": [
+        "OPERATOR"
+      ],
+      "hasAuthGate": true,
+      "tenantSignals": {
+        "acceptsCallerIdParam": false,
+        "usesScopeHelper": false,
+        "handlesInternalSecret": false,
+        "rawPrisma": true,
+        "possiblyUnscoped": false,
         "noAuthGate": false
       },
       "reviewed": false


### PR DESCRIPTION
## Summary

- Closes Admin gaps **A1** (no Content tab on Course Detail) and **A3** (no source-ref-status surface) from the UI Gap Zero umbrella **#2185**.
- New **Teaching Content** tab on Course Detail, positioned after Modules. Bi-pane via `DesignerShell`: LH intent groups (MCQ Bank / Cue Cards / Topic Prompts / Scenario Probes / Reflection Prompts) with per-group counts; RHS filterable list with provenance chips per row.
- Read-only skeleton. Editing actions are out of scope per #2185 (separate per-kind follow-ons).

## Architecture

- New read-only endpoint `GET /api/courses/:courseId/typed-content` aggregates `ContentQuestion(MCQ)` rows (scoped via `PlaybookSource`) and `AuthoredModule.settings.cueCardPool` / `.topicPool` sub-objects. Scenario Probes + Reflection Prompts return empty arrays today; they clear when their typed primitives land.
- Component layout mirrors the Modules tab pattern (PRs #2120 / #2121): `CourseContentTab` + `ContentLhPicker` + `ContentDetailPanel` + paired `content-tab.css`. All `hf-*` classes; no inline styles; no hex.
- Data-driven: zero per-course hardcoding. New courses exercise the tab without UI changes.
- Legacy `intelligence` tab is relabelled "Sources" to disambiguate. Legacy redirect `content → intelligence` is removed so the canonical `?tab=content` URL reaches the new tab. Sibling redirects test updated to pin the new semantics.

## Sibling stories closed

- #2185 (umbrella) — instance U2 advances the Admin tab gap-count by 2 (A1 + A3).
- Other instance stories (#2202, #2205, etc.) own their respective tabs / inspectors.

## Verified by

- `npx tsc --noEmit` — **38 errors** (= baseline 39, -1 improvement). [verified]
- `npx vitest run tests/components/admin/CourseContentTab.test.tsx` — **9/9 pass** (mount + LH switching + module filter + source filter + no-data empty + filtered-empty + zero-content + error banner). [verified]
- `npx vitest run tests/components/courses/course-tab-redirects.test.ts` — **13/13 pass** (updated for the new `content` tab semantics). [verified]
- `npm run kb:check` — KB regen captured the new route + relabelled tab (`route-inventory` 542 → 543); committed alongside. [verified]
- Lattice survey:
  - Surface: new Admin tab + new read-only API route.
  - Sibling-writer drift: N/A — read-only, no shared-column mutation. [verified]
  - Default-deny gates: N/A — no `prisma.<X>.{create|update|upsert}` writes; auth gate is `requireAuth("OPERATOR")`. [verified]
  - Cascade respect: N/A — no cascade-eligible knob introduced. [verified]
  - Convention conflict: `content` tab id was previously a legacy redirect → `intelligence`; explicitly retired with the existing test updated. [verified]
- No new ESLint chokepoint required — route is read-only, no AI / write path touched.

## Test plan

- [ ] On `dev.humanfirstfoundation.com` after deploy, open any course's detail page; verify the **Teaching Content** tab appears between Modules and Sources.
- [ ] Visit `?tab=content` directly — lands on the new tab (not the Sources tab).
- [ ] LH groups display non-zero counts where data exists (IELTS Speaking Practice should show populated Cue Cards + Topic Prompts).
- [ ] Click an LH group; RHS list switches to that kind's items.
- [ ] On MCQ Bank: source filter chips narrow the list; "All sources" chip restores it.
- [ ] On Cue Cards / Topic Prompts: module filter chips narrow the list; "All modules" chip restores it.
- [ ] On Scenario Probes / Reflection Prompts: the no-data empty state renders with operator guidance copy.
- [ ] When a filter hides every row, the filtered-empty state renders (distinct copy).
- [ ] Visit the Sources tab — content unchanged from previous (only the label moved from "Content" → "Sources").

🤖 Generated with [Claude Code](https://claude.com/claude-code)