### PR TITLE
fix(api): /api/student/teacher returns ok:true empty-state for caller without cohort (was 404)

### DIFF
--- a/apps/admin/app/api/student/teacher/route.ts
+++ b/apps/admin/app/api/student/teacher/route.ts
@@ -12,16 +12,27 @@ export async function GET(request: NextRequest) {
   const auth = await requireStudentOrAdmin(request);
   if (isStudentAuthError(auth)) return auth.error;
 
-  // Query all cohort memberships (prefer join table, fallback to legacy FK)
+  // Query all cohort memberships (prefer join table, fallback to legacy FK).
+  // `requireStudentOrAdmin` already resolved the target caller (STUDENT → own
+  // LEARNER; OPERATOR+ → ?callerId=<id>) and populated cohortGroupIds with that
+  // caller's memberships. An empty array therefore means "this caller is not
+  // a member of any classroom" — a legitimate empty-state, not an error.
   const cohortIds = auth.cohortGroupIds.length > 0
     ? auth.cohortGroupIds
     : auth.cohortGroupId ? [auth.cohortGroupId] : [];
 
+  // No-classroom is a valid state — return ok:true with empty/null fields so
+  // the caller-detail "ai-call" tab on the admin side doesn't surface a JS
+  // error every time an operator views a caller who isn't classroom-assigned.
   if (cohortIds.length === 0) {
-    return NextResponse.json(
-      { ok: false, error: "No classroom found" },
-      { status: 404 }
-    );
+    return NextResponse.json({
+      ok: true,
+      teacher: null,
+      classroom: null,
+      classrooms: [],
+      domain: null,
+      institution: null,
+    });
   }
 
   const cohorts = await prisma.cohortGroup.findMany({
@@ -35,11 +46,17 @@ export async function GET(request: NextRequest) {
     },
   });
 
+  // Memberships referenced cohorts that no longer exist — same empty-state
+  // shape so the consumer can branch on `classroom === null`.
   if (cohorts.length === 0) {
-    return NextResponse.json(
-      { ok: false, error: "Classroom not found" },
-      { status: 404 }
-    );
+    return NextResponse.json({
+      ok: true,
+      teacher: null,
+      classroom: null,
+      classrooms: [],
+      domain: null,
+      institution: null,
+    });
   }
 
   // Primary cohort (first membership) for backwards compat


### PR DESCRIPTION
## Summary

Admin-side view of `/x/callers/<id>?tab=ai-call` fetched `/api/student/teacher?callerId=<id>` and the route 404'd ("No classroom found") whenever the resolved caller had no cohort memberships AND no legacy `cohortGroupId`. Browser dev console showed an uncaught fetch reject on every page-load of a caller-detail page for any caller not yet assigned to a classroom.

Operator caught it tonight via a bug report on caller Kevin Dunaway / "Introduction to Psychology" — also affects 4 IELTS-enrolled test callers on hf_sandbox (paired data fix already landed via inline cohort assignment).

## Change

When `auth.cohortGroupIds` is empty (or the looked-up CohortGroup rows are stale), return **HTTP 200 with structured null fields** instead of 404. The "Your teacher" / classroom header is informational chrome — a missing classroom is a valid empty-state, not an error.

Auth gating unchanged: `requireStudentOrAdmin` continues to deny unauthenticated / mismatched-role access with its own 4xx. This fix only loosens the inner "no classroom" branch.

## Verified by

- **Lattice survey per `.claude/rules/lattice-survey.md`:**
  - Producer: this route
  - Consumer: FE caller-detail `ai-call` tab fetches `/api/student/teacher?callerId=<id>` and expects a JSON body
  - Sibling-writer risk: zero — no other writer touches the response shape
  - Convention-conflict: zero — empty-state-as-200 matches sibling patterns
- **Live evidence:** hf_sandbox 4 IELTS callers (Winter Doyle / Freya Popov / Kofi Okamoto / Kevin Dunaway) — none had cohort memberships before tonight; route 404'd on every admin view
- **Auth shape unchanged**

## Test plan

- [ ] CI green (tsc + lint + unit)
- [ ] Hit `/api/student/teacher?callerId=<unenrolled-caller-id>` → 200 with `classroom: null`
- [ ] Hit with classroom-assigned caller → 200 with full teacher/classroom payload (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)