### PR TITLE
refactor(cascade): #2225 B2a — voice-explain reads canonical DEFAULT_VOICE_PROVIDER_SLUG

### DIFF
--- a/apps/admin/lib/cascade/voice-explain.ts
+++ b/apps/admin/lib/cascade/voice-explain.ts
@@ -32,6 +32,7 @@ import {
   type VoiceCallSettings,
 } from "@/lib/system-settings";
 import { getVoiceSystemSettings } from "@/lib/voice/system-settings";
+import { DEFAULT_VOICE_PROVIDER_SLUG } from "@/lib/voice/default-provider";
 import { getVoiceProvider } from "@/lib/voice/provider-factory";
 import {
   cascadeableKeys,
@@ -168,7 +169,8 @@ async function loadRawInputs(
   const sys = await getVoiceSystemSettings();
   // Same enabled-slug rule as load-voice-config.ts (#1271).
   const explicit = sys.defaultProviderSlug?.trim();
-  const enabledSlug = explicit && explicit.length > 0 ? explicit : "vapi";
+  const enabledSlug =
+    explicit && explicit.length > 0 ? explicit : DEFAULT_VOICE_PROVIDER_SLUG;
 
   const [vpRow, adapter, caller, playbook] = await Promise.all([
     prisma.voiceProvider.findUnique({


### PR DESCRIPTION
## Summary

- Replace bare `"vapi"` literal at `apps/admin/lib/cascade/voice-explain.ts:171` with `DEFAULT_VOICE_PROVIDER_SLUG` imported from `apps/admin/lib/voice/default-provider.ts`.
- Per `.claude/rules/no-hardcoded-voice-id.md`, provider-slug defaults live in the canonical single-source-of-truth constant; `lib/cascade/` is NOT on the rule's allow-list.
- Brings `voice-explain` into line with sibling consumers (`load-voice-config.ts`, `poll-stale-calls.ts`) named in the constant's docstring.

## Lattice survey

- **Surface**: `lib/cascade/voice-explain.ts::loadRawInputs` — `enabledSlug` default-fallback when `VoiceSystemSettings.defaultProviderSlug` is empty.
- **Sibling writers/readers**: surveyed `"vapi"` literals across `apps/admin/lib/` + `apps/admin/app/`. The canonical chokepoint is `DEFAULT_VOICE_PROVIDER_SLUG` at `lib/voice/default-provider.ts:20`. Same drift exists in 6 other sites (`lib/chat/admin-tool-handlers.ts` ×2, `app/api/domains/[domainId]/voice-config/route.ts` ×2, `app/api/playbooks/[playbookId]/voice-config/route.ts` ×2) — out of scope for B2a; tracked as #2225 follow-ons. Provider-internal identity (`lib/voice/providers/vapi/index.ts:71 readonly slug = "vapi"`) is correctly NOT a default-fallback per rule comment.
- **Risk shapes**: no sibling-writer drift introduced (identical semantics); no default-deny gate at play; cascade respected (constant IS the cascade); no convention conflict.

## Verified by

- `npx tsc --noEmit` at baseline: **42 errors == 42 baseline (+0 new)** via pre-push hook output.
- `npx eslint apps/admin/lib/cascade/voice-explain.ts`: **clean, no output**.
- `npx vitest run tests/lib/cascade/voice-explain.test.ts`: **7/7 passing** (815ms).
- Diff is 3 lines (1 import + 2-line ternary reflow). [verified] via `git diff --cached` output above.

Closes B2a of #2225. **DO NOT MERGE.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)