### PR TITLE
feat(api): #2225 A4 — journey-setting PATCH supports domain-rooted writes (1 contract)

### DIFF
--- a/apps/admin/app/api/courses/[courseId]/journey-setting/route.ts
+++ b/apps/admin/app/api/courses/[courseId]/journey-setting/route.ts
@@ -29,9 +29,24 @@
  *      in the SAME `updatePlaybookConfig` transformer (one transaction).
  *   5. Return updated effective value + autoEnableLinks fan-out summary.
  *
+ * Storage roots:
+ *   - `config.*` / `sessionFlow.*` / `tolerances.*` / `playbook.voiceConfig.*`
+ *     → Playbook.config mutation via `updatePlaybookConfig`
+ *   - `behaviorTargets[…]` → 200 + `compoundOwnedSave: true` (Phase 3 —
+ *     the FirstSessionSettings compound editor owns the save via
+ *     `/api/courses/[courseId]/first-session`)
+ *   - `domain.<scalar>` (today only `domain.onboardingIdentitySpecId`
+ *     via the `intakeSpecId` contract) → A4 of #2225 — write through
+ *     `updateDomainConfig`, fan out section-staleness to every
+ *     dependent Playbook in the Domain. The Domain timestamp bump
+ *     (done by `updateDomainConfig`) covers prompt-level staleness;
+ *     this route handles section-grain staleness fanout.
+ *
  * Not handled yet (returned as 501):
- *   - storage roots `domain.*` (domain writes go to a different route)
- *   - storage root `behaviorTargets[…]` (separate model — Phase 3)
+ *   - storage root `domain.config.*` (no contract uses this shape today;
+ *     when one lands, branch on `resolved.segments[0] === "config"` and
+ *     route through `updateDomainConfig` with a `config` transformer)
+ *   - storage root `unknown` (typo / drift — 501)
  *
  * Auto-enable cycle protection: only 1 hop is permitted per ADR L3.
  * If the enforce-target itself has autoEnableLinks, those are NOT
@@ -55,7 +70,9 @@ import {
 import { requireAuth, isAuthError } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
 import { updatePlaybookConfig } from "@/lib/playbook/update-playbook-config";
+import { updateDomainConfig } from "@/lib/domain/update-domain-config";
 import { bumpSectionHash } from "@/lib/compose/section-staleness";
+import { bumpDomainSectionStaleness } from "@/lib/compose/bump-domain-staleness";
 import { getSectionsForSetting } from "@/lib/journey/section-staleness-bridge";
 import type { PlaybookConfig } from "@/lib/types/json-fields";
 
@@ -207,18 +224,104 @@ export async function PATCH(
     });
   }
 
-  if (
-    resolved.root === "domain" ||
-    resolved.root === "unknown"
-  ) {
+  if (resolved.root === "unknown") {
     return NextResponse.json(
       {
         ok: false,
-        error: `Storage root '${resolved.root}' not yet wired through this route (Phase 3 follow-up).`,
+        error: `Storage root 'unknown' not supported (storagePath: ${typeof contract.storagePath === "string" ? contract.storagePath : contract.storagePath.path}).`,
         code: "STORAGE_ROOT_NOT_SUPPORTED",
       },
       { status: 501 },
     );
+  }
+
+  // A4 of #2225 — Domain-rooted writes. Today there is exactly ONE
+  // contract whose primary storagePath lives under `domain.*`:
+  // `intakeSpecId` → `domain.onboardingIdentitySpecId` (a scalar column,
+  // not a JSON blob key). When a future contract lands on
+  // `domain.config.*`, branch here on `resolved.segments[0] === "config"`
+  // and route through `updateDomainConfig` with a `config` transformer.
+  if (resolved.root === "domain") {
+    if (resolved.segments.length !== 1) {
+      // Nested domain paths (e.g. `domain.config.foo`) — not wired yet.
+      return NextResponse.json(
+        {
+          ok: false,
+          error: `Domain-rooted storagePath '${typeof contract.storagePath === "string" ? contract.storagePath : contract.storagePath.path}' is nested; only single-segment scalar Domain columns are wired today.`,
+          code: "STORAGE_ROOT_NOT_SUPPORTED",
+        },
+        { status: 501 },
+      );
+    }
+    const scalarKey = resolved.segments[0];
+
+    // Resolve Domain id via Course (Playbook) → Domain.
+    const course = await prisma.playbook.findFirst({
+      where: { id: courseId },
+      select: { id: true, domainId: true },
+    });
+    if (!course) {
+      return NextResponse.json(
+        { ok: false, error: `Playbook ${courseId} not found` },
+        { status: 404 },
+      );
+    }
+
+    // updateDomainConfig is the canonical writer for the 4 compose-
+    // affecting Domain fields (onboardingFlowPhases, onboardingDefaultTargets,
+    // onboardingWelcome, onboardingIdentitySpecId). It bumps
+    // `Domain.composeInputsUpdatedAt` which the staleness check reads —
+    // every dependent Playbook sees the stale signal automatically.
+    type DomainUpdatableKey =
+      | "onboardingFlowPhases"
+      | "onboardingDefaultTargets"
+      | "onboardingWelcome"
+      | "onboardingIdentitySpecId";
+    const ALLOWED_DOMAIN_KEYS: ReadonlySet<DomainUpdatableKey> = new Set([
+      "onboardingFlowPhases",
+      "onboardingDefaultTargets",
+      "onboardingWelcome",
+      "onboardingIdentitySpecId",
+    ]);
+    if (!ALLOWED_DOMAIN_KEYS.has(scalarKey as DomainUpdatableKey)) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: `Domain column '${scalarKey}' is not in the updateDomainConfig allow-list. Add it to COMPOSE_AFFECTING_DOMAIN_FIELDS + DomainUpdatable first.`,
+          code: "DOMAIN_KEY_NOT_ALLOWED",
+        },
+        { status: 400 },
+      );
+    }
+    const domainKey = scalarKey as DomainUpdatableKey;
+
+    await updateDomainConfig(
+      course.domainId,
+      (cur) => ({ ...cur, [domainKey]: value as never }),
+      { reason: `journey-setting:${settingId}` },
+    );
+
+    // Section-grain staleness fanout: bump each affected section on
+    // every Playbook in this Domain. Fire-and-forget; the prompt-grain
+    // `Domain.composeInputsUpdatedAt` bump from `updateDomainConfig`
+    // above is the primary signal.
+    const bumpedSections = Array.from(
+      new Set<string>(getSectionsForSetting(settingId)),
+    );
+    if (bumpedSections.length > 0) {
+      void bumpDomainSectionStaleness(
+        course.domainId,
+        bumpedSections as Parameters<typeof bumpDomainSectionStaleness>[1],
+        { settingId, value },
+      );
+    }
+
+    return NextResponse.json({
+      ok: true,
+      effectiveValue: value,
+      autoEnabled: [],
+      bumpedSections,
+    });
   }
 
   // Find the playbook for this course

--- a/apps/admin/lib/compose/bump-domain-staleness.ts
+++ b/apps/admin/lib/compose/bump-domain-staleness.ts
@@ -1,0 +1,70 @@
+/**
+ * Domain-wide compose-staleness fanout — A4 of epic #2225.
+ *
+ * When a `Domain`-scoped compose-affecting write lands (currently only
+ * `Domain.onboardingIdentitySpecId` flows through the journey-setting
+ * PATCH route — see `app/api/courses/[courseId]/journey-setting/route.ts`),
+ * the staleness signal must reach every dependent Playbook's section
+ * cache.
+ *
+ * The domain-level coarse signal — `Domain.composeInputsUpdatedAt` — is
+ * already bumped by `updateDomainConfig` and read by the
+ * staleness check at `lib/compose/staleness.ts::isPromptStale` (the
+ * Domain timestamp is one of the four scope rows compared against
+ * `ComposedPrompt.composedAt`). That covers prompt-level staleness for
+ * every caller in every dependent playbook for free.
+ *
+ * This helper handles the SECTION-grain signal —
+ * `PlaybookSectionStaleness` rows are keyed on `(playbookId, sectionKey)`
+ * so a Domain write needs to bump the same `(playbookId, sectionKey)`
+ * pair for EVERY playbook in the domain. Without this, section-grain
+ * staleness banners in the Inspector would miss domain-rooted edits.
+ *
+ * Per `bumpPlaybookComposeTimestamp` defensive contract: best-effort,
+ * silent on missing rows, never throws.
+ */
+
+import { prisma } from "@/lib/prisma";
+import { bumpSectionHash } from "./section-staleness";
+import type { ComposeSectionKey } from "./section";
+
+/**
+ * Bump section-staleness for the given `sectionKey` on every Playbook
+ * in the given Domain. Returns the list of affected playbook ids
+ * (useful for response telemetry).
+ *
+ * Fire-and-forget caller pattern — domain writes have already committed
+ * by the time this runs; lazy recompose still covers any per-playbook
+ * miss via the Domain-level timestamp check.
+ */
+export async function bumpDomainSectionStaleness(
+  domainId: string,
+  sectionKeys: readonly ComposeSectionKey[],
+  inputs: unknown,
+): Promise<string[]> {
+  if (!domainId || sectionKeys.length === 0) return [];
+
+  const playbooks = await prisma.playbook.findMany({
+    where: { domainId },
+    select: { id: true },
+  });
+  const playbookIds = playbooks.map((p) => p.id);
+
+  await Promise.all(
+    playbookIds.flatMap((playbookId) =>
+      sectionKeys.map((sectionKey) =>
+        bumpSectionHash(playbookId, sectionKey, inputs).catch((err) => {
+          // Best-effort — never let a bump failure break the upstream
+          // domain write. See `bumpPlaybookComposeTimestamp` rationale.
+          console.warn(
+            `[bumpDomainSectionStaleness] swallowed error for ${playbookId}/${sectionKey}:`,
+            err,
+          );
+          return { changed: false, sectionHash: "" };
+        }),
+      ),
+    ),
+  );
+
+  return playbookIds;
+}

--- a/apps/admin/tests/api/courses/journey-setting-route.test.ts
+++ b/apps/admin/tests/api/courses/journey-setting-route.test.ts
@@ -7,7 +7,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const { mockPrisma } = vi.hoisted(() => ({
   mockPrisma: {
-    playbook: { findFirst: vi.fn(), findUnique: vi.fn(), update: vi.fn() },
+    playbook: { findFirst: vi.fn(), findUnique: vi.fn(), update: vi.fn(), findMany: vi.fn() },
+    domain: { findUnique: vi.fn(), update: vi.fn() },
   },
 }));
 
@@ -27,6 +28,17 @@ vi.mock("@/lib/playbook/update-playbook-config", () => ({
     timestampBumped: true,
     fanoutScope: "none",
   })),
+}));
+vi.mock("@/lib/domain/update-domain-config", () => ({
+  updateDomainConfig: vi.fn(async () => ({
+    domain: { id: "d1" },
+    composeAffectingChanged: true,
+    timestampBumped: true,
+    fanoutScope: "none",
+  })),
+}));
+vi.mock("@/lib/compose/bump-domain-staleness", () => ({
+  bumpDomainSectionStaleness: vi.fn(async () => []),
 }));
 vi.mock("@/lib/compose/section-staleness", () => ({
   bumpSectionHash: vi.fn(async () => ({ skipped: false })),
@@ -49,7 +61,8 @@ function makeReq(body: unknown, headers: Record<string, string> = {}) {
 describe("PATCH /api/courses/[courseId]/journey-setting — Phase 2 #1687", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockPrisma.playbook.findFirst.mockResolvedValue({ id: "course-1" });
+    mockPrisma.playbook.findFirst.mockResolvedValue({ id: "course-1", domainId: "domain-1" });
+    mockPrisma.playbook.findMany.mockResolvedValue([{ id: "course-1" }]);
   });
 
   it("403s the auth gate when OPERATOR not granted", async () => {
@@ -143,15 +156,17 @@ describe("PATCH /api/courses/[courseId]/journey-setting — Phase 2 #1687", () =
     expect(body.code).toBe("OPERATOR_ONLY");
   });
 
-  it("501s when storage root is domain (not yet wired)", async () => {
+  // A4 of #2225 — domain-rooted writes are now supported via
+  // updateDomainConfig. The full happy-path test lives in
+  // `tests/api/journey-setting-domain-write.test.ts`. This case stays
+  // here as a smoke test that the 501 stub is gone.
+  it("does NOT 501 on domain-rooted intakeSpecId write (A4 #2225)", async () => {
     const { PATCH } = await loadRoute();
     const res = await PATCH(
       makeReq({ settingId: "intakeSpecId", value: "spec-x" }) as never,
       PARAMS as never,
     );
-    expect(res.status).toBe(501);
-    const body = await res.json();
-    expect(body.code).toBe("STORAGE_ROOT_NOT_SUPPORTED");
+    expect(res.status).not.toBe(501);
   });
 
   it("Phase 3 #1693: behaviorTargets returns 200 with compoundOwnedSave flag", async () => {

--- a/apps/admin/tests/api/journey-setting-domain-write.test.ts
+++ b/apps/admin/tests/api/journey-setting-domain-write.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Domain-rooted journey-setting PATCH — A4 of epic #2225.
+ *
+ * Pins the `intakeSpecId` write path (storagePath
+ * `domain.onboardingIdentitySpecId`) end-to-end:
+ *   - 200 + updated effective value
+ *   - routes through `updateDomainConfig` (the canonical Domain writer)
+ *   - fans out section-staleness to dependent Playbooks via
+ *     `bumpDomainSectionStaleness`
+ *   - 403 for non-OPERATOR roles
+ *   - 400 on malformed body
+ *
+ * Scope: 1 contract (G1_INTAKE_SPEC_ID). Other "domain-rooted" contracts
+ * the original audit flagged carry domain-only `cascadeSources[]` but a
+ * Playbook-rooted PRIMARY storagePath — they don't reach this branch.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    playbook: { findFirst: vi.fn(), findMany: vi.fn() },
+    domain: { update: vi.fn(), findUnique: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn(async () => ({
+    ok: true,
+    session: { user: { id: "u1", role: "OPERATOR" } },
+  })),
+  isAuthError: (v: unknown) =>
+    typeof v === "object" && v !== null && "error" in v,
+}));
+
+vi.mock("@/lib/playbook/update-playbook-config", () => ({
+  updatePlaybookConfig: vi.fn(async () => ({
+    playbook: {},
+    composeAffectingChanged: true,
+    timestampBumped: true,
+    fanoutScope: "none",
+  })),
+}));
+
+vi.mock("@/lib/domain/update-domain-config", () => ({
+  updateDomainConfig: vi.fn(async () => ({
+    domain: { id: "domain-1" },
+    composeAffectingChanged: true,
+    timestampBumped: true,
+    fanoutScope: "none",
+  })),
+}));
+
+vi.mock("@/lib/compose/bump-domain-staleness", () => ({
+  bumpDomainSectionStaleness: vi.fn(async () => ["course-1", "course-2"]),
+}));
+
+vi.mock("@/lib/compose/section-staleness", () => ({
+  bumpSectionHash: vi.fn(async () => ({ changed: false, sectionHash: "" })),
+}));
+
+const PARAMS = { params: Promise.resolve({ courseId: "course-1" }) };
+
+async function loadRoute() {
+  return import("@/app/api/courses/[courseId]/journey-setting/route");
+}
+
+function makeReq(body: unknown, headers: Record<string, string> = {}) {
+  return new Request("http://x", {
+    method: "PATCH",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("PATCH /api/courses/[courseId]/journey-setting — A4 #2225 domain-rooted writes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.playbook.findFirst.mockResolvedValue({
+      id: "course-1",
+      domainId: "domain-1",
+    });
+  });
+
+  it("happy path: writes intakeSpecId via updateDomainConfig, returns updated value", async () => {
+    const { PATCH } = await loadRoute();
+    const res = await PATCH(
+      makeReq({ settingId: "intakeSpecId", value: "spec-onboarding-v2" }) as never,
+      PARAMS as never,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.effectiveValue).toBe("spec-onboarding-v2");
+
+    // updateDomainConfig is the canonical writer — must be called.
+    const { updateDomainConfig } = await import(
+      "@/lib/domain/update-domain-config"
+    );
+    expect(updateDomainConfig).toHaveBeenCalledTimes(1);
+    const [domainIdArg, transformer, opts] = vi.mocked(updateDomainConfig).mock
+      .calls[0];
+    expect(domainIdArg).toBe("domain-1");
+    // The transformer applies the new value onto a clone of the current
+    // Domain row — exercise it and confirm the right field flips.
+    const before = {
+      onboardingFlowPhases: null,
+      onboardingDefaultTargets: null,
+      onboardingWelcome: null,
+      onboardingIdentitySpecId: "spec-old",
+    };
+    const after = transformer(before);
+    expect(after).toMatchObject({
+      onboardingIdentitySpecId: "spec-onboarding-v2",
+      // other fields preserved
+      onboardingFlowPhases: null,
+      onboardingDefaultTargets: null,
+      onboardingWelcome: null,
+    });
+    expect(opts?.reason).toContain("journey-setting:intakeSpecId");
+  });
+
+  it("fans out section-staleness to every dependent Playbook in the Domain", async () => {
+    const { PATCH } = await loadRoute();
+    const res = await PATCH(
+      makeReq({ settingId: "intakeSpecId", value: "spec-x" }) as never,
+      PARAMS as never,
+    );
+    expect(res.status).toBe(200);
+
+    const { bumpDomainSectionStaleness } = await import(
+      "@/lib/compose/bump-domain-staleness"
+    );
+    expect(bumpDomainSectionStaleness).toHaveBeenCalledTimes(1);
+    const [domainIdArg, sections] = vi.mocked(bumpDomainSectionStaleness).mock
+      .calls[0];
+    expect(domainIdArg).toBe("domain-1");
+    // intakeSpecId's composeImpact.sections is ["intake"]
+    expect(Array.from(sections)).toContain("intake");
+
+    const body = await res.json();
+    expect(body.bumpedSections).toContain("intake");
+  });
+
+  it("403s for non-OPERATOR sessions (requireAuth gate)", async () => {
+    const permissions = await import("@/lib/permissions");
+    vi.mocked(permissions.requireAuth).mockResolvedValueOnce({
+      error: new Response("forbidden", { status: 403 }),
+    } as never);
+    const { PATCH } = await loadRoute();
+    const res = await PATCH(
+      makeReq({ settingId: "intakeSpecId", value: "spec-x" }) as never,
+      PARAMS as never,
+    );
+    expect(res.status).toBe(403);
+
+    // Domain writer must NOT have been called when auth failed.
+    const { updateDomainConfig } = await import(
+      "@/lib/domain/update-domain-config"
+    );
+    expect(updateDomainConfig).not.toHaveBeenCalled();
+  });
+
+  it("400s on malformed body (zod validation)", async () => {
+    const { PATCH } = await loadRoute();
+    const res = await PATCH(
+      makeReq({ value: "spec-x" /* missing settingId */ }) as never,
+      PARAMS as never,
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("BAD_BODY");
+  });
+
+  it("404s when the course's Playbook row doesn't exist", async () => {
+    mockPrisma.playbook.findFirst.mockResolvedValueOnce(null);
+    const { PATCH } = await loadRoute();
+    const res = await PATCH(
+      makeReq({ settingId: "intakeSpecId", value: "spec-x" }) as never,
+      PARAMS as never,
+    );
+    expect(res.status).toBe(404);
+
+    const { updateDomainConfig } = await import(
+      "@/lib/domain/update-domain-config"
+    );
+    expect(updateDomainConfig).not.toHaveBeenCalled();
+  });
+
+  it("rejects pipeline-actor headers for operator-only contracts", async () => {
+    // intakeSpecId is operator-only (writeGate). Pipeline-service tokens
+    // must be rejected explicitly via the x-pipeline-actor header check.
+    const { PATCH } = await loadRoute();
+    const res = await PATCH(
+      makeReq(
+        { settingId: "intakeSpecId", value: "spec-x" },
+        { "x-pipeline-actor": "EXTRACT" },
+      ) as never,
+      PARAMS as never,
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe("OPERATOR_ONLY");
+
+    const { updateDomainConfig } = await import(
+      "@/lib/domain/update-domain-config"
+    );
+    expect(updateDomainConfig).not.toHaveBeenCalled();
+  });
+
+  it("returns autoEnabled: [] for domain-rooted writes (no fan-out today)", async () => {
+    const { PATCH } = await loadRoute();
+    const res = await PATCH(
+      makeReq({ settingId: "intakeSpecId", value: "spec-x" }) as never,
+      PARAMS as never,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.autoEnabled).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Removes the HTTP 501 stub for storage root `domain.*` in `PATCH /api/courses/[courseId]/journey-setting`
- Wires the ONE contract whose primary `storagePath` lives under `domain.*`: `intakeSpecId` → `domain.onboardingIdentitySpecId` (scalar Domain column)
- Routes through `updateDomainConfig` (the canonical Domain writer used by `set-at-layer.ts`, the wizard tools, and `admin-tool-handlers.ts`)
- New `lib/compose/bump-domain-staleness.ts::bumpDomainSectionStaleness` fans out section-grain staleness to every Playbook in the Domain
- Scope: exactly 1 contract. The other 7 "domain-rooted" contracts the original audit flagged carry domain-only `cascadeSources[]` but a Playbook-rooted PRIMARY `storagePath` — they don't reach this branch
- Nested `domain.config.*` paths still return 501 (no contract uses that shape today; documented next-step in the route comment)

## What changed

| File | Change |
|---|---|
| `apps/admin/app/api/courses/[courseId]/journey-setting/route.ts` | New `resolved.root === "domain"` branch with `updateDomainConfig` + section-staleness fanout |
| `apps/admin/lib/compose/bump-domain-staleness.ts` | NEW — fans `bumpSectionHash` across every Playbook in the Domain |
| `apps/admin/tests/api/journey-setting-domain-write.test.ts` | NEW — 7 vitests pinning happy path + section fanout + 403 + 400 + 404 + operator-only header + autoEnabled shape |
| `apps/admin/tests/api/courses/journey-setting-route.test.ts` | Updated 501-assertion to assert the 501 is gone (the new dedicated test owns the happy-path coverage) |

## Verified by

- `npx tsc --noEmit` — 38 errors (baseline 42, -4). Zero new errors from this PR's files
- `npm run lint` on the 4 changed files — clean
- `npx vitest run tests/api/journey-setting-domain-write.test.ts` — 7 new vitests green
- `npx vitest run tests/api/courses/journey-setting-route.test.ts` — existing 13 tests still green
- `npx vitest run tests/lib/journey/arraykey-writer-coverage.test.ts` — 7 tests still green (no regression to the sibling Coverage gate)
- Full `tests/api/courses/` suite — 63 tests green across 8 files
- **Lattice survey** (per `.claude/rules/lattice-survey.md`):
  - **Sibling-writer drift**: `updateDomainConfig` is the canonical writer for the 4 onboarding fields (verified via `grep -rn "prisma.domain.update"` — only the canonical writer and unrelated route handlers exist; no parallel writers on the journey-setting path)
  - **Default-deny gates**: PATCH route already gates on OPERATOR via `requireAuth`; new branch inherits. Operator-only contracts (`intakeSpecId` has `writeGate: "operator-only"`) still reject `x-pipeline-actor` headers — pinned by vitest
  - **Cascade respect**: writes the Domain layer; `lib/cascade/resolvers/identity-spec.ts` reads the Domain layer; alignment is correct
  - **Convention conflict**: `domain.onboardingIdentitySpecId` is a scalar Domain column, not a `config.*` JSON key — the storage-path-applier's `domain` branch is intentionally a no-op for this shape. The route handler resolves the scalar write directly (no applier change needed)
- **Compose-staleness bump per `.claude/rules/ai-to-db-guard.md`** (table row for compose-staleness bumps): `updateDomainConfig` bumps `Domain.composeInputsUpdatedAt` which is one of the 4 scope timestamps read by `lib/compose/staleness.ts::isPromptStale`. Every caller in every dependent playbook sees the stale signal on the next call. The new `bumpDomainSectionStaleness` adds the section-grain layer (`PlaybookSectionStaleness` rows are per-playbook, so a Domain write needs per-playbook fanout for section-grain banners)

## Acceptance criteria

- [x] `intakeSpecId` PATCH succeeds (no more 501) — pinned by happy-path vitest
- [x] Updated value resolves through the cascade correctly on next read — `updateDomainConfig` is the canonical writer the cascade resolver reads from
- [x] All dependent Playbooks see compose-staleness bump — via `Domain.composeInputsUpdatedAt` (prompt-grain) + `bumpDomainSectionStaleness` (section-grain)
- [x] 0 other domain-rooted contracts affected (scope = 1) — only `intakeSpecId` has a domain-rooted PRIMARY storagePath

## What this PR does NOT do (per TL scope)

- Does NOT generalise to all 8 "domain-rooted" contracts the original audit flagged
- Does NOT modify cascade resolvers
- Does NOT add new contracts
- Does NOT change the audit pattern in `arraykey-writer-coverage`

## Test plan

- [ ] Live verify on hf-dev: PATCH `intakeSpecId` on a course; confirm the cascade resolver reads the new value on next compose
- [ ] Confirm compose-staleness banner on dependent Playbooks reflects the write

Closes A4 of #2225.

**DO NOT MERGE.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)