### PR TITLE
fix(lattice): #2225 A0 — registry-consumer-coverage actually verifies cascade-family match

### DIFF
--- a/apps/admin/tests/lib/journey/registry-consumer-coverage.test.ts
+++ b/apps/admin/tests/lib/journey/registry-consumer-coverage.test.ts
@@ -15,18 +15,33 @@
  *  PRs #1780-series added the registry entries but the consumer
  *  reads were deferred or forgotten).
  *
- * **How matching works:**
- *  Settings whose `storagePath.root` is a known cascade family
- *  (`sessionFlow.*`, `playbook.voiceConfig.*`, `behaviorTargets*`,
- *  `domain.*`) shortcut to COVERED — their reads go through the
- *  canonical resolver, which IS the consumer.
+ * **How matching works (corrected 2026-06-21 per A0 of #2225):**
+ *  Settings whose `(cascadeKnobKey ?? id)` matches a registered cascade
+ *  family in `lib/cascade/effective-value.ts::FAMILIES` shortcut to
+ *  COVERED via `family-shortcut` — their reads go through the canonical
+ *  resolver, which IS the consumer. The check uses the exported
+ *  `isResolvableKnob(knobKey)` helper so the test agrees with the
+ *  Inspector's runtime call `useEffectiveValue(cascadeKnobKey ?? id)`.
  *
- *  For `config.*` and `tolerances.*` paths the test concatenates
+ *  HISTORICAL BUG (pre-A0): the test previously shortcut on
+ *  `storagePath.root` matching `sessionFlow.*` / `playbook.voiceConfig.*` /
+ *  `behaviorTargets*` / `domain.*`. The cascade `FAMILIES` table only
+ *  matches FINE-GRAINED knob keys (`welcomeMessage`, `intake`,
+ *  `onboarding`, `stops`, `offboarding`, voice keys, BEH-*, mastery
+ *  knobs) — NOT the coarse storagePath roots. So leaf contracts like
+ *  `intakeGoalsQuestion` (knobKey `intakeGoalsQuestion`, NOT `intake`)
+ *  silently fell into `family-shortcut` even though `isResolvableKnob`
+ *  returns false for them. They appeared COVERED but the Inspector's
+ *  cascade chip rendered nothing. Fix replaces the storagePath-root
+ *  heuristic with the real `isResolvableKnob` check; non-cascade
+ *  contracts fall through to substring search as before.
+ *
+ *  For settings that aren't cascade-resolvable, the test concatenates
  *  source from the consumer surfaces (transforms / compose / cascade
  *  resolvers / pipeline schedulers) and checks that the most
- *  distinctive segment of the path appears as a substring. Generic
- *  trailing segments (`enabled`, `value`, `type`, `mode`) are
- *  stripped — the next-up segment is searched instead.
+ *  distinctive segment of the storagePath appears as a substring.
+ *  Generic trailing segments (`enabled`, `value`, `type`, `mode`)
+ *  are stripped — the next-up segment is searched instead.
  *
  *  Exemptions live in `REGISTRY_CONSUMER_EXEMPT_PATHS` with required
  *  one-line reason. The ratchet pins the current exempt count: it
@@ -54,6 +69,7 @@ import { join, resolve } from "node:path";
 
 import { JOURNEY_SETTINGS } from "@/lib/journey/setting-contracts.entries";
 import { VOICE_SETTINGS } from "@/lib/settings/voice-setting-contracts";
+import { isResolvableKnob } from "@/lib/cascade/effective-value";
 import type {
   JourneySettingContract,
   StoragePath,
@@ -188,15 +204,12 @@ function getPathString(sp: StoragePath): string {
   return typeof sp === "string" ? sp : sp.path;
 }
 
-function getStorageRoot(path: string): string {
-  if (path.startsWith("config.")) return "config";
-  if (path.startsWith("sessionFlow.")) return "sessionFlow";
-  if (path.startsWith("tolerances.")) return "tolerances";
-  if (path.startsWith("playbook.voiceConfig.")) return "playbook.voiceConfig";
-  if (path.startsWith("domain.")) return "domain";
-  if (path.startsWith("behaviorTargets")) return "behaviorTargets";
-  return "unknown";
-}
+// Note: `getStorageRoot` was removed 2026-06-21 (A0 of #2225). The
+// previous storagePath-root heuristic produced false-negative COVERED
+// classifications for contracts that LOOKED like they sat under a
+// cascade family but whose leaf knobKey isn't actually resolvable.
+// The replacement (`isResolvableKnob(cascadeKnobKey ?? id)`) lives
+// inline in `classify()`. See header docstring.
 
 /** Pick search terms to try. Strips `[]` placeholders + generic
  *  trailing names + handles `*Enabled` camelCase boolean suffixes by
@@ -260,19 +273,24 @@ function classify(c: JourneySettingContract): ClassResult {
     return { id: c.id, classification: "family-shortcut" };
   }
 
-  const path = getPathString(c.storagePath);
-  const root = getStorageRoot(path);
-
-  // Family shortcut — paths under a known cascade family are read
-  // through their canonical resolver (which IS in CONSUMER_DIRS).
-  if (
-    root === "sessionFlow" ||
-    root === "playbook.voiceConfig" ||
-    root === "behaviorTargets" ||
-    root === "domain"
-  ) {
+  // Family shortcut — the contract's knobKey actually matches a
+  // registered cascade family in `lib/cascade/effective-value.ts`.
+  // The Inspector calls `useEffectiveValue(cascadeKnobKey ?? id, scope)`
+  // at runtime; this check uses the SAME helper (`isResolvableKnob`)
+  // so the test's COVERED verdict aligns with the runtime cascade
+  // chip rendering. A contract that fails this check but whose
+  // storagePath looks like it sits "under" a cascade family (e.g.
+  // `sessionFlow.intake.goals.question`) is NOT covered by the
+  // cascade — it falls through to substring search below.
+  //
+  // Structural correction 2026-06-21 (A0 of #2225) — see header
+  // docstring for the historical false-negative this replaces.
+  const knobKey = c.cascadeKnobKey ?? c.id;
+  if (isResolvableKnob(knobKey)) {
     return { id: c.id, classification: "family-shortcut" };
   }
+
+  const path = getPathString(c.storagePath);
 
   // Exempt — known producer-only with documented reason.
   if (REGISTRY_CONSUMER_EXEMPT_PATHS[c.id]) {


### PR DESCRIPTION
## Summary

Replaces the false-negative `storagePath.root` heuristic in
`tests/lib/journey/registry-consumer-coverage.test.ts` with a real
`isResolvableKnob(cascadeKnobKey ?? id)` check from
`lib/cascade/effective-value.ts`. The Coverage gate now agrees with the
Inspector's runtime call `useEffectiveValue(cascadeKnobKey ?? id, scope)`.

## Why

The previous shortcut classified any contract with `storagePath` rooted
at `sessionFlow.*` / `playbook.voiceConfig.*` / `behaviorTargets*` /
`domain.*` as `family-shortcut = COVERED` — without checking whether
the cascade family resolver actually covers the leaf knob.

The cascade `FAMILIES` table only matches FINE-GRAINED knob keys
(`welcomeMessage` exact, `intake` / `onboarding` / `stops` / `offboarding`
exact-top-level, voice keys exact, `BEH-*` prefix, mastery-policy knobs
exact). Leaf contracts like `intakeGoalsQuestion` (knobKey
`intakeGoalsQuestion`, NOT `intake`) matched the root-prefix heuristic
but `isResolvableKnob` returns false for them — so at runtime the
Inspector's `useEffectiveValue` returns `unresolvable: true` and the
cascade chip silently renders nothing. The test said COVERED; the
runtime said NOTHING. That's the structural false-negative this PR
closes.

Foundational fix for epic #2225 — every downstream slice depends on
this gate giving honest readings.

## Before / After

**Before the fix:** 14 contracts hit `family-shortcut` via the
storagePath-root heuristic. A probe with `isResolvableKnob` showed
that 0 of those 14 actually resolve through the cascade — every single
`family-shortcut` classification was a false positive on the cascade
axis. Affected contracts (`intakeSpecId`, `intakeKnowledgeCheck`,
`intakeAboutYou`, `intakeAboutYouQuestion`, `intakeGoals`,
`intakeGoalsQuestion`, `intakeAiIntroCall`,
`intakeKnowledgeCheckMode`, `firstCallTargets`, `preTestStop`,
`midJourneyStop`, `npsStop`, `offboardingFlowPhases`, `postTestStop`).

**After the fix:** The 14 ex-fake-shortcuts redistribute to honest
buckets. Final distribution (105 contracts total):

| Classification | Count | Notes |
|---|---|---|
| `covered` | 66 | substring match in consumer source — incl. the 14 reclassifications (each has a distinctive segment present in `lib/intake/` / `lib/session-flow/` / etc.) |
| `family-shortcut` | 14 | 5 via real cascade match (`welcomeMessage` + 4 mastery-policy knobs) + 9 via `scope === "module"` carve-out |
| `no-compose-impact` | 25 | operator-only — no consumer needed |
| `exempt` | 0 | — |
| `gap` | 0 | — |

`EXPECTED_EXEMPT_COUNT = 0` stays valid. No ratchet bump needed —
substring search rescues the 14 ex-shortcuts so the structural fix is
behaviour-preserving on test outcome, but every future verdict is now
honest about cascade coverage.

## Verified by

- `npx vitest run tests/lib/journey/registry-consumer-coverage.test.ts` — green, 6/6 passing post-fix
- `npx tsc --noEmit` — 42 errors, exact match to `.ratchet.json::tsc_errors = 42` baseline (no new errors introduced)
- `npx eslint tests/lib/journey/registry-consumer-coverage.test.ts lib/cascade/effective-value.ts` — clean (no new warnings, no new errors)
- Pre-push hook ran: tsc 42 = baseline 42, lint clean
- Lattice survey per `.claude/rules/lattice-survey.md`: searched for sibling tests using the `family-shortcut` literal — only `registry-consumer-coverage.test.ts` uses it. No sibling-test contamination requiring a separate PR.
- Inverse-probe per `.claude/rules/verify-before-fix.md`: probed `isResolvableKnob` against the 9 known FAMILIES entries (TRUE) and the 10 representative leaf-contract ids that hit the false shortcut (FALSE) — clean discriminator.
- Quantified the false-negative population by running an instrumented dump script: 14 contracts hit the root-shortcut, 0 of them are cascade-resolvable, all 14 reclassify to substring-`covered` after the fix.

## Scope note

The task also requested a "Structural correction 2026-06-21" subsection
in `.claude/rules/registry-consumer-coverage.md`. Edits to that file
were blocked by the harness in this session. The structural correction
content is fully captured inline in the test file's header docstring
+ an in-classifier comment + a tombstone where `getStorageRoot` was
removed. A follow-on edit can mirror it into the rule file when the
harness restriction lifts — content is preserved word-for-word in the
docstring.

Closes A0 of #2225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)