### PR TITLE
feat(lattice): #2228 A1b — teachingStyle cascade FAMILIES + cascadeKnobKey bridge

### DIFF
--- a/apps/admin/lib/cascade/effective-value.ts
+++ b/apps/admin/lib/cascade/effective-value.ts
@@ -30,6 +30,7 @@ import { resolveVoiceConfigKnob } from "./resolvers/voice-config";
 import { resolveIdentitySpec } from "./resolvers/identity-spec";
 import { resolveMasteryPolicyKnob } from "./resolvers/mastery-policy";
 import { resolveAiMeasurementKnob } from "./resolvers/ai-measurement";
+import { resolveTeachingStyle } from "./resolvers/teaching-style";
 
 /**
  * Scope IDs the cascade can resolve against. SYSTEM is implicit (no id);
@@ -156,6 +157,17 @@ const FAMILIES: readonly KnobFamily[] = [
     name: "ai-measurement",
     match: (k) => k === "aiMeasurement.disableLlmIeltsScoring",
     resolve: (scope, knobKey) => resolveAiMeasurementKnob(scope, knobKey),
+  },
+  // #2228 A1b (2026-06-21) — `teachingStyle` is the sole CASCADE-Domain+
+  // Course knob still missing a FAMILIES entry. Asymmetric blob keys
+  // (`Domain.config.teachingStyleDefault` → `Playbook.config.teachingStyle`)
+  // mean it can't reuse `resolveMasteryPolicyKnob` — slim sibling resolver
+  // ships at `lib/cascade/resolvers/teaching-style.ts`, same shape as
+  // `welcome-message.ts`.
+  {
+    name: "teaching-style",
+    match: (k) => k === "teachingStyle",
+    resolve: (scope) => resolveTeachingStyle(scope),
   },
 ];
 

--- a/apps/admin/lib/cascade/resolvers/teaching-style.ts
+++ b/apps/admin/lib/cascade/resolvers/teaching-style.ts
@@ -1,0 +1,113 @@
+/**
+ * Teaching-style cascade resolver (#2228 A1b / epic #2225).
+ *
+ * `teachingStyle` is a CASCADE-Domain+Course knob but the two layers use
+ * ASYMMETRIC blob keys:
+ *
+ *   - Domain side: `Domain.config.teachingStyleDefault`
+ *   - Playbook side: `Playbook.config.teachingStyle`
+ *
+ * The mastery-policy resolver (`mastery-policy.ts`) requires symmetric
+ * keys (`Domain.config[knobKey]` === `Playbook.config[knobKey]`), so we
+ * land a slim sibling resolver here rather than bend SUPPORTED_KEYS to
+ * accept an asymmetric case. Pattern mirrors `welcome-message.ts` —
+ * same Domain-blob-vs-Playbook-blob asymmetric shape.
+ *
+ * `setAt` / `setBy`: returned `null` for both layers — `Playbook.config`
+ * and `Domain.config` are JSON blobs with no per-key authorship
+ * metadata. See `welcome-message.ts` TODO(cascade-provenance) for the
+ * follow-on story that would add `configUpdatedBy` / `configUpdatedAt`.
+ */
+
+// TODO(cascade-provenance): There is no per-key authorship metadata for
+// `Playbook.config.teachingStyle` or `Domain.config.teachingStyleDefault`.
+// Adding `configUpdatedBy` / `configUpdatedAt` columns to Playbook + Domain
+// would let us surface real "Set by Paul on 2026-05-22" provenance. Same
+// follow-on as `welcome-message.ts`.
+
+import { prisma } from "@/lib/prisma";
+
+import type { Effective, LayerHit } from "../layer-types";
+import type { ScopeChain } from "../effective-value";
+
+export async function resolveTeachingStyle(
+  scope: ScopeChain,
+): Promise<Effective<unknown>> {
+  if (!scope.playbookId) {
+    throw new Error(
+      `resolveTeachingStyle requires \`playbookId\` in scopeChain (got: ${JSON.stringify(
+        scope,
+      )})`,
+    );
+  }
+
+  const playbook = await prisma.playbook.findUnique({
+    where: { id: scope.playbookId },
+    select: {
+      id: true,
+      name: true,
+      config: true,
+      domainId: true,
+    },
+  });
+  if (!playbook) {
+    throw new Error(`Playbook not found: ${scope.playbookId}`);
+  }
+
+  const domain = await prisma.domain.findUnique({
+    where: { id: playbook.domainId },
+    select: { id: true, name: true, config: true },
+  });
+
+  const pbConfig = (playbook.config ?? {}) as Record<string, unknown>;
+  const domainConfig = (domain?.config ?? {}) as Record<string, unknown>;
+
+  // Build `layers` in SYSTEM→CALL order — DOMAIN before PLAYBOOK — so
+  // the inspector tray can iterate top-to-bottom without re-sorting.
+  const layers: LayerHit<unknown>[] = [];
+
+  const domainValue = domainConfig["teachingStyleDefault"];
+  if (domainValue !== undefined && domainValue !== null) {
+    layers.push({
+      layer: "DOMAIN",
+      scopeId: domain!.id,
+      scopeLabel: domain!.name,
+      value: domainValue,
+      setAt: null, // TODO(cascade-provenance)
+      setBy: null,
+    });
+  }
+
+  const playbookValue = pbConfig["teachingStyle"];
+  if (playbookValue !== undefined && playbookValue !== null) {
+    layers.push({
+      layer: "PLAYBOOK",
+      scopeId: playbook.id,
+      scopeLabel: playbook.name,
+      value: playbookValue,
+      setAt: null, // TODO(cascade-provenance)
+      setBy: null,
+    });
+  }
+
+  // Deepest (innermost) layer wins — the last entry in SYSTEM→CALL order.
+  const winner = layers.length > 0 ? layers[layers.length - 1] : null;
+
+  if (!winner) {
+    return {
+      value: null,
+      source: "SYSTEM",
+      layers: [],
+      isInherited: false,
+      recommendedLayerForEdit: "PLAYBOOK",
+    };
+  }
+
+  return {
+    value: winner.value,
+    source: winner.layer,
+    layers,
+    isInherited: winner.layer !== "PLAYBOOK",
+    recommendedLayerForEdit: "PLAYBOOK",
+  };
+}

--- a/apps/admin/lib/journey/setting-contracts.entries.ts
+++ b/apps/admin/lib/journey/setting-contracts.entries.ts
@@ -728,7 +728,13 @@ const G4_TIER_PRESET_ID: JourneySettingContract = {
     "When set to `ielts-speaking`, PROSODY calls the speech-assessment provider in IELTS mode and 4 sub-bands flow into the CallScore rows. Otherwise PROSODY scores in generic mode.",
   storagePath: "config.tierPresetId",
   control: "select",
-  cascadeSources: [],
+  // #2228 A1b — align cascadeSources with the FAMILIES `tier-preset`
+  // entry shipped by #2174 S3. Runtime resolver reads
+  // `Domain.config.tierPresetId` directly; `cascadeSources` is the
+  // documentation/Inspector-isInherited declaration.
+  cascadeSources: [
+    { level: "domain", storagePath: "domain.config.tierPresetId" },
+  ],
   composeImpact: {
     sections: ["moduleMastery", "loMastery"],
     kinds: ["scoring-weight"],
@@ -850,7 +856,17 @@ const G4_SKILL_SCORING_EMA_HALF_LIFE: JourneySettingContract = {
   helpText: "Days for the per-skill EMA to decay to half-weight.",
   storagePath: "config.skillScoringEmaHalfLifeDays",
   control: "number",
-  cascadeSources: [],
+  // #2228 A1b — align cascadeSources with the FAMILIES
+  // `mastery-policy` entry. The contract id (`skillScoringEmaHalfLife`)
+  // and the FAMILIES key (`skillScoringEmaHalfLifeDays`) differ by the
+  // `Days` suffix — `cascadeKnobKey` bridges the dispatch.
+  cascadeSources: [
+    {
+      level: "domain",
+      storagePath: "domain.config.skillScoringEmaHalfLifeDays",
+    },
+  ],
+  cascadeKnobKey: "skillScoringEmaHalfLifeDays",
   composeImpact: {
     sections: [],
     kinds: ["scoring-weight"],

--- a/apps/admin/tests/lib/cascade/resolvers/teaching-style.test.ts
+++ b/apps/admin/tests/lib/cascade/resolvers/teaching-style.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for teaching-style resolver.
+ * (#2228 A1b / epic #2225.)
+ *
+ * Covers AC:
+ *   - `isResolvableKnob("teachingStyle")` returns true
+ *   - Returns System fallback (value:null, empty layers) when no Domain
+ *     or Playbook override is set
+ *   - Returns Domain value when only Domain set (isInherited:true)
+ *   - Returns Playbook value when both set (deepest wins, isInherited:false)
+ *   - `LayerHit.source` correctly names the winning layer
+ *   - `setAt` / `setBy` null with TODO comment
+ *   - Throws when `playbookId` missing from scope
+ *
+ * Pattern mirrors `tests/lib/cascade/resolvers/welcome-message.test.ts`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const prismaMock = {
+  playbook: { findUnique: vi.fn() },
+  domain: { findUnique: vi.fn() },
+};
+vi.mock("@/lib/prisma", () => ({ prisma: prismaMock }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("isResolvableKnob('teachingStyle')", () => {
+  it("returns true once the FAMILIES entry is registered", async () => {
+    const { isResolvableKnob } = await import("@/lib/cascade/effective-value");
+    expect(isResolvableKnob("teachingStyle")).toBe(true);
+  });
+});
+
+describe("resolveTeachingStyle", () => {
+  it("returns two LayerHits when both Playbook and Domain set; PLAYBOOK wins", async () => {
+    prismaMock.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb1",
+      name: "OCEAN",
+      config: { teachingStyle: "direct" },
+      domainId: "dom1",
+    });
+    prismaMock.domain.findUnique.mockResolvedValueOnce({
+      id: "dom1",
+      name: "Education",
+      config: { teachingStyleDefault: "socratic" },
+    });
+
+    const { resolveTeachingStyle } = await import(
+      "@/lib/cascade/resolvers/teaching-style"
+    );
+    const r = await resolveTeachingStyle({ playbookId: "pb1" });
+
+    expect(r.layers).toHaveLength(2);
+    // SYSTEM→CALL order: DOMAIN first, then PLAYBOOK.
+    expect(r.layers[0].layer).toBe("DOMAIN");
+    expect(r.layers[0].value).toBe("socratic");
+    expect(r.layers[1].layer).toBe("PLAYBOOK");
+    expect(r.layers[1].value).toBe("direct");
+    // PLAYBOOK wins (deepest layer).
+    expect(r.value).toBe("direct");
+    expect(r.source).toBe("PLAYBOOK");
+    expect(r.isInherited).toBe(false);
+    expect(r.recommendedLayerForEdit).toBe("PLAYBOOK");
+  });
+
+  it("returns one DOMAIN hit when only Domain is set; isInherited:true", async () => {
+    prismaMock.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb1",
+      name: "OCEAN",
+      config: {},
+      domainId: "dom1",
+    });
+    prismaMock.domain.findUnique.mockResolvedValueOnce({
+      id: "dom1",
+      name: "Education",
+      config: { teachingStyleDefault: "adaptive" },
+    });
+
+    const { resolveTeachingStyle } = await import(
+      "@/lib/cascade/resolvers/teaching-style"
+    );
+    const r = await resolveTeachingStyle({ playbookId: "pb1" });
+
+    expect(r.layers).toHaveLength(1);
+    expect(r.layers[0].layer).toBe("DOMAIN");
+    expect(r.value).toBe("adaptive");
+    expect(r.source).toBe("DOMAIN");
+    expect(r.isInherited).toBe(true);
+  });
+
+  it("returns one PLAYBOOK hit when only Playbook is set", async () => {
+    prismaMock.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb1",
+      name: "OCEAN",
+      config: { teachingStyle: "socratic" },
+      domainId: "dom1",
+    });
+    prismaMock.domain.findUnique.mockResolvedValueOnce({
+      id: "dom1",
+      name: "Education",
+      config: {},
+    });
+
+    const { resolveTeachingStyle } = await import(
+      "@/lib/cascade/resolvers/teaching-style"
+    );
+    const r = await resolveTeachingStyle({ playbookId: "pb1" });
+
+    expect(r.layers).toHaveLength(1);
+    expect(r.layers[0].layer).toBe("PLAYBOOK");
+    expect(r.value).toBe("socratic");
+    expect(r.source).toBe("PLAYBOOK");
+    expect(r.isInherited).toBe(false);
+  });
+
+  it("returns value:null with empty layers when neither set", async () => {
+    prismaMock.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb1",
+      name: "OCEAN",
+      config: {},
+      domainId: "dom1",
+    });
+    prismaMock.domain.findUnique.mockResolvedValueOnce({
+      id: "dom1",
+      name: "Education",
+      config: null,
+    });
+
+    const { resolveTeachingStyle } = await import(
+      "@/lib/cascade/resolvers/teaching-style"
+    );
+    const r = await resolveTeachingStyle({ playbookId: "pb1" });
+
+    expect(r.layers).toHaveLength(0);
+    expect(r.value).toBeNull();
+    expect(r.source).toBe("SYSTEM");
+    expect(r.isInherited).toBe(false);
+    expect(r.recommendedLayerForEdit).toBe("PLAYBOOK");
+  });
+
+  it("returns setAt and setBy null for every hit (provenance TODO)", async () => {
+    prismaMock.playbook.findUnique.mockResolvedValueOnce({
+      id: "pb1",
+      name: "OCEAN",
+      config: { teachingStyle: "direct" },
+      domainId: "dom1",
+    });
+    prismaMock.domain.findUnique.mockResolvedValueOnce({
+      id: "dom1",
+      name: "Education",
+      config: { teachingStyleDefault: "socratic" },
+    });
+
+    const { resolveTeachingStyle } = await import(
+      "@/lib/cascade/resolvers/teaching-style"
+    );
+    const r = await resolveTeachingStyle({ playbookId: "pb1" });
+
+    for (const hit of r.layers) {
+      expect(hit.setAt).toBeNull();
+      expect(hit.setBy).toBeNull();
+    }
+  });
+
+  it("throws when playbookId missing from scope", async () => {
+    const { resolveTeachingStyle } = await import(
+      "@/lib/cascade/resolvers/teaching-style"
+    );
+    await expect(resolveTeachingStyle({})).rejects.toThrow(/playbookId/);
+  });
+
+  it("throws when playbook row not found", async () => {
+    prismaMock.playbook.findUnique.mockResolvedValueOnce(null);
+    const { resolveTeachingStyle } = await import(
+      "@/lib/cascade/resolvers/teaching-style"
+    );
+    await expect(
+      resolveTeachingStyle({ playbookId: "missing-id" }),
+    ).rejects.toThrow(/Playbook not found/);
+  });
+});


### PR DESCRIPTION
## Summary

A1b of epic #2225 — implements story #2228 in full. Closes the sole
CASCADE-Domain+Course gap in the FAMILIES dispatch table and fixes the
two contract ↔ FAMILIES mismatches the A1a enumeration surfaced.

- **New slim resolver** `lib/cascade/resolvers/teaching-style.ts` —
  reads `Domain.config.teachingStyleDefault` →
  `Playbook.config.teachingStyle` (asymmetric blob keys; can't reuse
  `resolveMasteryPolicyKnob`'s symmetric SUPPORTED_KEYS dispatch).
  Pattern mirrors `welcome-message.ts`.
- **New `teaching-style` FAMILIES entry** in `effective-value.ts` —
  `isResolvableKnob("teachingStyle")` now returns `true`.
- **`cascadeKnobKey: "skillScoringEmaHalfLifeDays"`** on
  `G4_SKILL_SCORING_EMA_HALF_LIFE` — bridges the contract id (`skillScoringEmaHalfLife`,
  no `Days`) to the FAMILIES key (`skillScoringEmaHalfLifeDays`, with
  `Days`). `CascadeTraceBreadcrumb.tsx:95` dispatches via
  `contract.cascadeKnobKey ?? contract.id` so the cascade chip now
  resolves instead of throwing "Unknown cascade knob key".
- **`cascadeSources` aligned** on `G4_TIER_PRESET_ID` (declares
  `domain.config.tierPresetId` — paired with the `tier-preset`
  FAMILIES entry from #2174 S3) and `G4_SKILL_SCORING_EMA_HALF_LIFE`
  (declares `domain.config.skillScoringEmaHalfLifeDays` — paired with
  the `mastery-policy` FAMILIES entry). Cosmetic / documentation —
  runtime resolver reads from \`Domain.config\` directly; the
  Inspector's \`isInherited\` chip and the registry-schema-coverage
  vitest benefit.
- **8 vitests** in \`tests/lib/cascade/resolvers/teaching-style.test.ts\`
  pin: \`isResolvableKnob\` true; three-way (System / Domain / Playbook)
  envelope; deepest-wins; \`isInherited\` semantics; \`setAt\`/\`setBy\`
  null; throws on missing \`playbookId\` / playbook row.

## Verified by

**Lattice survey** (per \`.claude/rules/lattice-survey.md\`):
- *Sibling-writer drift* — no other writer to \`Playbook.config.teachingStyle\`
  exists today; new resolver is read-only. Safe.
- *Default-deny gates* — no ESLint rule fires on FAMILIES additions. Safe.
- *Cascade respect* — extends the single FAMILIES chokepoint, doesn't
  parallel-implement. Correct.
- *Convention conflict* — 1 new slim resolver (per #2228's analysis the
  asymmetric storage paths make extending \`mastery-policy.ts::SUPPORTED_KEYS\`
  the wrong call). Pattern matches existing \`welcome-message.ts\`. Safe.

**Tests** (resolver + adjacent ratchets, all green):
- \`tests/lib/cascade/resolvers/teaching-style.test.ts\` — 8/8 pass
  (\`isResolvableKnob\` true, three-way envelope, deepest-wins,
  isInherited, setAt/setBy null, throws on missing scope)
- \`tests/lib/cascade/\` + \`tests/app/api/cascade-resolve.test.ts\` —
  137/137 pass (full cascade suite, no regressions)
- \`tests/lib/journey/\` — 177/177 pass (incl. registry-schema-coverage,
  registry-consumer-coverage, registry-options-coverage,
  registry-completeness, gated-by-coverage)
- \`tests/lib/cascade/knob-keys.test.ts\` — 21/21 pass (LISTED_KNOBS ↔
  isResolvableKnob invariant)
- \`tests/lib/lattice-self-maintenance.test.ts\` — 10/10 pass (no
  inventory drift)

**Type / Lint**:
- \`npx tsc --noEmit\` — 42 errors (== baseline 42, no new errors from
  touched files; verified \`teaching-style|cascade/effective-value|setting-contracts.entries\`
  produces no tsc output)
- \`npm run lint -- lib/cascade/resolvers/teaching-style.ts lib/cascade/effective-value.ts lib/journey/setting-contracts.entries.ts tests/lib/cascade/resolvers/teaching-style.test.ts\`
  — clean

**Acceptance criteria** (from #2228):
- [x] \`isResolvableKnob("teachingStyle")\` returns \`true\` — pinned by test
- [x] \`resolveEffective\` returns sensible envelope at System / Domain /
  Playbook layers — pinned by 4 envelope tests
- [x] \`isResolvableKnob("skillScoringEmaHalfLife")\` returns \`false\`
  (unchanged — FAMILIES still only matches \`...Days\` variant)
- [x] \`isResolvableKnob("skillScoringEmaHalfLifeDays")\` returns \`true\`
  (unchanged — mastery-policy FAMILIES entry pre-existed)
- [x] \`CascadeTraceBreadcrumb\` for \`skillScoringEmaHalfLife\` contract
  dispatches via \`contract.cascadeKnobKey\` to
  \`"skillScoringEmaHalfLifeDays"\` — bridge field declared
- [x] \`tierPresetId.cascadeSources\` and
  \`skillScoringEmaHalfLife.cascadeSources\` declare domain sources
  (non-empty arrays) — diff shows both
- [x] Existing tests pass — 314 tests across cascade + journey + lattice
- [x] \`npx tsc --noEmit\` no new errors vs baseline 42
- [x] Lint clean on touched files

## Test plan

- [x] \`npx vitest run tests/lib/cascade/resolvers/teaching-style.test.ts\`
- [x] \`npx vitest run tests/lib/cascade/ tests/app/api/cascade-resolve.test.ts\`
- [x] \`npx vitest run tests/lib/journey/\`
- [x] \`npx vitest run tests/lib/lattice-self-maintenance.test.ts\`
- [x] \`npx tsc --noEmit\` (baseline 42 holds)
- [x] \`npm run lint\` on touched files (clean)
- [ ] Live verification on hf-dev: open Journey Inspector for a course
  whose Domain has \`config.teachingStyleDefault\` set — confirm the
  cascade chip on the Teaching Style control surfaces "from Domain"
  provenance. (Operator follow-up post-merge.)
- [ ] Live verification: open the EMA half-life Inspector control —
  confirm cascade chip resolves (no "Unknown cascade knob key" toast
  in console).

Closes #2228. Step toward #2225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)