### PR TITLE
feat(admin): S2 — LLM IELTS Scoring toggle on Course Scoring tab + cascade chip

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/CourseSkillsTab.tsx
+++ b/apps/admin/app/x/courses/[courseId]/CourseSkillsTab.tsx
@@ -22,6 +22,7 @@ import {
 import { tierLabel } from "@/lib/banding/tier-colors";
 import { CascadeValue } from "@/components/shared/CascadeValue";
 import { CascadeInspectorTray } from "@/components/cascade/CascadeInspectorTray";
+import { useEffectiveValue } from "@/lib/cascade/use-effective-value";
 import { BandingPicker } from "@/components/shared/BandingPicker";
 import { VariantPresetPill } from "@/components/shared/VariantPresetPill";
 import type { Effective } from "@/lib/cascade/layer-types";
@@ -1075,6 +1076,9 @@ function RubricCalibrationLens({ courseId }: { courseId: string }) {
 // Replaces the retired `HF_IELTS_LLM_MEASURE_V1` env flag.
 // ────────────────────────────────────────────────────────────
 
+const AI_MEASUREMENT_DISABLE_LLM_KNOB =
+  "aiMeasurement.disableLlmIeltsScoring";
+
 function AiMeasurementMethodSection({
   courseId,
   aiMeasurement,
@@ -1092,6 +1096,18 @@ function AiMeasurementMethodSection({
   // /api/courses/[courseId]/design (#2158 design route extension).
   const [disabled, setDisabled] = useState(
     aiMeasurement.disableLlmIeltsScoring,
+  );
+  const [tray, setTray] = useState<boolean>(false);
+
+  // Cascade-honesty (Story #2206 S2 / epic #2185): route the toggle
+  // through `useEffectiveValue` → `<CascadeValue>` + `<LayerBadge>`
+  // per `.claude/rules/cascade-reuse.md`. The chip surfaces provenance
+  // so a Domain-level override (institution-wide flip) is auditable
+  // rather than silent. Snapshot fallback when the knob is not
+  // resolvable (e.g., feature-flag off in older deploys).
+  const { envelope, unresolvable } = useEffectiveValue<boolean | null>(
+    AI_MEASUREMENT_DISABLE_LLM_KNOB,
+    { courseId },
   );
 
   const llmActive = !disabled;
@@ -1149,12 +1165,29 @@ function AiMeasurementMethodSection({
       </header>
       <div className="hf-card-compact">
         <div className="hf-flex hf-items-center hf-gap-sm hf-mb-md">
-          <span
-            className={`hf-pill ${llmActive ? "hf-pill-success" : "hf-pill-neutral"}`}
-            data-testid="ai-measurement-status-pill"
-          >
-            {statusLabel}
-          </span>
+          {envelope && !unresolvable ? (
+            <CascadeValue
+              envelope={envelope}
+              knobKey={AI_MEASUREMENT_DISABLE_LLM_KNOB}
+              ariaLabel="LLM IELTS scoring — inspect cascade chain"
+              onInspect={() => setTray(true)}
+              hideSubtitle
+            >
+              <span
+                className={`hf-pill ${llmActive ? "hf-pill-success" : "hf-pill-neutral"}`}
+                data-testid="ai-measurement-status-pill"
+              >
+                {statusLabel}
+              </span>
+            </CascadeValue>
+          ) : (
+            <span
+              className={`hf-pill ${llmActive ? "hf-pill-success" : "hf-pill-neutral"}`}
+              data-testid="ai-measurement-status-pill"
+            >
+              {statusLabel}
+            </span>
+          )}
           <span className="hf-text-xs hf-text-muted">
             (auto-detected from IELTS BehaviorTargets)
           </span>
@@ -1185,6 +1218,14 @@ function AiMeasurementMethodSection({
           {error && <span className="hf-text-xs hf-text-error">{error}</span>}
         </div>
       </div>
+      {tray ? (
+        <CascadeInspectorTray
+          knobKey={AI_MEASUREMENT_DISABLE_LLM_KNOB}
+          knobLabel="LLM IELTS scoring"
+          scopeChain={{ playbookId: courseId }}
+          onClose={() => setTray(false)}
+        />
+      ) : null}
     </section>
   );
 }

--- a/apps/admin/lib/cascade/effective-value.ts
+++ b/apps/admin/lib/cascade/effective-value.ts
@@ -29,6 +29,7 @@ import { resolveWelcomeMessage } from "./resolvers/welcome-message";
 import { resolveVoiceConfigKnob } from "./resolvers/voice-config";
 import { resolveIdentitySpec } from "./resolvers/identity-spec";
 import { resolveMasteryPolicyKnob } from "./resolvers/mastery-policy";
+import { resolveAiMeasurementKnob } from "./resolvers/ai-measurement";
 
 /**
  * Scope IDs the cascade can resolve against. SYSTEM is implicit (no id);
@@ -144,6 +145,17 @@ const FAMILIES: readonly KnobFamily[] = [
     name: "progress-signals",
     match: (k) => k === "progressSignals",
     resolve: (scope, knobKey) => resolveMasteryPolicyKnob(scope, knobKey),
+  },
+  // #2206 S2 (2026-06-21) — per-course IELTS LLM-judged scoring
+  // kill-switch promoted to Domain → Course cascade per the
+  // "ALL settings → UI" framing. Cascade chip surfaces provenance so an
+  // institution-wide override is auditable rather than silent.
+  // Storage path is NESTED — `Playbook.config.aiMeasurement.<knob>` —
+  // matching the design route's partial-merge contract (PR #2158).
+  {
+    name: "ai-measurement",
+    match: (k) => k === "aiMeasurement.disableLlmIeltsScoring",
+    resolve: (scope, knobKey) => resolveAiMeasurementKnob(scope, knobKey),
   },
 ];
 

--- a/apps/admin/lib/cascade/resolvers/ai-measurement.ts
+++ b/apps/admin/lib/cascade/resolvers/ai-measurement.ts
@@ -1,0 +1,155 @@
+/**
+ * AI-measurement cascade resolver — story #2206 S2 / epic #2185.
+ *
+ * Resolves the per-course IELTS LLM-judged scoring kill-switch:
+ *
+ *   `Playbook.config.aiMeasurement.disableLlmIeltsScoring`
+ *     ← `Domain.config.aiMeasurement.disableLlmIeltsScoring`
+ *
+ * Born of the 2026-06-21 "ALL settings → UI" framing (handoff
+ * `handoff_lattice_all_settings_to_ui_2026_06_21.md` row S2): the toggle
+ * shipped in PR #2158 against `Playbook.config` only, with the
+ * `JourneySettingContract.cascadeSources = []` row commenting that
+ * Domain-level override would silently flip scoring for every course.
+ * The operator's S2 framing reverses that — every cascadable knob renders
+ * via `<CascadeValue>` + `<LayerBadge>` per `.claude/rules/cascade-reuse.md`,
+ * and the cascade chip itself surfaces the provenance so silent fan-out
+ * is impossible. The Domain layer now LIGHTS UP only when an institution
+ * operator deliberately writes the override at that scope.
+ *
+ * Storage shape — NESTED under `aiMeasurement.<knob>` rather than the
+ * flat `config.<knob>` shape the mastery-policy resolver uses. The
+ * sibling `welcome-message.ts` and `voice-config.ts` resolvers also
+ * walk specific-named paths; this resolver follows the same pattern.
+ *
+ * `setAt` / `setBy` — null for both layers (see TODO comment in
+ * `mastery-policy.ts`).
+ */
+
+import { prisma } from "@/lib/prisma";
+
+import type { Effective, LayerHit } from "../layer-types";
+import type { ScopeChain } from "../effective-value";
+
+const SUPPORTED_KEYS = ["aiMeasurement.disableLlmIeltsScoring"] as const;
+type AiMeasurementKey = (typeof SUPPORTED_KEYS)[number];
+
+function isAiMeasurementKey(k: string): k is AiMeasurementKey {
+  return (SUPPORTED_KEYS as readonly string[]).includes(k);
+}
+
+interface AiMeasurementShape {
+  disableLlmIeltsScoring?: boolean | null;
+}
+
+function readNested(
+  cfg: Record<string, unknown>,
+  knobKey: AiMeasurementKey,
+): unknown {
+  const ai = cfg.aiMeasurement;
+  if (!ai || typeof ai !== "object") return undefined;
+  const aiShape = ai as AiMeasurementShape;
+  // Today only one supported knob; extend the switch when siblings arrive.
+  if (knobKey === "aiMeasurement.disableLlmIeltsScoring") {
+    return aiShape.disableLlmIeltsScoring;
+  }
+  return undefined;
+}
+
+/**
+ * Resolver entry called from `FAMILIES` in `effective-value.ts`. Reads
+ * Playbook.config + Domain.config and returns the cascade envelope in
+ * SYSTEM→CALL order (Domain before Playbook).
+ *
+ * Throws when:
+ *   - `scope.playbookId` missing
+ *   - the playbook row isn't found
+ *   - the knob key isn't a supported aiMeasurement.* key (defence-in-depth)
+ */
+export async function resolveAiMeasurementKnob(
+  scope: ScopeChain,
+  knobKey: string,
+): Promise<Effective<unknown>> {
+  if (!isAiMeasurementKey(knobKey)) {
+    throw new Error(
+      `resolveAiMeasurementKnob: unsupported knob "${knobKey}". ` +
+        `Supported: ${SUPPORTED_KEYS.join(", ")}.`,
+    );
+  }
+  if (!scope.playbookId) {
+    throw new Error(
+      `resolveAiMeasurementKnob requires \`playbookId\` in scopeChain (got: ${JSON.stringify(
+        scope,
+      )})`,
+    );
+  }
+
+  const playbook = await prisma.playbook.findUnique({
+    where: { id: scope.playbookId },
+    select: {
+      id: true,
+      name: true,
+      config: true,
+      domainId: true,
+    },
+  });
+  if (!playbook) {
+    throw new Error(`Playbook not found: ${scope.playbookId}`);
+  }
+
+  const domain = await prisma.domain.findUnique({
+    where: { id: playbook.domainId },
+    select: { id: true, name: true, config: true },
+  });
+
+  const pbConfig = (playbook.config ?? {}) as Record<string, unknown>;
+  const domainConfig = (domain?.config ?? {}) as Record<string, unknown>;
+
+  // SYSTEM→CALL order: DOMAIN before PLAYBOOK.
+  const layers: LayerHit<unknown>[] = [];
+
+  const domainValue = readNested(domainConfig, knobKey);
+  if (domainValue !== undefined && domainValue !== null) {
+    layers.push({
+      layer: "DOMAIN",
+      scopeId: domain!.id,
+      scopeLabel: domain!.name,
+      value: domainValue,
+      setAt: null,
+      setBy: null,
+    });
+  }
+
+  const playbookValue = readNested(pbConfig, knobKey);
+  if (playbookValue !== undefined && playbookValue !== null) {
+    layers.push({
+      layer: "PLAYBOOK",
+      scopeId: playbook.id,
+      scopeLabel: playbook.name,
+      value: playbookValue,
+      setAt: null,
+      setBy: null,
+    });
+  }
+
+  // Deepest (innermost) layer wins.
+  const winner = layers.length > 0 ? layers[layers.length - 1] : null;
+
+  if (!winner) {
+    return {
+      value: null,
+      source: "SYSTEM",
+      layers: [],
+      isInherited: false,
+      recommendedLayerForEdit: "PLAYBOOK",
+    };
+  }
+
+  return {
+    value: winner.value,
+    source: winner.layer,
+    layers,
+    isInherited: winner.layer !== "PLAYBOOK",
+    recommendedLayerForEdit: "PLAYBOOK",
+  };
+}

--- a/apps/admin/lib/journey/setting-contracts.entries.ts
+++ b/apps/admin/lib/journey/setting-contracts.entries.ts
@@ -935,22 +935,28 @@ const G4_SCORING_MODE: JourneySettingContract = {
 // prompt; it changes the next call's scoring lineage. The Preview lens
 // is correct to stay silent here.
 //
-// NOT registered in `lib/cascade/effective-value.ts::FAMILIES` — the
-// override is intentionally course-level only (Domain-level override
-// would silently flip scoring for every course in the domain). Snapshot
-// read is correct per `.claude/rules/cascade-reuse.md` — the
-// `<CascadeValue>` envelope returns `unresolvable: true` and the
-// Inspector falls back to the snapshot read with no cascade chip.
+// #2206 S2 (2026-06-21) — promoted to Domain → Course cascade per the
+// "ALL settings → UI" framing (handoff_lattice_all_settings_to_ui_2026_06_21).
+// The cascade chip surfaces provenance (`<CascadeValue>` + `<LayerBadge>`)
+// so a Domain-level override is auditable rather than silent. Resolver
+// at `lib/cascade/resolvers/ai-measurement.ts`; FAMILIES row in
+// `lib/cascade/effective-value.ts`.
 const G4_AI_MEASUREMENT_DISABLE_LLM_IELTS: JourneySettingContract = {
   id: "aiMeasurementDisableLlmIeltsScoring",
   menuGroupKey: "I_scoring",
   group: "G4",
   educatorLabel: "Disable LLM IELTS scoring for this course",
   helpText:
-    "When enabled (default for IELTS-shaped courses), the LLM judges Fluency & Coherence, Lexical Resource, Grammatical Range & Accuracy, and Pronunciation from the transcript on each call. Tick this to disable LLM IELTS scoring — only rubric-based scoring will run.",
+    "When enabled (default for IELTS-shaped courses), the LLM judges Fluency & Coherence, Lexical Resource, Grammatical Range & Accuracy, and Pronunciation from the transcript on each call. Tick this to disable LLM IELTS scoring — only rubric-based scoring will run. Inherits from the Domain layer when not set on this course.",
   storagePath: "config.aiMeasurement.disableLlmIeltsScoring",
+  cascadeKnobKey: "aiMeasurement.disableLlmIeltsScoring",
   control: "toggle",
-  cascadeSources: [],
+  cascadeSources: [
+    {
+      level: "domain",
+      storagePath: "domain.config.aiMeasurement.disableLlmIeltsScoring",
+    },
+  ],
   composeImpact: {
     sections: [],
     kinds: ["scoring-weight"],

--- a/apps/admin/tests/lib/cascade/ai-measurement-resolver.test.ts
+++ b/apps/admin/tests/lib/cascade/ai-measurement-resolver.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for `lib/cascade/resolvers/ai-measurement.ts` (Story #2206 S2).
+ *
+ * Pins the Domain → Course cascade behaviour for the per-course IELTS
+ * LLM-judged scoring kill-switch:
+ *
+ *   `aiMeasurement.disableLlmIeltsScoring`
+ *
+ * Mirrors `mastery-policy-resolver.test.ts` shape with the nested-config
+ * read path documented in the resolver's header (sibling-pattern:
+ * `welcome-message.ts`).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    playbook: { findUnique: vi.fn() },
+    domain: { findUnique: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+import { resolveAiMeasurementKnob } from "@/lib/cascade/resolvers/ai-measurement";
+
+const KNOB = "aiMeasurement.disableLlmIeltsScoring";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("resolveAiMeasurementKnob — basic gates", () => {
+  it("throws on unsupported knob key", async () => {
+    await expect(
+      resolveAiMeasurementKnob({ playbookId: "pb-1" }, "aiMeasurement.bogus"),
+    ).rejects.toThrow(/unsupported knob/i);
+  });
+
+  it("throws on missing playbookId", async () => {
+    await expect(
+      resolveAiMeasurementKnob({ playbookId: "" }, KNOB),
+    ).rejects.toThrow(/playbookId/i);
+  });
+
+  it("throws when playbook row missing", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValueOnce(null);
+    await expect(
+      resolveAiMeasurementKnob({ playbookId: "pb-missing" }, KNOB),
+    ).rejects.toThrow(/Playbook not found/);
+  });
+});
+
+describe("resolveAiMeasurementKnob — cascade resolution", () => {
+  it("returns SYSTEM source when neither layer carries the knob", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb-1",
+      name: "IELTS Speaking Practice",
+      config: {},
+      domainId: "dom-1",
+    });
+    mockPrisma.domain.findUnique.mockResolvedValueOnce({
+      id: "dom-1",
+      name: "Acme Institute",
+      config: {},
+    });
+    const result = await resolveAiMeasurementKnob(
+      { playbookId: "pb-1" },
+      KNOB,
+    );
+    expect(result.value).toBeNull();
+    expect(result.source).toBe("SYSTEM");
+    expect(result.layers).toEqual([]);
+    expect(result.isInherited).toBe(false);
+    expect(result.recommendedLayerForEdit).toBe("PLAYBOOK");
+  });
+
+  it("PLAYBOOK wins over DOMAIN when both layers set the knob", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb-1",
+      name: "IELTS Speaking Practice",
+      config: { aiMeasurement: { disableLlmIeltsScoring: true } },
+      domainId: "dom-1",
+    });
+    mockPrisma.domain.findUnique.mockResolvedValueOnce({
+      id: "dom-1",
+      name: "Acme Institute",
+      config: { aiMeasurement: { disableLlmIeltsScoring: false } },
+    });
+    const result = await resolveAiMeasurementKnob(
+      { playbookId: "pb-1" },
+      KNOB,
+    );
+    expect(result.value).toBe(true);
+    expect(result.source).toBe("PLAYBOOK");
+    expect(result.layers).toHaveLength(2);
+    // SYSTEM → CALL order: DOMAIN before PLAYBOOK
+    expect(result.layers[0].layer).toBe("DOMAIN");
+    expect(result.layers[0].value).toBe(false);
+    expect(result.layers[1].layer).toBe("PLAYBOOK");
+    expect(result.layers[1].value).toBe(true);
+    expect(result.isInherited).toBe(false);
+  });
+
+  it("inherits from DOMAIN when PLAYBOOK has no override", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb-1",
+      name: "IELTS Speaking Practice",
+      config: {},
+      domainId: "dom-1",
+    });
+    mockPrisma.domain.findUnique.mockResolvedValueOnce({
+      id: "dom-1",
+      name: "Acme Institute",
+      config: { aiMeasurement: { disableLlmIeltsScoring: true } },
+    });
+    const result = await resolveAiMeasurementKnob(
+      { playbookId: "pb-1" },
+      KNOB,
+    );
+    expect(result.value).toBe(true);
+    expect(result.source).toBe("DOMAIN");
+    expect(result.layers).toHaveLength(1);
+    expect(result.layers[0].layer).toBe("DOMAIN");
+    expect(result.isInherited).toBe(true);
+  });
+
+  it("uses PLAYBOOK alone when DOMAIN has no override", async () => {
+    mockPrisma.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb-1",
+      name: "IELTS Speaking Practice",
+      config: { aiMeasurement: { disableLlmIeltsScoring: true } },
+      domainId: "dom-1",
+    });
+    mockPrisma.domain.findUnique.mockResolvedValueOnce({
+      id: "dom-1",
+      name: "Acme Institute",
+      config: {},
+    });
+    const result = await resolveAiMeasurementKnob(
+      { playbookId: "pb-1" },
+      KNOB,
+    );
+    expect(result.value).toBe(true);
+    expect(result.source).toBe("PLAYBOOK");
+    expect(result.layers).toHaveLength(1);
+    expect(result.layers[0].layer).toBe("PLAYBOOK");
+    expect(result.isInherited).toBe(false);
+  });
+
+  it("ignores null sibling aiMeasurement keys (partial-merge from PR #2158)", async () => {
+    // When `disableLlmIeltsScoring` is null (cleared) but a sibling
+    // future key is set, the resolver returns null for this knob.
+    mockPrisma.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb-1",
+      name: "IELTS Speaking Practice",
+      config: {
+        aiMeasurement: {
+          disableLlmIeltsScoring: null,
+          someFutureKnob: "value",
+        },
+      },
+      domainId: "dom-1",
+    });
+    mockPrisma.domain.findUnique.mockResolvedValueOnce({
+      id: "dom-1",
+      name: "Acme Institute",
+      config: {},
+    });
+    const result = await resolveAiMeasurementKnob(
+      { playbookId: "pb-1" },
+      KNOB,
+    );
+    expect(result.value).toBeNull();
+    expect(result.source).toBe("SYSTEM");
+    expect(result.layers).toEqual([]);
+  });
+});
+
+describe("resolveAiMeasurementKnob — registered in FAMILIES", () => {
+  it("isResolvableKnob returns true for the supported knob", async () => {
+    const { isResolvableKnob } = await import("@/lib/cascade/effective-value");
+    expect(isResolvableKnob(KNOB)).toBe(true);
+  });
+
+  it("isResolvableKnob returns false for an unrelated key", async () => {
+    const { isResolvableKnob } = await import("@/lib/cascade/effective-value");
+    expect(isResolvableKnob("aiMeasurement.somethingElse")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

S2 of `memory/handoff_lattice_all_settings_to_ui_2026_06_21.md` — operator framing: "ALL settings → UI; Course Pane lenses = setup; learner SIM = usage."

Closes the cascade-chip gap for `Playbook.config.aiMeasurement.disableLlmIeltsScoring`. The toggle was already on the Scoring tab (PR #2158) but rendered as a snapshot-only pill — operator had no view of provenance, and a Domain-level override would silently flip scoring for every course.

Per `.claude/rules/cascade-reuse.md`, every cascadable knob MUST route through `useEffectiveValue` + `<CascadeValue>` + `<LayerBadge>`. This PR:

- Adds new resolver `lib/cascade/resolvers/ai-measurement.ts` (nested `Playbook.config.aiMeasurement.*` → `Domain.config.aiMeasurement.*`)
- Registers as `ai-measurement` family in `lib/cascade/effective-value.ts::FAMILIES`
- Wires `<CascadeValue>` chip around the existing status pill in `AiMeasurementMethodSection`
- Mounts `<CascadeInspectorTray>` on chip click
- Upgrades `JOURNEY_SETTINGS` contract `aiMeasurementDisableLlmIeltsScoring` to declare the Domain cascade source + `cascadeKnobKey`

## Lattice 5-layer

1. **Typed primitive** — boolean on `PlaybookConfig.aiMeasurement.disableLlmIeltsScoring` (pre-existing, #2158)
2. **Generic engine** — `resolveAiMeasurementKnob` + `resolveEffective` dispatch
3. **UI surface** — this PR (cascade chip in Scoring tab)
4. **Coverage gates** — registry-schema-coverage + registry-consumer-coverage + registry-completeness all stay green (177/177)
5. **Paired rule** — `.claude/rules/cascade-reuse.md`; this PR is the third reference implementation (Journey Inspector + Rubric Calibration)

## Test plan

- [x] Lattice sibling-writer survey per `.claude/rules/lattice-survey.md`: confirmed pre-existing #2158 contract + design route partial-merge; no competing writers; cascade resolver is the new READ path (write path unchanged)
- [x] `npx tsc --noEmit` on changed files: clean (baseline 42 / current 42, pre-push hook)
- [x] `npx eslint` on changed files: 0 errors, 0 new warnings
- [x] `npx vitest run tests/lib/cascade/ai-measurement-resolver.test.ts` — 10/10 pass
- [x] `npx vitest run tests/lib/cascade/` — 120/120 pass
- [x] `npx vitest run tests/lib/journey/` — 177/177 pass (registry-schema, registry-consumer, registry-completeness, options, fixture-type, arraykey-writer, gated-by, registry-rules)
- [ ] Manual smoke (deferred to operator post-merge): on hf_sandbox, navigate `/x/courses/<courseId>` Skills tab → Rubric Calibration → AI Measurement Method card → confirm cascade chip renders; click chip → `<CascadeInspectorTray>` mounts; toggle still saves via existing PUT `/api/courses/[courseId]/design`

## Verified by

- Cascade-chip primitive: `lib/cascade/effective-value.ts::FAMILIES` row `ai-measurement` ↔ `apps/admin/lib/cascade/resolvers/ai-measurement.ts` ↔ `app/x/courses/[courseId]/CourseSkillsTab.tsx` (3-layer chain matches the canonical Journey-Inspector pattern at `components/journey-tab/JourneyInspectorPanel.tsx`)
- Coverage gates do not regress: registry-schema-coverage walks `PlaybookConfig` paths; `config.aiMeasurement.disableLlmIeltsScoring` continues to be covered by its existing contract row.
- Vitest run: 10 new tests passing 198ms.

Ready for `/vm-cp` (UI + lib only — no schema migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)