### PR TITLE
fix(journey): #2225 A2b — moduleScaffoldPool array-editor renders editable list

### DIFF
--- a/apps/admin/components/journey-controls/JourneyArrayEditor.tsx
+++ b/apps/admin/components/journey-controls/JourneyArrayEditor.tsx
@@ -23,6 +23,8 @@ import type { JourneyFieldProps } from "./JourneyField";
  *   - `moduleProfileFieldsToCapture` → `{ key: string, prompt: string,
  *     type: "text" | "number" | "band" }` (one entry per profile field
  *     the EXTRACT routine should capture; see Theme 10 / #1704).
+ *   - `moduleScaffoldPool` → `string[]` (each row is a plain scaffold
+ *     line; uses the `string-list` schema kind below — A2b of #2225).
  *
  * Each row provides add / remove / move-up / move-down. The editor
  * commits whenever a row changes; the cascade-edit hook handles debounce
@@ -43,11 +45,36 @@ interface RowField {
   hint?: string;
 }
 
-interface RowSchema {
+/**
+ * Object-row schema: rows are `Record<string, ...>` shaped, with one
+ * input per declared field. Default kind when `kind` is omitted.
+ */
+interface ObjectRowSchema {
+  kind?: "object";
   fields: RowField[];
   /** Shown above the rows list, e.g. "Card 1". */
   itemTitle: (index: number) => string;
 }
+
+/**
+ * String-row schema: rows are plain strings (storage shape `string[]`).
+ * Used for pools of free-text lines such as `moduleScaffoldPool` — the
+ * operator authors one scaffold line per row. Each row renders a single
+ * textarea (or input when `type === "string"`).
+ */
+interface StringRowSchema {
+  kind: "string-list";
+  /** Shown above the rows list, e.g. "Scaffold 1". */
+  itemTitle: (index: number) => string;
+  /** Single-line vs multi-line input. Defaults to multi-line for prose. */
+  inputType?: "string" | "string-multiline";
+  /** Optional helper text under the input. */
+  hint?: string;
+  /** Placeholder shown when a row is empty. */
+  placeholder?: string;
+}
+
+type RowSchema = ObjectRowSchema | StringRowSchema;
 
 const ROW_SCHEMAS: Record<string, RowSchema> = {
   moduleCueCardPool: {
@@ -117,19 +144,40 @@ const ROW_SCHEMAS: Record<string, RowSchema> = {
       },
     ],
   },
+  // A2b of #2225 — string-array storage. Each row is a single scaffold
+  // line the client-side stall detector picks from after a 10s silence
+  // window. Plain strings (not objects) because the runtime treats the
+  // pool as `string[]` (`config.modules[].settings.scaffoldPool`).
+  moduleScaffoldPool: {
+    kind: "string-list",
+    itemTitle: (i) => `Scaffold ${i + 1}`,
+    inputType: "string-multiline",
+    hint: 'e.g. "Take your time…" / "When you\'re ready, carry on…"',
+    placeholder: "Subtle scaffold line",
+  },
 };
 
-type Row = Record<string, string | number | string[]>;
+type ObjectRow = Record<string, string | number | string[]>;
+type StringRow = string;
+type Row = ObjectRow | StringRow;
 
-function coerce(value: unknown): Row[] {
+function coerce(value: unknown, schema: RowSchema | undefined): Row[] {
   if (!Array.isArray(value)) return [];
+  if (schema && schema.kind === "string-list") {
+    // String-row mode: drop non-string entries; preserve order. Strings
+    // are immutable, so no clone needed.
+    return value.filter((v): v is string => typeof v === "string");
+  }
   return value
-    .filter((v): v is Row => !!v && typeof v === "object" && !Array.isArray(v))
+    .filter(
+      (v): v is ObjectRow => !!v && typeof v === "object" && !Array.isArray(v),
+    )
     .map((v) => ({ ...v }));
 }
 
 function defaultRow(schema: RowSchema): Row {
-  const row: Row = {};
+  if (schema.kind === "string-list") return "";
+  const row: ObjectRow = {};
   for (const f of schema.fields) {
     row[f.key] = f.default ?? (f.type === "number" ? 0 : "");
   }
@@ -164,7 +212,7 @@ export function JourneyArrayEditor({
 
   const f = useCascadeEditField<Row[]>({
     contract,
-    value: coerce(value),
+    value: coerce(value, schema),
     onSave: async (next) => onSave(next),
   });
 
@@ -215,7 +263,20 @@ export function JourneyArrayEditor({
 
   function setRowField(index: number, fieldKey: string, raw: string, type: RowFieldType) {
     const next = [...f.draftValue];
-    next[index] = { ...next[index], [fieldKey]: inputToRowField(raw, type) };
+    const existing = next[index];
+    if (typeof existing === "string") {
+      // Should not happen — string-row contracts route through
+      // setStringRow. Guard kept defensively to satisfy the type
+      // narrowing.
+      return;
+    }
+    next[index] = { ...existing, [fieldKey]: inputToRowField(raw, type) };
+    updateDebounced(next);
+  }
+
+  function setStringRow(index: number, raw: string) {
+    const next = [...f.draftValue];
+    next[index] = raw;
     updateDebounced(next);
   }
 
@@ -269,59 +330,100 @@ export function JourneyArrayEditor({
                   </div>
                 </div>
                 <div className="hf-jf-array-row-fields">
-                  {schema.fields.map((field) => {
-                    const raw = rowFieldToInput(row[field.key] as string | number | string[] | undefined, field.type);
-                    const inputId = `hf-jf-${contract.id}-${index}-${field.key}`;
-                    return (
-                      <label key={field.key} className="hf-jf-array-field">
-                        <span className="hf-jf-array-field-label">{field.label}</span>
-                        {field.type === "string-multiline" ? (
-                          <textarea
-                            id={inputId}
-                            className="hf-input hf-jf-input"
-                            rows={3}
-                            value={raw}
-                            disabled={disabled || f.isSaving}
-                            data-testid={`hf-jf-field-${contract.id}-${index}-${field.key}`}
-                            onChange={(e) => setRowField(index, field.key, e.target.value, field.type)}
-                            onBlur={() => void f.commit()}
-                          />
-                        ) : field.type === "select" ? (
-                          <select
-                            id={inputId}
-                            className="hf-input hf-jf-input"
-                            value={raw}
-                            disabled={disabled || f.isSaving}
-                            data-testid={`hf-jf-field-${contract.id}-${index}-${field.key}`}
-                            onChange={(e) => {
-                              setRowField(index, field.key, e.target.value, field.type);
-                              void f.commit();
-                            }}
-                          >
-                            {field.options?.map((opt) => (
-                              <option key={opt.value} value={opt.value}>
-                                {opt.label}
-                              </option>
-                            ))}
-                          </select>
-                        ) : (
-                          <input
-                            id={inputId}
-                            type={field.type === "number" ? "number" : "text"}
-                            className="hf-input hf-jf-input"
-                            value={raw}
-                            disabled={disabled || f.isSaving}
-                            data-testid={`hf-jf-field-${contract.id}-${index}-${field.key}`}
-                            onChange={(e) => setRowField(index, field.key, e.target.value, field.type)}
-                            onBlur={() => void f.commit()}
-                          />
-                        )}
-                        {field.hint ? (
-                          <span className="hf-jf-help hf-jf-array-field-hint">{field.hint}</span>
-                        ) : null}
-                      </label>
-                    );
-                  })}
+                  {schema.kind === "string-list" ? (
+                    (() => {
+                      const inputId = `hf-jf-${contract.id}-${index}-value`;
+                      const raw = typeof row === "string" ? row : "";
+                      const inputType = schema.inputType ?? "string-multiline";
+                      return (
+                        <label className="hf-jf-array-field">
+                          {inputType === "string-multiline" ? (
+                            <textarea
+                              id={inputId}
+                              className="hf-input hf-jf-input"
+                              rows={2}
+                              value={raw}
+                              placeholder={schema.placeholder}
+                              disabled={disabled || f.isSaving}
+                              data-testid={`hf-jf-field-${contract.id}-${index}-value`}
+                              onChange={(e) => setStringRow(index, e.target.value)}
+                              onBlur={() => void f.commit()}
+                            />
+                          ) : (
+                            <input
+                              id={inputId}
+                              type="text"
+                              className="hf-input hf-jf-input"
+                              value={raw}
+                              placeholder={schema.placeholder}
+                              disabled={disabled || f.isSaving}
+                              data-testid={`hf-jf-field-${contract.id}-${index}-value`}
+                              onChange={(e) => setStringRow(index, e.target.value)}
+                              onBlur={() => void f.commit()}
+                            />
+                          )}
+                          {schema.hint ? (
+                            <span className="hf-jf-help hf-jf-array-field-hint">{schema.hint}</span>
+                          ) : null}
+                        </label>
+                      );
+                    })()
+                  ) : (
+                    schema.fields.map((field) => {
+                      const objectRow = (typeof row === "string" ? {} : row) as ObjectRow;
+                      const raw = rowFieldToInput(objectRow[field.key] as string | number | string[] | undefined, field.type);
+                      const inputId = `hf-jf-${contract.id}-${index}-${field.key}`;
+                      return (
+                        <label key={field.key} className="hf-jf-array-field">
+                          <span className="hf-jf-array-field-label">{field.label}</span>
+                          {field.type === "string-multiline" ? (
+                            <textarea
+                              id={inputId}
+                              className="hf-input hf-jf-input"
+                              rows={3}
+                              value={raw}
+                              disabled={disabled || f.isSaving}
+                              data-testid={`hf-jf-field-${contract.id}-${index}-${field.key}`}
+                              onChange={(e) => setRowField(index, field.key, e.target.value, field.type)}
+                              onBlur={() => void f.commit()}
+                            />
+                          ) : field.type === "select" ? (
+                            <select
+                              id={inputId}
+                              className="hf-input hf-jf-input"
+                              value={raw}
+                              disabled={disabled || f.isSaving}
+                              data-testid={`hf-jf-field-${contract.id}-${index}-${field.key}`}
+                              onChange={(e) => {
+                                setRowField(index, field.key, e.target.value, field.type);
+                                void f.commit();
+                              }}
+                            >
+                              {field.options?.map((opt) => (
+                                <option key={opt.value} value={opt.value}>
+                                  {opt.label}
+                                </option>
+                              ))}
+                            </select>
+                          ) : (
+                            <input
+                              id={inputId}
+                              type={field.type === "number" ? "number" : "text"}
+                              className="hf-input hf-jf-input"
+                              value={raw}
+                              disabled={disabled || f.isSaving}
+                              data-testid={`hf-jf-field-${contract.id}-${index}-${field.key}`}
+                              onChange={(e) => setRowField(index, field.key, e.target.value, field.type)}
+                              onBlur={() => void f.commit()}
+                            />
+                          )}
+                          {field.hint ? (
+                            <span className="hf-jf-help hf-jf-array-field-hint">{field.hint}</span>
+                          ) : null}
+                        </label>
+                      );
+                    })
+                  )}
                 </div>
               </li>
             ))}

--- a/apps/admin/tests/components/journey-controls/JourneyArrayEditor.test.tsx
+++ b/apps/admin/tests/components/journey-controls/JourneyArrayEditor.test.tsx
@@ -177,6 +177,93 @@ describe("JourneyArrayEditor — moduleScheduledCues", () => {
   });
 });
 
+describe("JourneyArrayEditor — moduleScaffoldPool (A2b of #2225)", () => {
+  const scaffoldPoolContract: JourneySettingContract = {
+    id: "moduleScaffoldPool",
+    group: "G8",
+    educatorLabel: "Stall scaffold pool",
+    storagePath: { path: "config.modules[].settings.scaffoldPool", arrayKey: "id" },
+    control: "array-editor",
+    cascadeSources: [],
+    composeImpact: {
+      sections: [],
+      kinds: ["stop-timing"],
+      requiresReprompt: false,
+    },
+    previewLocators: [],
+  };
+
+  it("renders string-array rows (NOT the 'No row schema registered' fallback)", () => {
+    render(
+      <JourneyArrayEditor
+        contract={scaffoldPoolContract}
+        value={["Take your time…", "When you're ready, carry on…"]}
+        onSave={vi.fn(() => Promise.resolve())}
+      />,
+    );
+    // Editable list visible — not the fallback alert that the A2 audit caught.
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.getByTestId("hf-jf-row-moduleScaffoldPool-0")).toBeInTheDocument();
+    expect(screen.getByTestId("hf-jf-row-moduleScaffoldPool-1")).toBeInTheDocument();
+    expect(
+      (screen.getByTestId("hf-jf-field-moduleScaffoldPool-0-value") as HTMLTextAreaElement).value,
+    ).toBe("Take your time…");
+    expect(
+      (screen.getByTestId("hf-jf-field-moduleScaffoldPool-1-value") as HTMLTextAreaElement).value,
+    ).toBe("When you're ready, carry on…");
+  });
+
+  it("Add row appends an empty string row", () => {
+    render(
+      <JourneyArrayEditor
+        contract={scaffoldPoolContract}
+        value={[]}
+        onSave={vi.fn(() => Promise.resolve())}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("hf-jf-array-add-moduleScaffoldPool"));
+    expect(screen.getByTestId("hf-jf-row-moduleScaffoldPool-0")).toBeInTheDocument();
+    expect(
+      (screen.getByTestId("hf-jf-field-moduleScaffoldPool-0-value") as HTMLTextAreaElement).value,
+    ).toBe("");
+  });
+
+  it("Editing a row commits the new string[] on blur", async () => {
+    const onSave = vi.fn(() => Promise.resolve());
+    render(
+      <JourneyArrayEditor
+        contract={scaffoldPoolContract}
+        value={["Take your time…"]}
+        onSave={onSave}
+      />,
+    );
+    const input = screen.getByTestId("hf-jf-field-moduleScaffoldPool-0-value");
+    fireEvent.change(input, { target: { value: "Whenever you're ready" } });
+    await act(async () => {
+      fireEvent.blur(input);
+      await Promise.resolve();
+    });
+    expect(onSave).toHaveBeenCalledWith(["Whenever you're ready"]);
+  });
+
+  it("Remove row drops the entry from the saved string[]", async () => {
+    const onSave = vi.fn(() => Promise.resolve());
+    render(
+      <JourneyArrayEditor
+        contract={scaffoldPoolContract}
+        value={["A", "B"]}
+        onSave={onSave}
+      />,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("hf-jf-row-remove-moduleScaffoldPool-0"));
+      vi.advanceTimersByTime(700);
+      await Promise.resolve();
+    });
+    expect(onSave).toHaveBeenCalledWith(["B"]);
+  });
+});
+
 describe("JourneyArrayEditor — unknown contract.id", () => {
   it("renders an error panel for contracts without a row schema", () => {
     const unknownContract: JourneySettingContract = {


### PR DESCRIPTION
## Summary

A2b of epic #2225 (Lattice Gap Zero — admin tab tunables). Closes the
operator-screenshot symptom from the A2 audit: the Stall scaffold pool
card in the Module Inspector showed the "No row schema registered"
fallback alert instead of an editable list, because the
`G8_MODULE_SCAFFOLD_POOL` contract declared `control: "array-editor"`
but `JourneyArrayEditor.tsx::ROW_SCHEMAS` only carried object-row
schemas (cueCardPool / scheduledCues / profileFieldsToCapture).

**Option A taken** — extend the schema, not the storage:

- Added a `StringRowSchema` discriminator (`kind: "string-list"`)
  sibling to the existing object-row schemas. Default `kind: "object"`
  preserves byte-for-byte behaviour on the 3 existing contracts.
- Registered `moduleScaffoldPool` with `kind: "string-list"` + multiline
  textarea + placeholder + hint.
- Refactored `coerce` / `defaultRow` / row-render JSX to dispatch on
  `schema.kind`. Added `setStringRow` sibling to `setRowField`.
- 4 new vitests pin the moduleScaffoldPool flow (renders list not
  fallback, Add row appends "", edit commits string[] on blur, Remove
  drops the entry).

**No cascade / writer / runtime impact** — the editor reads what the
contract already declares (`config.modules[].settings.scaffoldPool`,
arrayKey `id`) and writes the same `string[]` shape the runtime stall
detector already expects.

## Verified by

- **Lattice survey** (`.claude/rules/lattice-survey.md`): pure render-
  side fix to an existing control primitive. No DB column mutation, no
  chain-stage boundary crossed, no new guard/contract, no AI path
  touched, no new cascade knob. The 4 classic risk shapes do not apply:
  - Sibling-writer drift — no writer touched (single PATCH path
    unchanged, still consumes `string[]`).
  - Default-deny gates — none apply to a render-side primitive.
  - Cascade respect — `moduleScaffoldPool` is module-scoped (not
    cascadable); no resolver involved.
  - Convention conflict — `string[]` storage is unchanged; the rendered
    surface now matches the declared storage shape.
- **tsc** clean (42 errors == baseline 42; net-zero).
- **lint** clean on changed files (1 pre-existing unused-param warning
  in `rowFieldToInput`, untouched by this PR).
- **vitest** 12/12 `JourneyArrayEditor.test.tsx` pass (8 existing + 4
  new). Full `tests/components/journey-controls/` suite: 52/52 pass.

## Test plan

- [x] `npx tsc --noEmit` — no new errors
- [x] `npx eslint apps/admin/components/journey-controls/JourneyArrayEditor.tsx apps/admin/tests/components/journey-controls/JourneyArrayEditor.test.tsx` — clean
- [x] `npx vitest run tests/components/journey-controls/JourneyArrayEditor.test.tsx` — 12/12 pass
- [x] `npx vitest run tests/components/journey-controls/` — 52/52 pass
- [ ] Live verify on hf-dev after merge — open Module Inspector on an
      IELTS Part 2 or Part 3 module; the Stall scaffold pool card
      should render an editable list with the existing scaffold lines,
      Add/Remove/Move buttons, and commit `string[]` on save.

Closes A2b of #2225 (parent stays open for siblings A2a / A2c / future
fixes from the audit).

DO NOT MERGE — operator review of the screenshot context first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)