### PR TITLE
feat(journey): #2225 A2 — migrate G8 pool contracts to array-editor control

### DIFF
--- a/apps/admin/components/journey-controls/JourneyArrayEditor.tsx
+++ b/apps/admin/components/journey-controls/JourneyArrayEditor.tsx
@@ -20,6 +20,10 @@ import type { JourneyFieldProps } from "./JourneyField";
  *     newline-separated string in the UI).
  *   - `moduleScheduledCues` → `{ at: number, text: string }` (one entry
  *     per scheduled cue; `at` is seconds-from-session-start).
+ *   - `moduleTopicPool` → `{ topic: string, questions: string[] }` (one
+ *     entry per topic frame; questions are authored as a newline-separated
+ *     string in the UI — same shape pattern as cueCardPool's bullets).
+ *     Added #2225 A2.
  *   - `moduleProfileFieldsToCapture` → `{ key: string, prompt: string,
  *     type: "text" | "number" | "band" }` (one entry per profile field
  *     the EXTRACT routine should capture; see Theme 10 / #1704).
@@ -84,6 +88,25 @@ const ROW_SCHEMAS: Record<string, RowSchema> = {
         type: "string",
         default: "",
         hint: 'e.g. "15 seconds left"',
+      },
+    ],
+  },
+  moduleTopicPool: {
+    itemTitle: (i) => `Topic ${i + 1}`,
+    fields: [
+      {
+        key: "topic",
+        label: "Topic",
+        type: "string",
+        default: "",
+        hint: 'e.g. "Work or studies", "Hometown"',
+      },
+      {
+        key: "questions",
+        label: "Questions",
+        type: "string-multiline",
+        default: "",
+        hint: "One question per line. Tutor asks them one at a time.",
       },
     ],
   },

--- a/apps/admin/lib/journey/setting-contracts.entries.ts
+++ b/apps/admin/lib/journey/setting-contracts.entries.ts
@@ -2070,8 +2070,9 @@ const G8_MODULE_CUE_CARD_POOL: JourneySettingContract = {
 // pre-authored questions one at a time. Source-ref form lives in the
 // course-ref doc (`topicPool: source:<id>`); the resolver inlines
 // `Array<{ topic, questions[] }>` at projection time.
-// Phase 1 ships as `json-fallback` — the Theme 1b JourneyArrayEditor
-// primitive is deferred per epic #1700 decision 5.
+// #2225 A2 — migrated `json-fallback` → `array-editor`. Data shape is
+// `Array<{topic, questions[]}>`; the array-of-objects editor now has a
+// `moduleTopicPool` row schema in `JourneyArrayEditor.tsx::ROW_SCHEMAS`.
 const G8_MODULE_TOPIC_POOL: JourneySettingContract = {
   id: "moduleTopicPool",
   menuGroupKey: "E_learner_visual",
@@ -2084,7 +2085,7 @@ const G8_MODULE_TOPIC_POOL: JourneySettingContract = {
     path: "config.modules[].settings.topicPool",
     arrayKey: "id",
   },
-  control: "json-fallback",
+  control: "array-editor",
   cascadeSources: [],
   composeImpact: {
     sections: ["instructions"],
@@ -2238,6 +2239,11 @@ const G8_MODULE_SILENT_MODE: JourneySettingContract = {
   appliesTo: ["exam"],
 };
 
+// #2225 A2 — migrated `json-fallback` → `array-editor`. Data shape is
+// `ProfileFieldToCapture[]` = `{key, prompt, type}[]`; the
+// `moduleProfileFieldsToCapture` row schema already exists in
+// `JourneyArrayEditor.tsx::ROW_SCHEMAS` (was wired in Theme 1b but the
+// contract never adopted the primitive).
 const G8_MODULE_PROFILE_FIELDS_TO_CAPTURE: JourneySettingContract = {
   id: "moduleProfileFieldsToCapture",
   menuGroupKey: "A_intake",
@@ -2250,7 +2256,7 @@ const G8_MODULE_PROFILE_FIELDS_TO_CAPTURE: JourneySettingContract = {
     path: "config.modules[].settings.profileFieldsToCapture",
     arrayKey: "id",
   },
-  control: "json-fallback",
+  control: "array-editor",
   cascadeSources: [],
   composeImpact: {
     sections: ["instructions"],


### PR DESCRIPTION
## Summary

A2 of epic #2225 (RHS Inspector Robustness — control-type mismatch). Migrates G8 module-scoped contracts from `text` / `json-fallback` to `control: "array-editor"` where the underlying storage is array-of-objects.

**Migrated (2):**

| Contract | From | To | Data shape | Schema |
|---|---|---|---|---|
| `moduleTopicPool` | `json-fallback` | `array-editor` | `Array<{topic, questions: string[]}>` | **Added** new `moduleTopicPool` row schema in `JourneyArrayEditor.tsx::ROW_SCHEMAS` (topic + multiline questions, same shape as cueCardPool bullets) |
| `moduleProfileFieldsToCapture` | `json-fallback` | `array-editor` | `ProfileFieldToCapture[]` = `{key, prompt, type}[]` | Already present in ROW_SCHEMAS (wired in Theme 1b #1815 but contract never adopted) |

**Kept as `text` (deliberately):**

| Contract | Why |
|---|---|
| `moduleClosingLine` | Storage is `string` per module (not an array). `text` is correct. |
| `moduleFirstTimeOrientationLine` | Storage is `string` per module (not an array). `text` is correct. |

The structural-path requirement (`arrayKey: "id"`) on these contracts addresses array-element addressing on the `config.modules[]` parent — it does **not** mean the leaf value is an array. Both fields store a single string per module's settings; the PATCH route's `arraySelector` resolves which module's settings row to write into.

**Out of scope (pre-existing structural gap, noted for follow-on):**

`moduleScaffoldPool` already declares `control: "array-editor"` but its storage shape is `string[]` (per `AuthoredModuleSettings.scaffoldPool`) and there is no matching `ROW_SCHEMAS` entry. Opening this control today renders the editor's "No row schema registered for `moduleScaffoldPool`" branch. Fix requires either:
- A second editor variant for `string[]` (one column, no nested object), OR
- Refactor the storage to `Array<{text: string}>` + schema entry.

Out-of-scope for A2 per scope; flag for A5 (control-type ↔ data-shape Coverage gate) or a sibling follow-on.

## Test plan

- [x] tsc baseline parity: error count is **identical** before vs after edits in this worktree (54243 = 54243). The worktree lacks `node_modules` so the absolute count is noise; the **delta** is 0.
- [x] No new Lattice rules / gates fire on `control` field changes outside `registry-options-coverage` (which scopes to `control === "select"`, not relevant here).
- [x] `JourneyField.tsx` PRIMITIVES dispatch already includes `"array-editor": JourneyArrayEditor` — no dispatcher change needed.
- [x] `JourneyArrayEditor`'s `ROW_SCHEMAS` lookup gracefully renders an error pane if a schema is missing (no runtime crash); both migrated contracts now have schemas.
- [ ] Manual verification on a deployed env: open Course Pane → Module Inspector on an IELTS / equivalent course → confirm `moduleTopicPool` + `moduleProfileFieldsToCapture` now render structured row editors (not JSON-blob fallback).
- [ ] `npx vitest run tests/lib/journey` green (deferred — worktree has no node_modules).

## Verified by

**Lattice survey** (`.claude/rules/lattice-survey.md`):

| Risk shape | Outcome |
|---|---|
| Sibling-writer drift | None — Inspector `control` field only affects READ rendering. Save still routes through `lib/journey/storage-path-applier.ts` + the `PATCH /api/courses/[courseId]/journey-setting` route which is shape-agnostic. |
| Default-deny gates | None — no ESLint rule fires on a `control` field migration between non-select kinds. |
| Cascade respect | N/A — post-#2225 A0, `registry-consumer-coverage.test.ts` uses `isResolvableKnob` against `effective-value.ts::FAMILIES`, not control-type. |
| Convention conflict | `array-editor` is the established convention for array-of-object pool data (precedent: `moduleCueCardPool` / `moduleScheduledCues` / `moduleProfileFieldsToCapture` schemas in `ROW_SCHEMAS`). |

**Evidence:**

- `apps/admin/lib/types/json-fields.ts` lines 1356, 1401, 1407 confirm the migrated contracts' storage types are arrays-of-objects (vs `moduleClosingLine` / `moduleFirstTimeOrientationLine` which are `string`).
- `apps/admin/components/journey-controls/JourneyArrayEditor.tsx::ROW_SCHEMAS` now covers all 4 array-of-object G8 pools (cueCard / scheduledCues / topicPool [NEW] / profileFields).
- `apps/admin/components/journey-controls/JourneyField.tsx:74` confirms `"array-editor": JourneyArrayEditor` is in the dispatch table.

DO NOT MERGE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)