### PR TITLE
feat(admin): W6 — ResultsReadoutShell + post-exam mount (closes shell-coverage gap 2→1)

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/mock-results/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/mock-results/route.ts
@@ -1,0 +1,168 @@
+/**
+ * @api GET /api/callers/:callerId/mock-results?sessionId=…
+ * @visibility public
+ * @scope callers:read
+ * @auth session (VIEWER+ — STUDENT scoped to own caller)
+ * @tags callers, voice, mock
+ * @description Returns the per-criterion Mock results payload for the
+ *   sanctioned `ResultsReadoutShell` learner surface (W6 of
+ *   `memory/handoff_lattice_all_settings_to_ui_2026_06_21.md`).
+ *
+ *   The shape mirrors the FOH `SessionScore` contract at
+ *   `apps/foh/lib/types.ts` (criteria array of `{key, label, score}` +
+ *   overall + optional narrative/tier). Labels arrive in the response
+ *   payload (resolved server-side from canonical `Parameter.name`) so the
+ *   shell's source file stays free of IELTS criterion literals — the
+ *   build-time `learner-ui-leak-coverage.test.ts` walk only scans literals
+ *   in learner-UI DIRS (this route lives under `app/api/`, not
+ *   `components/sim/`).
+ *
+ *   **Sanctioned per BDD US-Mock-05** + `.claude/rules/learner-ui-leak-coverage.md`
+ *   exemptions ("Mock Results screen sanctioned per BDD US-Mock-05 —
+ *   per-criterion bands shown only on Results screen").
+ *
+ *   **Honest scoring** — when no `CallScore` rows exist for the session
+ *   yet (pipeline still running, or no `IELTS-MEASURE-001` rows landed),
+ *   returns `{ ok: true, result: null }`. The shell's empty state
+ *   renders accordingly. We do NOT fake bands (operator-pinned rule —
+ *   see MEMORY.md "NEVER fill empty scores with hardcoded /
+ *   AI-guessed defaults" + `feedback_no_hardcoded_score_backfill.md`).
+ *
+ *   **STUDENT scoping** — gated by `requireAuth("VIEWER")` +
+ *   `studentAllowedToReadCaller` so a STUDENT can ONLY read their own
+ *   caller's results (per `lib/learner-scope.ts`). OPERATOR+ may read
+ *   any caller's results for review.
+ *
+ * @pathParam callerId string - Caller.id
+ * @queryParam sessionId string - Session.id / Call.id (the row to score)
+ * @response 200 {ok: true, result: ResultsReadoutPayload | null}
+ * @response 400 {ok: false, error: string}
+ * @response 403 {ok: false, error: string}
+ * @response 500 {ok: false, error: string}
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import {
+  studentAllowedToReadCaller,
+  callerScopeMismatchResponse,
+} from "@/lib/learner-scope";
+import type { ResultsReadoutPayload } from "@/components/sim/ResultsReadoutShell";
+
+/**
+ * IELTS criterion parameterIds the Results screen surfaces, in the
+ * canonical display order (FC → LR → GRA → P). Keys are the canonical
+ * `Parameter.parameterId` values written by `IELTS-MEASURE-001` (see
+ * `lib/pipeline/prosody-consumer.ts` + `lib/lesson-plan/build-post-assessment-plan.ts`
+ * for sibling consumers).
+ *
+ * The shell's `key` field receives a short, learner-UI-safe alias so
+ * the test ids stay readable; the `label` field is resolved server-side
+ * from `Parameter.name` (HF-canonical authored display name), keeping
+ * IELTS criterion literals OUT of the learner-UI source per the
+ * `learner-ui-leak-coverage` Coverage gate.
+ */
+const CRITERION_PARAM_ORDER: ReadonlyArray<{ parameterId: string; key: string }> = [
+  { parameterId: "skill_fluency_and_coherence_fc", key: "fluency" },
+  { parameterId: "skill_lexical_resource_lr", key: "lexical" },
+  { parameterId: "skill_grammatical_range_and_accuracy_gra", key: "grammar" },
+  { parameterId: "skill_pronunciation_p", key: "pronunciation" },
+];
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ callerId: string }> },
+): Promise<NextResponse> {
+  try {
+    const authResult = await requireAuth("VIEWER");
+    if (isAuthError(authResult)) return authResult.error;
+
+    const { callerId } = await params;
+    if (!studentAllowedToReadCaller(authResult.session, callerId)) {
+      return callerScopeMismatchResponse();
+    }
+
+    const sessionId = req.nextUrl.searchParams.get("sessionId");
+    if (!sessionId) {
+      return NextResponse.json(
+        { ok: false, error: "sessionId query param is required" },
+        { status: 400 },
+      );
+    }
+
+    // Read every per-criterion CallScore for the session. Scoped to the
+    // caller too (defence-in-depth — the unique-key on (callId, parameterId,
+    // moduleId) already prevents cross-caller leakage but a paranoid
+    // join keeps STUDENT data crisp).
+    const paramIds = CRITERION_PARAM_ORDER.map((c) => c.parameterId);
+    const scores = await prisma.callScore.findMany({
+      where: {
+        callId: sessionId,
+        callerId,
+        parameterId: { in: paramIds },
+      },
+      select: {
+        parameterId: true,
+        score: true,
+      },
+    });
+
+    // No criterion rows yet → honest empty (shell renders the empty
+    // state). Never fabricate bands.
+    if (scores.length === 0) {
+      return NextResponse.json({ ok: true, result: null });
+    }
+
+    // Resolve canonical labels server-side from the Parameter rows.
+    // `Parameter.name` is the HF-authored display name (e.g. "Fluency
+    // and Coherence") — IP boundary per `.claude/rules/spec-readonly-boundary.md`.
+    // Labels never appear as literals in this file; they flow from DB
+    // → response → shell prop.
+    const params_ = await prisma.parameter.findMany({
+      where: { parameterId: { in: paramIds } },
+      select: { parameterId: true, name: true },
+    });
+    const labelByParamId = new Map(params_.map((p) => [p.parameterId, p.name]));
+
+    // Aggregate per-criterion (a session can carry multiple scores for
+    // the same criterion across sub-modules — Mock covers P1/P2/P3
+    // segments per epic #1700). Take the mean per parameterId so the
+    // overall Mock band reflects the full session.
+    const buckets = new Map<string, number[]>();
+    for (const row of scores) {
+      const arr = buckets.get(row.parameterId) ?? [];
+      arr.push(row.score);
+      buckets.set(row.parameterId, arr);
+    }
+
+    const criteria = CRITERION_PARAM_ORDER.flatMap(({ parameterId, key }) => {
+      const bucket = buckets.get(parameterId);
+      if (!bucket || bucket.length === 0) return [];
+      const mean = bucket.reduce((a, b) => a + b, 0) / bucket.length;
+      const label = labelByParamId.get(parameterId);
+      if (!label) return []; // no canonical label → skip rather than fabricate
+      return [{ key, label, score: mean }];
+    });
+
+    if (criteria.length === 0) {
+      return NextResponse.json({ ok: true, result: null });
+    }
+
+    const overall =
+      criteria.reduce((a, c) => a + c.score, 0) / criteria.length;
+
+    const payload: ResultsReadoutPayload = {
+      overall,
+      criteria,
+    };
+
+    return NextResponse.json({ ok: true, result: payload });
+  } catch (err) {
+    console.error("[/api/callers/[callerId]/mock-results] error", err);
+    return NextResponse.json(
+      { ok: false, error: "Failed to resolve mock results" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/admin/components/sim/ResultsReadoutShell.tsx
+++ b/apps/admin/components/sim/ResultsReadoutShell.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+/**
+ * ResultsReadoutShell — post-exam Mock Results screen.
+ *
+ * W6 of memory/handoff_lattice_all_settings_to_ui_2026_06_21.md (story
+ * #2185 U11, drops `tests/components/shell-coverage.test.ts::EXPECTED_GAP_COUNT`
+ * from 2 → 1).
+ *
+ * **Sanctioned learner-facing surface** for per-criterion bands. Per
+ * `.claude/rules/learner-ui-leak-coverage.md` exemptions + BDD US-Mock-05
+ * (HF-IELTS-Pre-Voice-Testing-Checklist Unit 5), this is the ONE learner
+ * surface where IELTS criterion labels (Fluency & Coherence / Lexical
+ * Resource / Grammatical Range / Pronunciation) are allowed to render.
+ * The labels arrive via the data payload — never as string literals in
+ * this source file — so the build-time leak-coverage walk (which scans
+ * literals in learner-UI dirs) stays clean.
+ *
+ * **Capability-driven** per `.claude/rules/shell-coverage.md` + epic
+ * #2163 S3 decision: the shell reads affordances from
+ * `capabilities` (default = `SHELL_DEFAULTS["results-readout"]`):
+ *
+ *   - `colourTheme: "brand"` — accent-tinted celebration palette
+ *   - `chatFeedVisibility: "none"` — full-screen replacement, no chat
+ *   - `showTimer: "none"` — no clock
+ *   - `showProgressBar: "none"` — the score IS the progress
+ *   - `modePillKey: null` — no mode pill (results live above the mode)
+ *   - `dismissOnEnd: "next-module"` — auto-advance call site
+ *   - `stallChipBehaviour: "none"` — no learner input expected
+ *   - `allowModuleSwitch: false` / `allowBackToHome: false` — structured
+ *     exit via the parent dismiss handler
+ *
+ * The shell is render-thin and intentionally avoids hard-branching on
+ * the shell-kind literal inside JSX (per epic #2163 — affordances
+ * declarative; procedural branches defeat the Coverage walk).
+ *
+ * **Data shape** mirrors the FOH `SessionScore` contract at
+ * `apps/foh/lib/types.ts`. The shell accepts a `result` prop of shape
+ * `{ overall, tierLabel?, narrative?, criteria: Array<{label, score, key?}> }`
+ * — the host fetches from `/api/callers/[callerId]/mock-results?sessionId=…`
+ * and passes the result down. Labels arrive in `result.criteria[].label`
+ * (resolved server-side from canonical `Parameter` rows), so no IELTS
+ * criterion string appears in this file as a literal.
+ *
+ * **Loading / error / empty states** are honest — no fake scores ever.
+ * If the session has no `CallScore` rows yet, the empty state renders
+ * with a message instead of fabricated bands (per the operator-pinned
+ * "never fill empty scores with hardcoded defaults" rule).
+ */
+
+import {
+  SHELL_DEFAULTS,
+  type LearnerShellCapabilities,
+} from "@/lib/types/json-fields";
+import "./learner-shells.css";
+
+/**
+ * Per-criterion row for the Results screen. Mirrors the FOH
+ * `CriterionScore` shape (`apps/foh/lib/types.ts`).
+ */
+export interface ResultsReadoutCriterion {
+  /** Stable key for React iteration (e.g. parameterId / FOH CriterionKey). */
+  key: string;
+  /** Display label resolved server-side from Parameter row — never a
+   *  literal in this source file. */
+  label: string;
+  /** Numeric band (typically 0–9 for IELTS). */
+  score: number;
+}
+
+/**
+ * Result payload consumed by the shell. The host (typically SimChat
+ * dispatcher) fetches this from `/api/callers/[callerId]/mock-results`
+ * and passes it down. Shape mirrors the FOH `SessionScore` contract.
+ */
+export interface ResultsReadoutPayload {
+  /** Overall band (typically a number like 6.5; rendered to 1dp). */
+  overall: number;
+  /** Optional human-readable tier label (e.g. "Modest user"). Resolved
+   *  server-side; never a literal here. */
+  tierLabel?: string;
+  /** Optional narrative — strengths / one-area-to-work-on per BDD
+   *  US-Mock-05. Resolved server-side; rendered as plain text. */
+  narrative?: string;
+  /** Per-criterion bands. Array order is the display order. */
+  criteria: ResultsReadoutCriterion[];
+}
+
+interface ResultsReadoutShellProps {
+  /** Capability frame. Defaults to `SHELL_DEFAULTS["results-readout"]`. */
+  capabilities?: LearnerShellCapabilities;
+  /** Server-resolved result payload. `null` while loading; pass `error`
+   *  separately when the fetch failed. */
+  result?: ResultsReadoutPayload | null;
+  /** Honest loading state — render a placeholder while the host's
+   *  fetch is in-flight. Never substitute fake bands. */
+  loading?: boolean;
+  /** Honest error state — render the message instead of a result. */
+  error?: string | null;
+  /** Optional dismiss handler (rendered as a child control). When
+   *  omitted, no dismiss affordance renders. */
+  onDismiss?: () => void;
+  /** Optional next-module handler (rendered as a child control). */
+  onNext?: () => void;
+  /** Child controls slot for fully custom CTAs (overrides default
+   *  buttons when supplied). */
+  children?: React.ReactNode;
+}
+
+function formatBand(score: number): string {
+  if (!Number.isFinite(score)) return "—";
+  // IELTS bands are reported to 1dp (e.g. 6.5). Other scoring schemes
+  // may use integers; we trim trailing zeros so "6.0" doesn't render
+  // when "6" is more honest.
+  const rounded = Math.round(score * 10) / 10;
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+}
+
+export function ResultsReadoutShell({
+  capabilities = SHELL_DEFAULTS["results-readout"],
+  result = null,
+  loading = false,
+  error = null,
+  onDismiss,
+  onNext,
+  children,
+}: ResultsReadoutShellProps) {
+  const hasResult = result !== null && result.criteria.length > 0;
+  return (
+    <section
+      className="hf-results-readout-shell"
+      role="region"
+      aria-label="Results"
+      data-testid="hf-results-readout-shell"
+      data-shell-kind="results-readout"
+      data-colour-theme={capabilities.colourTheme}
+      data-mode-pill={capabilities.modePillKey ?? ""}
+      data-chat-feed-visibility={capabilities.chatFeedVisibility}
+      data-show-timer={capabilities.showTimer}
+      data-show-progress-bar={capabilities.showProgressBar}
+      data-allow-module-switch={String(capabilities.allowModuleSwitch)}
+      data-allow-back-to-home={String(capabilities.allowBackToHome)}
+      data-dismiss-on-end={capabilities.dismissOnEnd}
+      data-stall-chip-behaviour={capabilities.stallChipBehaviour}
+    >
+      {capabilities.modePillKey ? (
+        <div
+          className="hf-shell-mode-pill"
+          data-testid="hf-shell-mode-pill"
+          data-mode-pill-key={capabilities.modePillKey}
+        >
+          {capabilities.modePillKey}
+        </div>
+      ) : null}
+
+      {loading ? (
+        <div
+          className="hf-results-readout-loading"
+          data-testid="hf-results-readout-loading"
+          role="status"
+          aria-live="polite"
+        >
+          Loading your results…
+        </div>
+      ) : null}
+
+      {!loading && error ? (
+        <div
+          className="hf-results-readout-error"
+          data-testid="hf-results-readout-error"
+          role="alert"
+        >
+          {error}
+        </div>
+      ) : null}
+
+      {!loading && !error && !hasResult ? (
+        <div
+          className="hf-results-readout-empty"
+          data-testid="hf-results-readout-empty"
+          role="status"
+        >
+          Results are still being scored. Check back in a moment.
+        </div>
+      ) : null}
+
+      {!loading && !error && hasResult && result ? (
+        <>
+          <div
+            className="hf-results-readout-overall"
+            data-testid="hf-results-readout-overall"
+          >
+            <span
+              className="hf-results-readout-overall-label"
+              data-testid="hf-results-readout-overall-label"
+            >
+              Overall
+            </span>
+            <span
+              className="hf-results-readout-overall-score"
+              data-testid="hf-results-readout-overall-score"
+              data-score={String(result.overall)}
+            >
+              {formatBand(result.overall)}
+            </span>
+            {result.tierLabel ? (
+              <span
+                className="hf-results-readout-tier"
+                data-testid="hf-results-readout-tier"
+              >
+                {result.tierLabel}
+              </span>
+            ) : null}
+          </div>
+
+          <ul
+            className="hf-results-readout-criteria"
+            data-testid="hf-results-readout-criteria"
+          >
+            {result.criteria.map((c) => (
+              <li key={c.key} data-criterion-key={c.key}>
+                <span
+                  className="hf-results-readout-criterion-label"
+                  data-testid={`hf-results-readout-criterion-label-${c.key}`}
+                >
+                  {c.label}
+                </span>
+                <span
+                  className="hf-results-readout-criterion-score"
+                  data-testid={`hf-results-readout-criterion-score-${c.key}`}
+                  data-score={String(c.score)}
+                >
+                  {formatBand(c.score)}
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          {result.narrative ? (
+            <p
+              className="hf-results-readout-narrative"
+              data-testid="hf-results-readout-narrative"
+            >
+              {result.narrative}
+            </p>
+          ) : null}
+        </>
+      ) : null}
+
+      {children ? (
+        <div className="hf-results-readout-controls">{children}</div>
+      ) : onDismiss || onNext ? (
+        <div className="hf-results-readout-controls">
+          {onDismiss ? (
+            <button
+              type="button"
+              className="hf-button-secondary"
+              data-testid="hf-results-readout-dismiss"
+              onClick={onDismiss}
+            >
+              Done
+            </button>
+          ) : null}
+          {onNext ? (
+            <button
+              type="button"
+              className="hf-button-primary"
+              data-testid="hf-results-readout-next"
+              onClick={onNext}
+            >
+              Continue
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/admin/components/sim/SimChat.tsx
+++ b/apps/admin/components/sim/SimChat.tsx
@@ -17,6 +17,10 @@ import { useVoiceMode } from './useVoiceMode';
 import { ExamModeShell } from './ExamModeShell';
 import { ChatFeedShell } from './ChatFeedShell';
 import { MCQRoundsShell } from './MCQRoundsShell';
+import {
+  ResultsReadoutShell,
+  type ResultsReadoutPayload,
+} from './ResultsReadoutShell';
 import { resolveLearnerShell } from '@/lib/voice/resolve-learner-shell';
 import type { AuthoredModuleMode } from '@/lib/types/json-fields';
 import { useProviderCall } from './useProviderCall';
@@ -1321,21 +1325,20 @@ export function SimChat({
   const { shellKind: resolvedShellKind, capabilities: resolvedCapabilities, matchedRuleId } = learnerShellResult;
 
   // Defensive fallback path. When the resolver returns a kind we don't
-  // have a consumer for yet (e.g. `results-readout`, `intake-wizard` —
-  // epic #2163 S4-S7), fall back to ChatFeedShell AND fire an
-  // operator-visible signal so the silent-degrade trap doesn't catch us
-  // (per `.claude/rules/data-presence-coverage.md` "NO SILENT FALLBACKS").
-  // `ENROLLMENT` is structurally impossible here (SimChat is SIM_CALL),
-  // but the fallback exists so any future kind addition is observable.
+  // have a consumer for yet (currently only `intake-wizard` — epic
+  // #2163 S4-S7 / W7 of the same handoff), fall back to ChatFeedShell
+  // AND fire an operator-visible signal so the silent-degrade trap
+  // doesn't catch us (per `.claude/rules/data-presence-coverage.md`
+  // "NO SILENT FALLBACKS"). `results-readout` was wired by PR #2220
+  // (W6) and is no longer a fallback case; `ENROLLMENT` is structurally
+  // impossible here (SimChat is SIM_CALL).
   useEffect(() => {
     if (
       resolvedShellKind !== 'chat-feed' &&
       resolvedShellKind !== 'exam' &&
-      resolvedShellKind !== 'mcq-rounds'
+      resolvedShellKind !== 'mcq-rounds' &&
+      resolvedShellKind !== 'results-readout'
     ) {
-      // Structured payload — surfaces in the browser console (operator-
-      // visible during dev / staging) AND any client-error reporter the
-      // surface plugs into.
       console.warn('[learner_shell.fallback_unwired]', {
         subject: 'learner_shell.fallback_unwired',
         shellKind: resolvedShellKind,
@@ -1345,6 +1348,61 @@ export function SimChat({
       });
     }
   }, [resolvedShellKind, matchedRuleId, callerId, requestedModuleId]);
+
+  // W6 of memory/handoff_lattice_all_settings_to_ui_2026_06_21.md
+  // (story #2185 U11) — ResultsReadoutShell overlay state. Per BDD
+  // US-Mock-05 this is the ONE sanctioned learner surface that displays
+  // per-criterion bands.
+  //
+  // Mount gate: Mock-style module (same `examMode` signal as the dark
+  // exam shell) AND the call has ended. The fetch is best-effort —
+  // null result yields the empty state (never fake bands per the
+  // operator-pinned "no hardcoded score backfill" rule).
+  const showResultsShell = examMode && callPhase === 'ended';
+  const [resultsResult, setResultsResult] = useState<ResultsReadoutPayload | null>(
+    null,
+  );
+  const [resultsLoading, setResultsLoading] = useState(false);
+  const [resultsError, setResultsError] = useState<string | null>(null);
+  useEffect(() => {
+    if (!showResultsShell || !callId) {
+      setResultsResult(null);
+      setResultsError(null);
+      setResultsLoading(false);
+      return;
+    }
+    const controller = new AbortController();
+    setResultsLoading(true);
+    setResultsError(null);
+    fetch(
+      `/api/callers/${encodeURIComponent(callerId)}/mock-results?sessionId=${encodeURIComponent(
+        callId,
+      )}`,
+      { signal: controller.signal, credentials: 'same-origin' },
+    )
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+      .then(
+        (body: {
+          ok?: boolean;
+          result?: ResultsReadoutPayload | null;
+          error?: string;
+        } | null) => {
+          if (!body?.ok) {
+            setResultsError(body?.error ?? 'Could not load results.');
+            setResultsResult(null);
+            return;
+          }
+          setResultsResult(body.result ?? null);
+        },
+      )
+      .catch((err) => {
+        if ((err as Error)?.name === 'AbortError') return;
+        setResultsError('Could not load results.');
+        setResultsResult(null);
+      })
+      .finally(() => setResultsLoading(false));
+    return () => controller.abort();
+  }, [showResultsShell, callerId, callId]);
   const examSpeakerRole: 'examiner' | 'learner' | 'idle' =
     voiceMode.state === 'ai-speaking'
       ? 'examiner'
@@ -2326,6 +2384,17 @@ export function SimChat({
     />
   ) : null;
 
+  // W6 — ResultsReadoutShell mounts as a full-screen overlay once the
+  // Mock-style call has ended. Embedded mode (operator-side views)
+  // skips the overlay so the chat feed remains inspectable.
+  const resultsShell = showResultsShell && !isEmbedded ? (
+    <ResultsReadoutShell
+      result={resultsResult}
+      loading={resultsLoading}
+      error={resultsError}
+    />
+  ) : null;
+
   if (isEmbedded) {
     return <div className="sim-embedded">{content}</div>;
   }
@@ -2333,44 +2402,44 @@ export function SimChat({
   // Standalone: dispatch on the resolver's shellKind. The resolver IS the
   // policy — when a new shell variant lands, extend SHELL_SELECTION_RULES
   // in `lib/voice/resolve-learner-shell.ts`, not this switch.
+  //
+  // W6 (PR #2220): every branch also mounts `resultsShell` (the
+  // ResultsReadoutShell overlay) so post-Mock terminal state shows
+  // per-criterion bands per BDD US-Mock-05 regardless of the underlying
+  // shell wrapper.
   switch (resolvedShellKind) {
     case 'exam':
-      // Exam shell is rendered as a position-fixed overlay on top of the
-      // chat-feed content (the chat is still beneath, so transcript +
-      // pipeline + voiceMode lifecycle continue uninterrupted). Existing
-      // #1745 overlay behaviour is preserved via `examShellOverlay`.
       return (
         <ChatFeedShell capabilities={resolvedCapabilities}>
           {content}
           {examShellOverlay}
+          {resultsShell}
         </ChatFeedShell>
       );
     case 'mcq-rounds':
-      // Quiz-mode shell. MCQ data feed is stubbed at the shell level
-      // pending #2180 sampling engine; today the shell wraps the chat
-      // feed underneath so existing call lifecycle still works.
       return (
         <MCQRoundsShell capabilities={resolvedCapabilities}>
           {content}
           {examShellOverlay}
+          {resultsShell}
         </MCQRoundsShell>
       );
     case 'chat-feed':
-      // Default — wrap content in the typed ChatFeedShell. Behaviour is
-      // byte-identical to the pre-#2206 default render path.
       return (
         <ChatFeedShell capabilities={resolvedCapabilities}>
           {content}
           {examShellOverlay}
+          {resultsShell}
         </ChatFeedShell>
       );
     default:
-      // Unwired kind (results-readout / intake-wizard / future) — fall back
-      // to ChatFeedShell. The AppLog was already fired by the effect above.
+      // Unwired kind (intake-wizard / future) — fall back to ChatFeedShell.
+      // AppLog fired by the effect above.
       return (
         <ChatFeedShell capabilities={resolvedCapabilities}>
           {content}
           {examShellOverlay}
+          {resultsShell}
         </ChatFeedShell>
       );
   }

--- a/apps/admin/components/sim/learner-shells.css
+++ b/apps/admin/components/sim/learner-shells.css
@@ -124,3 +124,149 @@
   gap: 12px;
   justify-content: center;
 }
+
+/* ResultsReadoutShell (W6 of memory/handoff_lattice_all_settings_to_ui_2026_06_21.md,
+ * #2185 U11) — post-exam Mock Results screen. The ONE sanctioned
+ * learner-facing surface that displays per-criterion bands (per BDD
+ * US-Mock-05 + .claude/rules/learner-ui-leak-coverage.md exemptions).
+ * Brand-themed celebration palette per SHELL_DEFAULTS["results-readout"]
+ * (colourTheme === "brand"). Full-screen overlay (chatFeedVisibility ===
+ * "none"). No timer, no progress bar, no mode pill — the result IS the
+ * screen. */
+.hf-results-readout-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 24px;
+  padding: 48px 24px;
+  overflow-y: auto;
+  background: var(--results-shell-bg, var(--surface-primary));
+  color: var(--results-shell-text, var(--text-primary));
+}
+
+.hf-results-readout-shell[data-colour-theme="default"] {
+  --results-shell-bg: var(--surface-primary);
+  --results-shell-text: var(--text-primary);
+}
+
+.hf-results-readout-shell[data-colour-theme="dark"] {
+  --results-shell-bg: #0b0f1a;
+  --results-shell-text: #e8ecf3;
+}
+
+.hf-results-readout-shell[data-colour-theme="neutral"] {
+  --results-shell-bg: var(--surface-secondary);
+  --results-shell-text: var(--text-primary);
+}
+
+.hf-results-readout-shell[data-colour-theme="brand"] {
+  --results-shell-bg: color-mix(in srgb, var(--accent-primary) 12%, var(--surface-primary));
+  --results-shell-text: var(--text-primary);
+}
+
+.hf-results-readout-overall {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 32px 48px;
+  border-radius: 20px;
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  box-shadow: 0 4px 16px color-mix(in srgb, var(--accent-primary) 14%, transparent);
+}
+
+.hf-results-readout-overall-label {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--results-shell-text) 60%, transparent);
+}
+
+.hf-results-readout-overall-score {
+  font-size: 64px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--accent-primary);
+}
+
+.hf-results-readout-tier {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--results-shell-text);
+}
+
+.hf-results-readout-criteria {
+  width: 100%;
+  max-width: 720px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.hf-results-readout-criteria li {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px;
+  border-radius: 12px;
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+}
+
+.hf-results-readout-criterion-label {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--results-shell-text) 70%, transparent);
+}
+
+.hf-results-readout-criterion-score {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.hf-results-readout-narrative {
+  width: 100%;
+  max-width: 720px;
+  padding: 20px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--accent-primary) 6%, transparent);
+  color: var(--results-shell-text);
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+.hf-results-readout-loading,
+.hf-results-readout-error,
+.hf-results-readout-empty {
+  width: 100%;
+  max-width: 480px;
+  padding: 32px;
+  border-radius: 12px;
+  background: var(--surface-primary);
+  border: 1px solid var(--border-default);
+  text-align: center;
+  color: var(--results-shell-text);
+}
+
+.hf-results-readout-error {
+  border-color: color-mix(in srgb, var(--accent-error, #c44) 40%, var(--border-default));
+}
+
+.hf-results-readout-controls {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  margin-top: 8px;
+}

--- a/apps/admin/tests/components/shell-coverage.test.ts
+++ b/apps/admin/tests/components/shell-coverage.test.ts
@@ -17,10 +17,11 @@
  *  `resolveLearnerShell`) but no concrete UI consumer is shipped — the
  *  learner sees the default chat-feed regardless of declared shell.
  *
- *  Today's incumbent: only `ExamModeShell` ships on main.
- *  `ChatFeedShell` + `MCQRoundsShell` arrive via PR #2202 (S3 of #2163).
- *  `ResultsReadoutShell` + `IntakeWizardShell` are the remaining
- *  GAP entries.
+ *  Today's incumbent: `ExamModeShell` + `ChatFeedShell` + `MCQRoundsShell`
+ *  + `ResultsReadoutShell` ship on main. `ResultsReadoutShell` lands via
+ *  W6 of `memory/handoff_lattice_all_settings_to_ui_2026_06_21.md`
+ *  (story #2185 U11, demo-critical for IELTS Mock → Mock Results screen).
+ *  `IntakeWizardShell` is the remaining GAP entry, deferred to W7.
  *
  *  Sibling to:
  *   - `tests/lib/sim-chat/mode-ui-coverage.test.ts` — AuthoredModuleMode
@@ -144,10 +145,10 @@ const EXPECTED_EXEMPT_COUNT = 0;
  * dispatch via `resolveLearnerShell`. The remaining 2 gaps
  * (results-readout + intake-wizard) close in S4-S7 of epic #2163.
  *
- * When `ResultsReadoutShell.tsx` ships, drop to 1.
- * When `IntakeWizardShell.tsx` ships, drop to 0.
+ * When `ResultsReadoutShell.tsx` ships (W6, this PR), drop to 1.
+ * When `IntakeWizardShell.tsx` ships (W7), drop to 0.
  */
-const EXPECTED_GAP_COUNT = 2;
+const EXPECTED_GAP_COUNT = 1;
 
 // ────────────────────────────────────────────────────────────
 // Classification

--- a/apps/admin/tests/components/sim/ResultsReadoutShell.test.tsx
+++ b/apps/admin/tests/components/sim/ResultsReadoutShell.test.tsx
@@ -1,0 +1,274 @@
+/**
+ * Tests for ResultsReadoutShell (W6 of memory/handoff_lattice_all_settings_to_ui_2026_06_21.md,
+ * story #2185 U11). Capability-driven Mock Results screen — the ONE
+ * sanctioned learner-facing surface that renders per-criterion bands
+ * (per BDD US-Mock-05 + `.claude/rules/learner-ui-leak-coverage.md`
+ * exemptions).
+ *
+ * Pinned acceptance:
+ *  1. Default `SHELL_DEFAULTS["results-readout"]` capabilities stamp the
+ *     expected data attributes (brand theme, no mode pill, no timer,
+ *     no progress bar, dismissOnEnd="next-module").
+ *  2. Overall band + per-criterion list render when a real `result`
+ *     payload is supplied.
+ *  3. Labels flow from props, not literals — the shell stays leak-clean.
+ *  4. Honest empty state when `result` is null (per the operator-pinned
+ *     "never fill empty scores with hardcoded defaults" rule).
+ *  5. Loading + error states render without fabricating bands.
+ *  6. Capability overrides flow through to data attributes.
+ *  7. Optional dismiss / next CTAs render when handlers supplied.
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+
+import {
+  ResultsReadoutShell,
+  type ResultsReadoutPayload,
+} from "@/components/sim/ResultsReadoutShell";
+import {
+  SHELL_DEFAULTS,
+  type LearnerShellCapabilities,
+} from "@/lib/types/json-fields";
+
+afterEach(() => {
+  cleanup();
+});
+
+// ────────────────────────────────────────────────────────────
+// Default capability frame
+// ────────────────────────────────────────────────────────────
+
+describe("ResultsReadoutShell — default SHELL_DEFAULTS['results-readout'] capabilities", () => {
+  it("stamps data attributes matching the canonical defaults", () => {
+    render(<ResultsReadoutShell />);
+    const shell = screen.getByTestId("hf-results-readout-shell");
+    const expected = SHELL_DEFAULTS["results-readout"];
+    expect(shell.getAttribute("data-shell-kind")).toBe("results-readout");
+    expect(shell.getAttribute("data-colour-theme")).toBe(expected.colourTheme); // "brand"
+    expect(shell.getAttribute("data-mode-pill")).toBe(expected.modePillKey ?? ""); // ""
+    expect(shell.getAttribute("data-chat-feed-visibility")).toBe(
+      expected.chatFeedVisibility,
+    ); // "none"
+    expect(shell.getAttribute("data-show-timer")).toBe(expected.showTimer); // "none"
+    expect(shell.getAttribute("data-show-progress-bar")).toBe(
+      expected.showProgressBar,
+    ); // "none"
+    expect(shell.getAttribute("data-allow-module-switch")).toBe("false");
+    expect(shell.getAttribute("data-allow-back-to-home")).toBe("false");
+    expect(shell.getAttribute("data-dismiss-on-end")).toBe("next-module");
+    expect(shell.getAttribute("data-stall-chip-behaviour")).toBe("none");
+  });
+
+  it("does NOT render the mode pill when modePillKey is null", () => {
+    render(<ResultsReadoutShell />);
+    expect(screen.queryByTestId("hf-shell-mode-pill")).toBeNull();
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Result rendering — overall + per-criterion bands
+// ────────────────────────────────────────────────────────────
+
+describe("ResultsReadoutShell — renders per-criterion bands from data (BDD US-Mock-05)", () => {
+  // Labels arrive as props (server-resolved from canonical Parameter.name
+  // rows). They never appear as literals in the shell source — this test
+  // pins that pattern by passing arbitrary label strings.
+  const SAMPLE: ResultsReadoutPayload = {
+    overall: 6.5,
+    tierLabel: "Competent user",
+    narrative: "Strong fluency; work on a wider lexical range.",
+    criteria: [
+      { key: "fluency", label: "Fluency-and-Coherence-label", score: 7 },
+      { key: "lexical", label: "Lexical-Resource-label", score: 6 },
+      { key: "grammar", label: "Grammar-label", score: 6.5 },
+      { key: "pronunciation", label: "Pronunciation-label", score: 6.5 },
+    ],
+  };
+
+  it("renders the overall band, tier label, and narrative when supplied", () => {
+    render(<ResultsReadoutShell result={SAMPLE} />);
+    expect(screen.getByTestId("hf-results-readout-overall-score")).toHaveTextContent(
+      "6.5",
+    );
+    expect(screen.getByTestId("hf-results-readout-tier")).toHaveTextContent(
+      "Competent user",
+    );
+    expect(screen.getByTestId("hf-results-readout-narrative")).toHaveTextContent(
+      "Strong fluency; work on a wider lexical range.",
+    );
+  });
+
+  it("renders every criterion row with label + score from props", () => {
+    render(<ResultsReadoutShell result={SAMPLE} />);
+    expect(
+      screen.getByTestId("hf-results-readout-criterion-label-fluency"),
+    ).toHaveTextContent("Fluency-and-Coherence-label");
+    expect(
+      screen.getByTestId("hf-results-readout-criterion-score-fluency"),
+    ).toHaveTextContent("7");
+    expect(
+      screen.getByTestId("hf-results-readout-criterion-label-lexical"),
+    ).toHaveTextContent("Lexical-Resource-label");
+    expect(
+      screen.getByTestId("hf-results-readout-criterion-score-lexical"),
+    ).toHaveTextContent("6");
+    expect(
+      screen.getByTestId("hf-results-readout-criterion-score-grammar"),
+    ).toHaveTextContent("6.5");
+    expect(
+      screen.getByTestId("hf-results-readout-criterion-score-pronunciation"),
+    ).toHaveTextContent("6.5");
+  });
+
+  it("integer bands render without trailing zero ('6' not '6.0')", () => {
+    const payload: ResultsReadoutPayload = {
+      overall: 6,
+      criteria: [{ key: "k", label: "L", score: 6 }],
+    };
+    render(<ResultsReadoutShell result={payload} />);
+    expect(screen.getByTestId("hf-results-readout-overall-score")).toHaveTextContent(
+      "6",
+    );
+    expect(screen.getByTestId("hf-results-readout-criterion-score-k")).toHaveTextContent(
+      "6",
+    );
+  });
+
+  it("non-finite band renders as em-dash (honest)", () => {
+    const payload: ResultsReadoutPayload = {
+      overall: Number.NaN,
+      criteria: [{ key: "k", label: "L", score: Number.NaN }],
+    };
+    render(<ResultsReadoutShell result={payload} />);
+    expect(screen.getByTestId("hf-results-readout-overall-score")).toHaveTextContent(
+      "—",
+    );
+  });
+
+  it("tier label + narrative are optional (absent props → not rendered)", () => {
+    const payload: ResultsReadoutPayload = {
+      overall: 6,
+      criteria: [{ key: "k", label: "L", score: 6 }],
+    };
+    render(<ResultsReadoutShell result={payload} />);
+    expect(screen.queryByTestId("hf-results-readout-tier")).toBeNull();
+    expect(screen.queryByTestId("hf-results-readout-narrative")).toBeNull();
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Honest empty / loading / error states (no fake bands)
+// ────────────────────────────────────────────────────────────
+
+describe("ResultsReadoutShell — honest loading / error / empty (no fake bands)", () => {
+  it("renders the empty state when result is null and no error/loading", () => {
+    render(<ResultsReadoutShell result={null} />);
+    expect(
+      screen.getByTestId("hf-results-readout-empty"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("hf-results-readout-overall")).toBeNull();
+    expect(screen.queryByTestId("hf-results-readout-criteria")).toBeNull();
+  });
+
+  it("renders the empty state when result.criteria is empty", () => {
+    const empty: ResultsReadoutPayload = { overall: 0, criteria: [] };
+    render(<ResultsReadoutShell result={empty} />);
+    expect(screen.getByTestId("hf-results-readout-empty")).toBeInTheDocument();
+    expect(screen.queryByTestId("hf-results-readout-overall")).toBeNull();
+  });
+
+  it("renders the loading state when loading=true (no fake bands)", () => {
+    render(<ResultsReadoutShell loading />);
+    expect(screen.getByTestId("hf-results-readout-loading")).toBeInTheDocument();
+    expect(screen.queryByTestId("hf-results-readout-overall")).toBeNull();
+    expect(screen.queryByTestId("hf-results-readout-empty")).toBeNull();
+  });
+
+  it("renders the error state when error string is supplied (no fake bands)", () => {
+    render(<ResultsReadoutShell error="Could not load results." />);
+    const err = screen.getByTestId("hf-results-readout-error");
+    expect(err).toHaveTextContent("Could not load results.");
+    expect(screen.queryByTestId("hf-results-readout-overall")).toBeNull();
+    expect(screen.queryByTestId("hf-results-readout-empty")).toBeNull();
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Capability overrides flow through to data attributes
+// ────────────────────────────────────────────────────────────
+
+describe("ResultsReadoutShell — capability overrides", () => {
+  it("colourTheme override flows to data-colour-theme attribute", () => {
+    const caps: LearnerShellCapabilities = {
+      ...SHELL_DEFAULTS["results-readout"],
+      colourTheme: "dark",
+    };
+    render(<ResultsReadoutShell capabilities={caps} />);
+    expect(
+      screen.getByTestId("hf-results-readout-shell").getAttribute("data-colour-theme"),
+    ).toBe("dark");
+  });
+
+  it("dismissOnEnd override flows to data-dismiss-on-end attribute", () => {
+    const caps: LearnerShellCapabilities = {
+      ...SHELL_DEFAULTS["results-readout"],
+      dismissOnEnd: "home",
+    };
+    render(<ResultsReadoutShell capabilities={caps} />);
+    expect(
+      screen
+        .getByTestId("hf-results-readout-shell")
+        .getAttribute("data-dismiss-on-end"),
+    ).toBe("home");
+  });
+
+  it("a non-null modePillKey override renders the pill", () => {
+    const caps: LearnerShellCapabilities = {
+      ...SHELL_DEFAULTS["results-readout"],
+      modePillKey: "mock-exam",
+    };
+    render(<ResultsReadoutShell capabilities={caps} />);
+    const pill = screen.getByTestId("hf-shell-mode-pill");
+    expect(pill.getAttribute("data-mode-pill-key")).toBe("mock-exam");
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Dismiss / Next CTAs + children slot
+// ────────────────────────────────────────────────────────────
+
+describe("ResultsReadoutShell — dismiss + next CTAs", () => {
+  it("renders the dismiss button when onDismiss handler supplied", () => {
+    const onDismiss = vi.fn();
+    render(<ResultsReadoutShell onDismiss={onDismiss} />);
+    const btn = screen.getByTestId("hf-results-readout-dismiss");
+    fireEvent.click(btn);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the next button when onNext handler supplied", () => {
+    const onNext = vi.fn();
+    render(<ResultsReadoutShell onNext={onNext} />);
+    const btn = screen.getByTestId("hf-results-readout-next");
+    fireEvent.click(btn);
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
+
+  it("children slot OVERRIDES the default CTAs", () => {
+    render(
+      <ResultsReadoutShell onDismiss={() => {}} onNext={() => {}}>
+        <button type="button" data-testid="custom-cta">Custom</button>
+      </ResultsReadoutShell>,
+    );
+    expect(screen.getByTestId("custom-cta")).toBeInTheDocument();
+    expect(screen.queryByTestId("hf-results-readout-dismiss")).toBeNull();
+    expect(screen.queryByTestId("hf-results-readout-next")).toBeNull();
+  });
+
+  it("renders no controls slot when no handlers and no children", () => {
+    render(<ResultsReadoutShell />);
+    expect(screen.queryByTestId("hf-results-readout-dismiss")).toBeNull();
+    expect(screen.queryByTestId("hf-results-readout-next")).toBeNull();
+  });
+});

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -2909,6 +2909,38 @@ Get all media shared with a caller across their calls. Supports sort, order, typ
 
 ---
 
+### `GET` /api/callers/:callerId/mock-results?sessionId=…
+
+Returns the per-criterion Mock results payload for the
+
+**Auth**: session (VIEWER+ — STUDENT scoped to own caller) · **Scope**: `callers:read`
+
+| Parameter | In | Type | Required | Description |
+|-----------|-----|------|----------|-------------|
+| callerId | path | string | Yes | Caller.id |
+
+**Response** `200`
+```json
+{ok: true, result: ResultsReadoutPayload | null}
+```
+
+**Response** `400`
+```json
+{ok: false, error: string}
+```
+
+**Response** `403`
+```json
+{ok: false, error: string}
+```
+
+**Response** `500`
+```json
+{ok: false, error: string}
+```
+
+---
+
 ### `GET` /api/callers/:callerId/prompt-staleness
 
 Returns whether the active composed prompt for this caller is stale (upstream compose-affecting writes newer than the cached `ComposedPrompt.composedAt`). Powers the `<StalePromptPill />` UI.
@@ -16387,8 +16419,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 543 |
-| Files with annotations | 529 |
+| Route files found | 544 |
+| Files with annotations | 530 |
 | Files missing annotations | 14 |
 | Coverage | 97.4% |
 

--- a/docs/API-PUBLIC.md
+++ b/docs/API-PUBLIC.md
@@ -945,6 +945,38 @@ Returns learning trajectory for a caller. The shape adapts to
 
 ---
 
+### `GET` /api/v1/callers/:callerId/mock-results?sessionId=…
+
+Returns the per-criterion Mock results payload for the
+
+**Auth**: session (VIEWER+ — STUDENT scoped to own caller) · **Scope**: `callers:read`
+
+| Parameter | In | Type | Required | Description |
+|-----------|-----|------|----------|-------------|
+| callerId | path | string | Yes | Caller.id |
+
+**Response** `200`
+```json
+{ok: true, result: ResultsReadoutPayload | null}
+```
+
+**Response** `400`
+```json
+{ok: false, error: string}
+```
+
+**Response** `403`
+```json
+{ok: false, error: string}
+```
+
+**Response** `500`
+```json
+{ok: false, error: string}
+```
+
+---
+
 ### `POST` /api/v1/callers/:callerId/reset
 
 Full reset for a caller — deletes ALL runtime data (calls, transcripts,


### PR DESCRIPTION
## Summary

W6 of `memory/handoff_lattice_all_settings_to_ui_2026_06_21.md` (story #2185 U11). **Demo-critical for tonight's IELTS Mock → Mock Results screen** (per BDD US-Mock-05 + HF-IELTS-Pre-Voice-Testing-Checklist Unit 5).

- `ResultsReadoutShell.tsx` — capability-driven shell (per `.claude/rules/shell-coverage.md`); reads `SHELL_DEFAULTS["results-readout"]` for affordances (brand theme, no timer, no mode pill). Never branches on shellKind inside JSX. Honest loading / empty / error states — never fabricates bands (per operator-pinned "no hardcoded score backfill" rule).
- `GET /api/callers/[callerId]/mock-results?sessionId=X` — STUDENT-scoped (per `lib/learner-scope.ts`); reads `CallScore` rows and resolves canonical labels from `Parameter.name` server-side, so IELTS criterion literals never appear in the learner-UI source (learner-ui-leak-coverage stays clean).
- SimChat dispatcher — mounts ResultsReadoutShell as a full-screen overlay when `examMode && callPhase === "ended"`, parallel to the existing `ExamModeShell` pattern.
- `shell-coverage.test.ts::EXPECTED_GAP_COUNT` **2 → 1** (only `IntakeWizardShell` remains for W7).

### Sanctioned per BDD US-Mock-05

This is the ONE learner-facing surface allowed to display per-criterion bands (FC / LR / GRA / Pron). Labels arrive via the response payload — never as literals in the `.tsx` source — so the build-time `learner-ui-leak-coverage` walk stays green.

### Lattice 5-layer status

1. Typed primitive — `LearnerShellKind` includes `"results-readout"` (PR #2173).
2. Generic engine — `resolveLearnerShell` returns it (PR #2199).
3. UI surface — **THIS PR** (shell + admin GET route + SimChat dispatch).
4. Coverage gate — `shell-coverage` ratchet drops 2 → 1.
5. Paired rule — `.claude/rules/shell-coverage.md` already names ResultsReadoutShell in KIND_TO_COMPONENT; only needed the file.

## Verified by

- **Survey** (per `.claude/rules/lattice-survey.md`): qmd search across ResultsReadoutShell / ExamModeShell capabilities / ChatFeedShell / MCQRoundsShell / `apps/foh/app/api/scores/route.ts`; read each existing shell + SimChat dispatcher (`apps/admin/components/sim/SimChat.tsx:2222`) for the canonical post-end overlay pattern.
- ✅ `vitest tests/components/sim/ResultsReadoutShell.test.tsx` → **18/18 pass** — default capabilities frame; band rendering with arbitrary label props (pins the label-as-data pattern); integer/non-finite band formatting; honest empty/loading/error; capability overrides flow through.
- ✅ `vitest tests/components/shell-coverage.test.ts` → **9/9 pass**; ratchet drops to `EXPECTED_GAP_COUNT = 1`.
- ✅ `vitest tests/components/sim/` → **57/57 pass** — no regressions on sibling ExamModeShell + learner-shells + PinnedCardSlot.
- ✅ `vitest tests/lib/sim-chat/learner-ui-leak-coverage.test.ts` → **11/11 pass** — no new IELTS criterion literal leaks (labels flow via props).
- ✅ `vitest tests/api/route-auth-zod-coverage.test.ts` → **5/5 pass** (new GET route is no-body; gates on `requireAuth("VIEWER")` + `studentAllowedToReadCaller` per learner-scope discipline).
- ✅ `npx tsc --noEmit` → 42 errors (matches `.ratchet.json::tsc_errors` baseline; no new errors from W6 files).
- ✅ `npx eslint` on net-new files → 0 errors / 0 warnings.
- ⚠ `lattice-self-maintenance.test.ts` pre-existing failure on `data-presence-` citation — confirmed via `git stash` + re-run on bare origin/main; unrelated to W6.

## Test plan

- [ ] Operator smoke: end an IELTS Mock-style call on hf-dev; confirm ResultsReadoutShell mounts post-end with the real per-criterion bands (or honest empty state if no CallScore rows yet).
- [ ] Confirm STUDENT scoping: a STUDENT session cannot read another caller's mock-results via `?callerId=` swap.
- [ ] Confirm labels render from `Parameter.name` (canonical) — `Fluency and Coherence`, etc., not the parameterId.
- [ ] Confirm overlay is suppressed in embedded mode (operator-side views need the chat feed inspectable).
- [ ] After W7 (IntakeWizardShell) lands, drop `EXPECTED_GAP_COUNT` to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)