### PR TITLE
feat(sim): #2227 — pinned cue card restorable after dismiss (U8 of #2185)

### DIFF
--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -1975,6 +1975,42 @@ html.light {
   outline: none;
 }
 
+/* #2227 (U8 of #2185) — collapsed-state restore chip. Sits in the same
+   slot region as the expanded card so the affordance never disappears
+   from the learner's field of view. Click to re-expand; reuses the
+   in-memory pinned-card content (no refetch). */
+.hf-pinned-card-restore {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--border-default);
+  background: var(--surface-secondary);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  max-width: 100%;
+  transition: all 0.15s ease;
+}
+.hf-pinned-card-restore:hover,
+.hf-pinned-card-restore:focus-visible {
+  border-color: color-mix(in srgb, var(--accent-primary) 40%, transparent);
+  color: var(--text-primary);
+  outline: none;
+}
+.hf-pinned-card-restore-icon {
+  font-size: 13px;
+  line-height: 1;
+}
+.hf-pinned-card-restore-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 220px;
+}
+
 /* #1743 — stall-detector chip. Subtle fade-in cue above the chat surface
    when the learner has gone quiet during a monologue / discussion module.
    Voice never triggers from this; it is a visual nudge only. */

--- a/apps/admin/components/sim/PinnedCardSlot.tsx
+++ b/apps/admin/components/sim/PinnedCardSlot.tsx
@@ -9,18 +9,21 @@
  *
  * Fetch: one-shot `GET /api/calls/[callId]/pinned-card` when the
  * supplied `callId` becomes available (a sim `[Talk Here]` click). The
- * card never changes mid-session — no SSE / polling.
+ * card never changes mid-session — no SSE / polling, and the expand
+ * path after collapse reuses the in-memory `card` state (no refetch).
  *
  * Render variants by `kind`:
  *   - "cueCard":   topic + bullets + optional secondaryNote
  *   - "topicFocus": topic + optional focusArea (single-line)
  *
- * Dismissibility: Esc key removes the card for the rest of the session
- * (does not refetch on the next render). The learner can also call this
- * a "soft" hide by clicking the ✕ button.
+ * Collapse / restore (#2227, U8 of #2185): clicking ✕ (or pressing Esc)
+ * collapses the card to a small persistent chip in the same slot region.
+ * Clicking the chip expands the card back to full view. Esc toggles
+ * between the two states. The pre-#2227 "hard dismiss" is gone — the
+ * card can no longer become unrecoverable during a session.
  *
  * Auto-clear: when `phaseEnded` flips true (callPhase === "ended" /
- * "wrapping" at the consumer), the card stops rendering.
+ * "wrapping" at the consumer), neither the card nor the chip renders.
  */
 
 "use client";
@@ -39,11 +42,11 @@ export function PinnedCardSlot({
   phaseEnded,
 }: PinnedCardSlotProps): React.ReactElement | null {
   const [card, setCard] = useState<PinnedCardContent | null>(null);
-  const [dismissed, setDismissed] = useState(false);
+  const [collapsed, setCollapsed] = useState(false);
 
-  // Reset dismissal when callId changes — a new call earns a fresh card.
+  // Reset collapse when callId changes — a new call earns a fresh card.
   useEffect(() => {
-    setDismissed(false);
+    setCollapsed(false);
     setCard(null);
   }, [callId]);
 
@@ -66,18 +69,37 @@ export function PinnedCardSlot({
     return () => controller.abort();
   }, [callId]);
 
-  const handleDismiss = useCallback(() => setDismissed(true), []);
+  const handleToggle = useCallback(() => setCollapsed((prev) => !prev), []);
 
   useEffect(() => {
-    if (!card || dismissed || phaseEnded) return;
+    if (!card || phaseEnded) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") handleDismiss();
+      if (e.key === "Escape") handleToggle();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [card, dismissed, phaseEnded, handleDismiss]);
+  }, [card, phaseEnded, handleToggle]);
 
-  if (!card || dismissed || phaseEnded) return null;
+  if (!card || phaseEnded) return null;
+
+  if (collapsed) {
+    const restoreLabel =
+      card.kind === "cueCard" ? "Show cue card" : "Show topic focus";
+    return (
+      <button
+        type="button"
+        className="hf-pinned-card-restore"
+        aria-label={restoreLabel}
+        data-testid="pinned-card-restore-chip"
+        onClick={handleToggle}
+      >
+        <span className="hf-pinned-card-restore-icon" aria-hidden="true">
+          📌
+        </span>
+        <span className="hf-pinned-card-restore-label">{card.topic}</span>
+      </button>
+    );
+  }
 
   if (card.kind === "cueCard") {
     return (
@@ -90,8 +112,8 @@ export function PinnedCardSlot({
         <button
           type="button"
           className="hf-pinned-card-dismiss"
-          aria-label="Dismiss pinned card"
-          onClick={handleDismiss}
+          aria-label="Collapse pinned card"
+          onClick={handleToggle}
         >
           ✕
         </button>
@@ -121,8 +143,8 @@ export function PinnedCardSlot({
       <button
         type="button"
         className="hf-pinned-card-dismiss"
-        aria-label="Dismiss pinned card"
-        onClick={handleDismiss}
+        aria-label="Collapse pinned card"
+        onClick={handleToggle}
       >
         ✕
       </button>

--- a/apps/admin/tests/components/sim/PinnedCardSlot.test.tsx
+++ b/apps/admin/tests/components/sim/PinnedCardSlot.test.tsx
@@ -1,11 +1,18 @@
 /**
  * #1744 (epic #1700 Theme 3) — PinnedCardSlot render contract.
+ * #2227 (U8 of #2185) — collapse / restore round-trip.
  *
  * Pinned acceptance:
  *   1. cueCard variant renders topic + bullets + secondaryNote
  *   2. topicFocus variant renders topic + focusArea on one line
  *   3. phaseEnded=true → renders null even when a card is loaded
- *   4. Esc dismisses; click ✕ also dismisses; remounting with new callId resets
+ *   4. Esc collapses (chip renders); ✕ collapses (chip renders); new
+ *      callId resets to expanded
+ *   5. (#2227) cueCard collapse → chip → click to expand round-trip,
+ *      no refetch
+ *   6. (#2227) topicFocus collapse → chip → click to expand round-trip,
+ *      no refetch
+ *   7. (#2227) Esc toggles — second Esc on a collapsed card re-expands
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -91,9 +98,10 @@ describe("PinnedCardSlot", () => {
     );
     rerender(<PinnedCardSlot callId="call-3" phaseEnded={true} />);
     expect(screen.queryByTestId("pinned-card-slot")).toBeNull();
+    expect(screen.queryByTestId("pinned-card-restore-chip")).toBeNull();
   });
 
-  it("(4) Esc dismisses; ✕ dismisses; new callId resets dismissal", async () => {
+  it("(4) Esc collapses; ✕ collapses; new callId resets to expanded", async () => {
     vi.stubGlobal(
       "fetch",
       mockFetch({
@@ -109,16 +117,115 @@ describe("PinnedCardSlot", () => {
     );
 
     fireEvent.keyDown(window, { key: "Escape" });
+    // Esc collapses to a chip — full card gone, chip present.
     expect(screen.queryByTestId("pinned-card-slot")).toBeNull();
+    expect(screen.getByTestId("pinned-card-restore-chip")).toBeInTheDocument();
 
-    // New callId resets dismissal — re-fetch should render again.
+    // New callId resets to expanded — chip gone, full card back.
     rerender(<PinnedCardSlot callId="call-5" phaseEnded={false} />);
     await waitFor(() =>
       expect(screen.getByTestId("pinned-card-slot")).toBeInTheDocument(),
     );
+    expect(screen.queryByTestId("pinned-card-restore-chip")).toBeNull();
 
-    // ✕ button also dismisses.
-    fireEvent.click(screen.getByLabelText("Dismiss pinned card"));
+    // ✕ button also collapses to chip.
+    fireEvent.click(screen.getByLabelText("Collapse pinned card"));
     expect(screen.queryByTestId("pinned-card-slot")).toBeNull();
+    expect(screen.getByTestId("pinned-card-restore-chip")).toBeInTheDocument();
+  });
+
+  it("(5) #2227 cueCard collapse → chip → click expand, no refetch", async () => {
+    const fetchMock = mockFetch({
+      ok: true,
+      card: {
+        kind: "cueCard",
+        topic: "Family member you admire",
+        bullets: [
+          "who this person is",
+          "how often you see them",
+          "what kind of personality they have",
+        ],
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<PinnedCardSlot callId="call-6" phaseEnded={false} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("pinned-card-slot")).toBeInTheDocument(),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Collapse via ✕.
+    fireEvent.click(screen.getByLabelText("Collapse pinned card"));
+    const chip = screen.getByTestId("pinned-card-restore-chip");
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveAttribute("aria-label", "Show cue card");
+    // Chip carries the topic so the learner sees what they're restoring.
+    expect(chip).toHaveTextContent("Family member you admire");
+
+    // Click chip → expand. No additional fetch.
+    fireEvent.click(chip);
+    await waitFor(() =>
+      expect(screen.getByTestId("pinned-card-slot")).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("pinned-card-restore-chip")).toBeNull();
+    expect(screen.getByText("who this person is")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("(6) #2227 topicFocus collapse → chip → click expand, no refetch", async () => {
+    const fetchMock = mockFetch({
+      ok: true,
+      card: {
+        kind: "topicFocus",
+        topic: "Education in your country",
+        focusArea: "structuring an argument",
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<PinnedCardSlot callId="call-7" phaseEnded={false} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("pinned-card-slot")).toBeInTheDocument(),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Collapse via ✕.
+    fireEvent.click(screen.getByLabelText("Collapse pinned card"));
+    const chip = screen.getByTestId("pinned-card-restore-chip");
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveAttribute("aria-label", "Show topic focus");
+    expect(chip).toHaveTextContent("Education in your country");
+
+    // Click chip → expand. No additional fetch.
+    fireEvent.click(chip);
+    await waitFor(() =>
+      expect(screen.getByTestId("pinned-card-slot")).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("pinned-card-restore-chip")).toBeNull();
+    expect(screen.getByText("— structuring an argument")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("(7) #2227 Esc toggles — second Esc on collapsed card re-expands", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        ok: true,
+        card: { kind: "cueCard", topic: "Toggle", bullets: ["a"] },
+      }),
+    );
+    render(<PinnedCardSlot callId="call-8" phaseEnded={false} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("pinned-card-slot")).toBeInTheDocument(),
+    );
+
+    // Esc 1 — collapse.
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByTestId("pinned-card-slot")).toBeNull();
+    expect(screen.getByTestId("pinned-card-restore-chip")).toBeInTheDocument();
+
+    // Esc 2 — expand.
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.getByTestId("pinned-card-slot")).toBeInTheDocument();
+    expect(screen.queryByTestId("pinned-card-restore-chip")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- `<PinnedCardSlot>` ✕ button now collapses the card to a small persistent chip in the same slot region; click the chip to expand back. Esc toggles between the two states.
- Pre-#2227 "hard dismiss" is gone — the card can no longer become unrecoverable mid-session (the operator complaint that originated this story).
- No API / schema change. Card content is immutable mid-session per `createSession` (#1733); expand reuses in-memory state, no refetch.

## Verified by

- ✅ `vitest tests/components/sim/PinnedCardSlot.test.tsx` — 7/7 green (existing 4 + new 3 for cueCard collapse→expand, topicFocus collapse→expand, Esc toggle round-trip)
- ✅ `vitest tests/lib/sim-chat/mode-ui-coverage.test.ts` — 8/8 (unaffected ratchet, no new mode literal)
- ✅ `vitest tests/components/shell-coverage.test.ts` — 9/9 (PinnedCardSlot isn't a shell)
- ✅ `vitest tests/lib/sim-chat/learner-ui-leak-coverage.test.ts` — 11/11
- ✅ `npx tsc --noEmit` clean for touched files
- ✅ ESLint clean (1 pre-existing `react-hooks/set-state-in-effect` warning at the same site as before — count unchanged; rule is `warn`-severity per `react-hooks-compiler-rules-warn.md`)
- ✅ Lattice survey ([`.claude/rules/lattice-survey.md`](.claude/rules/lattice-survey.md)): `Session.metadata.pinnedCard` is write-once at `createSession` (#1733). Mid-session sibling writers `lib/scoring/write-overall-band.ts` + `lib/curriculum/build-post-assessment-plan.ts` use Prisma JSON merge and preserve `metadata.pinnedCard`. No refetch needed on expand — the "card immutable mid-session" assumption holds.

## Out of scope (deferred to follow-on U-story)

- Chat narrates "📌 Cue card pinned above" when the assistant ramps into Part 2 (the second half of the originating operator complaint). Needs a ramp detector — either regex on assistant turn or a structured COMPOSE-stage signal. Separate story with its own scope.
- Persistence across page refresh (localStorage). Stays session-only; matches today.
- Promoting dismissibility to `LearnerShellCapabilities` — Tech Lead's call: it's per-card-type (cueCard vs topicFocus), not per-shell-kind. Premature for a one-shell affordance. Future migration is mechanical (no schema change).

## Test plan

- [x] Vitest pins the dismiss→chip→expand round trip on both `cueCard` and `topicFocus` variants
- [x] Vitest pins Esc toggle (collapse, then expand) on the same card
- [x] Vitest pins `phaseEnded=true` hides BOTH full card AND chip
- [x] Vitest pins new `callId` resets to expanded state (matches existing #1744 contract)
- [ ] Manual sim on hf_sandbox: open Mock module → cue card pins → ✕ → chip shows topic → click chip → card returns. Then Esc → chip → Esc → card.

Closes #2227. Umbrella #2185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)