### PR TITLE
feat(journey): #2225 A3 — Course-only pill for intrinsically-course-scoped settings

### DIFF
--- a/apps/admin/components/journey-tab/CascadeTraceBreadcrumb.tsx
+++ b/apps/admin/components/journey-tab/CascadeTraceBreadcrumb.tsx
@@ -57,7 +57,27 @@ function displayValue(v: unknown): string {
 
 function StaticChain({ contract }: CascadeTraceBreadcrumbProps) {
   const sources = contract.cascadeSources;
-  if (!sources.length) return null;
+  if (!sources.length) {
+    // A3 of epic #2225 — intrinsically course-only contract (no
+    // Domain/System ancestor declared, no resolvable cascade family).
+    // Pre-A3 this branch silently rendered nothing — 73 contracts in
+    // the Inspector left operators wondering why the cascade chip was
+    // missing. Now we name the absence explicitly.
+    return (
+      <div
+        className="hf-cascade-trace"
+        data-testid={`hf-cascade-trace-${contract.id}-course-only`}
+      >
+        <span className="hf-category-label">Cascade:</span>{" "}
+        <span
+          className="hf-badge hf-badge-muted"
+          title="This setting is configured per course — no Domain or System default applies"
+        >
+          Course-only
+        </span>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/apps/admin/tests/components/journey-tab/CascadeTraceBreadcrumb.test.tsx
+++ b/apps/admin/tests/components/journey-tab/CascadeTraceBreadcrumb.test.tsx
@@ -57,12 +57,19 @@ function renderInProvider(
 }
 
 describe("CascadeTraceBreadcrumb — Slice C2 (#1737) hook integration", () => {
-  it("renders nothing when cascadeSources is empty AND no courseId scope", () => {
-    const { container } = renderInProvider(
+  it("renders the Course-only pill when cascadeSources is empty AND no courseId scope (A3 of #2225)", () => {
+    // A3 of epic #2225: intrinsically course-only contracts (no Domain
+    // or System ancestor declared) now render an explicit "Course-only"
+    // pill instead of nothing. Pre-A3, 73 course-only contracts rendered
+    // a silent blank that confused operators.
+    renderInProvider(
       <CascadeTraceBreadcrumb contract={baseContract} />,
       { courseId: null },
     );
-    expect(container.firstChild).toBeNull();
+    expect(
+      screen.getByTestId("hf-cascade-trace-welcomeMessage-course-only"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Course-only")).toBeInTheDocument();
   });
 
   it("renders the static chain when courseId missing (no scope to resolve)", () => {
@@ -187,5 +194,120 @@ describe("CascadeTraceBreadcrumb — Slice C2 (#1737) hook integration", () => {
     });
     const url = vi.mocked(global.fetch).mock.calls[0][0] as string;
     expect(url).toContain("knobKey=voiceProvider");
+  });
+});
+
+describe("CascadeTraceBreadcrumb — A3 of #2225 (Course-only pill)", () => {
+  it("renders Course-only pill when cascadeSources.length === 0 AND unresolvable === true (route 400)", async () => {
+    // courseId is present, so the hook fetches. The route returns 400
+    // (knob not in cascade family) → unresolvable: true → component
+    // falls through to StaticChain. StaticChain sees zero
+    // cascadeSources, so renders the Course-only pill.
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: () =>
+        Promise.resolve({
+          ok: false,
+          error: 'Unknown cascade knob key: "welcomeMessage"',
+        }),
+    } as Response);
+
+    renderInProvider(
+      <CascadeTraceBreadcrumb contract={baseContract} />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("hf-cascade-trace-welcomeMessage-course-only"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText("Course-only")).toBeInTheDocument();
+  });
+
+  it("does NOT render Course-only pill when cascadeSources.length > 0 (static chain wins)", async () => {
+    // With non-empty cascadeSources, even when unresolvable the
+    // StaticChain renders the existing layer-chip strip — NOT the
+    // Course-only pill. The two render paths are mutually exclusive.
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: () =>
+        Promise.resolve({
+          ok: false,
+          error: 'Unknown cascade knob key: "welcomeMessage"',
+        }),
+    } as Response);
+
+    renderInProvider(
+      <CascadeTraceBreadcrumb
+        contract={{
+          ...baseContract,
+          cascadeSources: [
+            { level: "domain", storagePath: "domain.welcomeMessage" },
+            { level: "group", storagePath: "config.sessionFlow.welcomeMessage" },
+          ],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("hf-cascade-trace-welcomeMessage"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByTestId("hf-cascade-trace-welcomeMessage-course-only"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Course-only")).not.toBeInTheDocument();
+  });
+
+  it("does NOT render Course-only pill when envelope resolves (cascade-resolved path takes over)", async () => {
+    // When the route returns a real envelope, the resolved-path renders
+    // <CascadeValue> — neither StaticChain branch is taken. Course-only
+    // pill MUST NOT appear.
+    const envelope: Effective<string> = {
+      value: "vapi",
+      source: "PLAYBOOK",
+      layers: [
+        {
+          layer: "PLAYBOOK",
+          scopeId: "pb-1",
+          scopeLabel: "Course",
+          value: "vapi",
+          setAt: null,
+          setBy: null,
+        },
+      ],
+      isInherited: false,
+      recommendedLayerForEdit: "PLAYBOOK",
+    };
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(envelope),
+    } as Response);
+
+    renderInProvider(
+      <CascadeTraceBreadcrumb
+        contract={{
+          ...baseContract,
+          id: "voiceProviderContract",
+          cascadeKnobKey: "voiceProvider",
+          cascadeSources: [],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("hf-cascade-trace-voiceProviderContract"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByTestId(
+        "hf-cascade-trace-voiceProviderContract-course-only",
+      ),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Course-only")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Replace the silent-blank render in `StaticChain` (CascadeTraceBreadcrumb) with an explicit "Course-only" pill when `cascadeSources.length === 0`. Pre-A3, 73 contracts in the Inspector rendered nothing in the cascade-chip slot, leaving operators wondering why the chip was missing. The highest-leverage UX fix for the operator's "many JSONs empty" complaint — it names the 73-contract silent-blank state instead of leaving it unexplained.

- Render-side only — no semantic change. `registry-consumer-coverage.test.ts` stays green [verified].
- 20 already-covered contracts continue to render their cascade chip (the static-chain or live-envelope path).
- 1 A1b-pending contract (`teachingStyle`) continues to render its cascade chip once A1b merges.
- No new contract fields, no FAMILIES changes, no new cascade resolvers.

## Before / After

```
Before (course-only contract):

  Educator Label: "Welcome message"
  [text input ........................]
  <nothing rendered here — silent blank>

After (course-only contract):

  Educator Label: "Welcome message"
  [text input ........................]
  Cascade: [Course-only]
         (tooltip on hover: "This setting is configured per
          course — no Domain or System default applies")

Unchanged (cascade-eligible contract with non-empty sources):

  Educator Label: "Voice provider"
  [select dropdown ..................]
  Cascade: [Domain] → [Course] → [effective]

Unchanged (cascade-resolved live envelope):

  Educator Label: "Voice provider"
  [select dropdown ..................]
  Cascade: [Course: vapi]   ← live <CascadeValue> chip with provenance
```

## Verified by

- `npx vitest run tests/components/journey-tab/CascadeTraceBreadcrumb.test.tsx` — 8 tests pass (5 incumbent + 3 new A3-specific).
- `npx vitest run tests/lib/journey/registry-consumer-coverage.test.ts` — 6 tests pass (Coverage gate semantically unchanged).
- `npx eslint components/journey-tab/CascadeTraceBreadcrumb.tsx tests/components/journey-tab/CascadeTraceBreadcrumb.test.tsx` — clean.
- `npx tsc --noEmit` — no new errors introduced (worktree pre-existing dep-resolution errors only; verified by file-filtered scan showing only `JSX.IntrinsicElements`/`react/jsx-runtime` cascades from missing `react` types in worktree, identical between pre- and post-change). [verified]
- Lattice survey:
  - Sibling-writer drift — pure render-side change, no writes.
  - Default-deny gates — no ESLint rule fires (no chokepoint involved).
  - Cascade respect — renders the natural negative ("not in cascade") rather than nothing; strengthens cascade-honesty discipline per [`.claude/rules/cascade-reuse.md`](https://github.com/WANDERCOLTD/HF/blob/main/.claude/rules/cascade-reuse.md).
  - Convention conflict — `hf-badge-muted` is the established convention for non-action info chips per [`.claude/rules/ui-design-system.md`](https://github.com/WANDERCOLTD/HF/blob/main/.claude/rules/ui-design-system.md).
- UI Design System compliance — uses existing `hf-cascade-trace` / `hf-category-label` / `hf-badge` / `hf-badge-muted` classes; no new CSS, no inline styles, no hardcoded colors.

Closes A3 of #2225.

DO NOT MERGE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)