### PR TITLE
feat(seeds): #2225 B4-impl — cascade values for 4 published playbooks

### DIFF
--- a/apps/admin/prisma/seed-2225-b4-cascade-values.ts
+++ b/apps/admin/prisma/seed-2225-b4-cascade-values.ts
@@ -1,0 +1,241 @@
+/**
+ * Epic #2225 B4-impl — Seed approved cascade values for 3 wizard-created
+ * playbooks (Big Five OCEAN / Spot the Spin / CIO/CTO Standard — Revision
+ * Aid). The IELTS Speaking Practice playbook is handled directly in
+ * `prisma/seed-ielts-course.ts` (the canonical seed that creates it).
+ *
+ * Approved values: https://github.com/WANDERCOLTD/HF/issues/2225#issuecomment-4763486228
+ * B4 proposal: https://github.com/WANDERCOLTD/HF/issues/2225#issuecomment-4763475679
+ *
+ * What this seed does (idempotent — conservative "only-if-unset" merge):
+ *
+ *   For each of the 3 target playbooks, found by `Playbook.name` substring
+ *   match, merge the approved cascade values into `Playbook.config` ONLY
+ *   when the key is currently absent. We never overwrite an operator's
+ *   deliberate choice — mirrors the pattern of
+ *   `scripts/backfill-cio-cto-playbook-configs.ts` (#1081).
+ *
+ *   - Big Five OCEAN              → tierPresetId, skillScoringEmaHalfLifeDays
+ *   - Spot the Spin (Seducing…)    → tierPresetId, skillScoringEmaHalfLifeDays
+ *   - CIO/CTO Standard Revision Aid → voiceConfig.{maxDurationSeconds,
+ *     silenceTimeoutSeconds}, tierPresetId="custom" + skillTierMapping,
+ *     skillScoringEmaHalfLifeDays, progressSignals=null (operator-approved
+ *     explicit null — disables progress narrator per silent-scoring pedagogy;
+ *     see `lib/prompt/composition/scoring-config.ts:80-81` which reads via
+ *     optional chain, so `null` resolves to undefined → no signal rendered).
+ *
+ * Lattice survey result:
+ *   - storagePath `playbook.voiceConfig.maxDurationSeconds` → writes to
+ *     `Playbook.config.voiceConfig.maxDurationSeconds` per
+ *     `lib/journey/storage-path-applier.ts:107` (verified).
+ *   - `tierPresetId` + `skillScoringEmaHalfLifeDays` + `skillTierMapping`
+ *     are all in `CASCADABLE_KEYS` per
+ *     `lib/cascade/resolvers/mastery-policy.ts:75-82` (verified).
+ *   - `tierPresetId: "custom"` is a valid TierPresetId per
+ *     `lib/banding/presets.ts:170-189` — co-seeded `skillTierMapping`
+ *     is the canonical opt-out-of-preset pattern (verified).
+ *   - `progressSignals` reader uses optional chain
+ *     `config.progressSignals?.lowWater` → `null` survives at runtime
+ *     (verified at `lib/prompt/composition/scoring-config.ts:80-81`).
+ *
+ * Sibling-writer convergence:
+ *   - `scripts/seed-ielts-prosody.ts` sets `tierPresetId="ielts-speaking"`
+ *     on IELTS playbooks only — disjoint from this script's targets.
+ *   - `scripts/backfill-cio-cto-playbook-configs.ts` (#1081) sets
+ *     `useFreshMastery` / `maxMasteryTier` on CIO/CTO playbooks — disjoint
+ *     keys; safe to coexist on Revision Aid (which gets {} from that
+ *     script).
+ *   - `scripts/fix-cio-cto-playbooks.ts` writes other Playbook columns
+ *     (validationPassed, measureSpecCount, etc.) — does not touch the
+ *     keys this script writes.
+ *
+ * Usage:
+ *   npx tsx prisma/seed-2225-b4-cascade-values.ts          # dry-run (default)
+ *   npx tsx prisma/seed-2225-b4-cascade-values.ts --apply  # write
+ *
+ * Idempotent: re-runs report "NOOP" for keys already present. Profiles:
+ * post-projection (run after the 3 target playbooks exist on the DB).
+ */
+
+import { PrismaClient, type Prisma } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+interface Target {
+  /** `Playbook.name` substring match (case-sensitive). */
+  playbookNameMatch: string;
+  /** Human label for log output. */
+  label: string;
+  /** Keys to merge into `Playbook.config` when currently unset. */
+  expected: Prisma.JsonObject;
+}
+
+const TARGETS: Target[] = [
+  {
+    playbookNameMatch: "Big Five",
+    label: "Big Five OCEAN",
+    expected: {
+      tierPresetId: "generic",
+      skillScoringEmaHalfLifeDays: 7,
+    },
+  },
+  {
+    playbookNameMatch: "Spot the Spin",
+    label: "Spot the Spin (Seducing Strangers)",
+    expected: {
+      tierPresetId: "generic",
+      skillScoringEmaHalfLifeDays: 7,
+    },
+  },
+  {
+    playbookNameMatch: "Revision Aid",
+    label: "CIO/CTO Standard — Revision Aid",
+    expected: {
+      voiceConfig: {
+        maxDurationSeconds: 1500,
+        silenceTimeoutSeconds: 60,
+      },
+      tierPresetId: "custom",
+      skillTierMapping: {
+        thresholds: {
+          approachingEmerging: 0.25,
+          emerging: 0.45,
+          developing: 0.7,
+          secure: 1.0,
+        },
+        tierBands: {
+          approachingEmerging: 1,
+          emerging: 2,
+          developing: 3,
+          secure: 4,
+        },
+        tierLabels: {
+          approachingEmerging: "Foundation",
+          emerging: "Developing",
+          developing: "Practitioner",
+          secure: "Distinction",
+        },
+      },
+      skillScoringEmaHalfLifeDays: 21,
+      // Explicit null per operator decision — disables progress narrator
+      // per silent-scoring pedagogy. Reader at
+      // `lib/prompt/composition/scoring-config.ts:80-81` uses optional
+      // chain (`config.progressSignals?.lowWater`) so null resolves to
+      // undefined → no progress signal rendered (verified).
+      progressSignals: null,
+    },
+  },
+];
+
+function isJsonObject(v: unknown): v is Prisma.JsonObject {
+  return !!v && typeof v === "object" && !Array.isArray(v);
+}
+
+interface PatchAction {
+  playbookId: string;
+  playbookName: string;
+  diff: Record<string, { from: unknown; to: unknown }>;
+}
+
+export interface SeedReport {
+  mode: "DRY-RUN" | "APPLY";
+  patches: PatchAction[];
+  noops: number;
+  missing: number;
+}
+
+async function main(): Promise<SeedReport> {
+  const apply = process.argv.includes("--apply");
+  const mode: "DRY-RUN" | "APPLY" = apply ? "APPLY" : "DRY-RUN";
+
+  console.log(`[seed-2225-b4] mode=${mode}`);
+  console.log(`[seed-2225-b4] inspecting ${TARGETS.length} target playbook(s)`);
+
+  const patches: PatchAction[] = [];
+  let noops = 0;
+  let missing = 0;
+
+  for (const t of TARGETS) {
+    const row = await prisma.playbook.findFirst({
+      where: { name: { contains: t.playbookNameMatch } },
+      select: { id: true, name: true, config: true },
+    });
+    if (!row) {
+      missing++;
+      console.warn(
+        `  MISSING  "${t.playbookNameMatch}" — no playbook with that substring; skipping ("${t.label}")`,
+      );
+      continue;
+    }
+
+    const current: Prisma.JsonObject = isJsonObject(row.config) ? (row.config as Prisma.JsonObject) : {};
+    const diff: Record<string, { from: unknown; to: unknown }> = {};
+
+    for (const [k, v] of Object.entries(t.expected)) {
+      if (current[k] === undefined) {
+        diff[k] = { from: undefined, to: v };
+      }
+    }
+
+    if (Object.keys(diff).length === 0) {
+      noops++;
+      console.log(`  NOOP     ${row.id.slice(0, 8)}  "${row.name}" — all keys already present`);
+      continue;
+    }
+
+    console.log(`  PATCH    ${row.id.slice(0, 8)}  "${row.name}" (${t.label})`);
+    for (const [k, d] of Object.entries(diff)) {
+      console.log(`           ${k}: ${JSON.stringify(d.from)} → ${JSON.stringify(d.to)}`);
+    }
+
+    patches.push({ playbookId: row.id, playbookName: row.name, diff });
+
+    if (apply) {
+      await prisma.$transaction(async (tx) => {
+        // Re-read under the transaction to avoid clobbering a concurrent edit.
+        const fresh = await tx.playbook.findUnique({
+          where: { id: row.id },
+          select: { config: true },
+        });
+        const freshCfg: Prisma.JsonObject = isJsonObject(fresh?.config)
+          ? (fresh!.config as Prisma.JsonObject)
+          : {};
+        const merged: Prisma.JsonObject = { ...freshCfg };
+        for (const [k, v] of Object.entries(t.expected)) {
+          if (merged[k] === undefined) {
+            merged[k] = v as Prisma.JsonValue;
+          }
+        }
+        await tx.playbook.update({
+          where: { id: row.id },
+          data: { config: merged },
+        });
+      });
+    }
+  }
+
+  console.log("");
+  console.log(
+    `[seed-2225-b4] summary: patch=${patches.length} noop=${noops} missing=${missing}`,
+  );
+  console.log(
+    `[seed-2225-b4] ${apply ? "APPLIED" : "DRY-RUN (no writes); re-run with --apply to commit."}`,
+  );
+
+  return { mode, patches, noops, missing };
+}
+
+// Run as CLI when invoked directly. Skip when imported (e.g. by tests).
+if (require.main === module) {
+  main()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error("[seed-2225-b4] FATAL", err);
+      process.exit(1);
+    })
+    .finally(() => {
+      prisma.$disconnect();
+    });
+}
+
+export { main as runSeed };

--- a/apps/admin/prisma/seed-ielts-course.ts
+++ b/apps/admin/prisma/seed-ielts-course.ts
@@ -168,6 +168,18 @@ export async function main(prisma: PrismaClient): Promise<void> {
         },
         // No nps / surveys configured here — projection's goalTemplates carry
         // the learning + skill goals; the wizard adds engagement goals later.
+        //
+        // ── B4-impl of epic #2225 — approved cascade values (op approval:
+        //    https://github.com/WANDERCOLTD/HF/issues/2225#issuecomment-4763486228).
+        //    Storage paths verified via lib/settings/voice-setting-contracts.ts
+        //    (maxCallDuration → playbook.voiceConfig.maxDurationSeconds) +
+        //    lib/cascade/resolvers/mastery-policy.ts (tierPresetId +
+        //    skillScoringEmaHalfLifeDays both in CASCADABLE_KEYS).
+        voiceConfig: {
+          maxDurationSeconds: 1800,
+        },
+        tierPresetId: "ielts-speaking",
+        skillScoringEmaHalfLifeDays: 14,
       },
     },
   });


### PR DESCRIPTION
## Summary

B4-impl of epic #2225 — seeds the approved cascade values for the 4
published playbooks on hf_staging, per the B4 proposal
(https://github.com/WANDERCOLTD/HF/issues/2225#issuecomment-4763475679)
and operator approval
(https://github.com/WANDERCOLTD/HF/issues/2225#issuecomment-4763486228).

12 cells filled across the 4 target playbooks:

| Playbook | File touched | Keys added |
|---|---|---|
| IELTS Speaking Practice | `prisma/seed-ielts-course.ts` (edit) | `voiceConfig.maxDurationSeconds: 1800`, `tierPresetId: "ielts-speaking"`, `skillScoringEmaHalfLifeDays: 14` |
| Big Five OCEAN | `prisma/seed-2225-b4-cascade-values.ts` (new) | `tierPresetId: "generic"`, `skillScoringEmaHalfLifeDays: 7` |
| Spot the Spin (Seducing Strangers) | `prisma/seed-2225-b4-cascade-values.ts` (new) | `tierPresetId: "generic"`, `skillScoringEmaHalfLifeDays: 7` |
| CIO/CTO Standard — Revision Aid | `prisma/seed-2225-b4-cascade-values.ts` (new) | `voiceConfig.{maxDurationSeconds: 1500, silenceTimeoutSeconds: 60}`, `tierPresetId: "custom"` + co-seeded `skillTierMapping` (Foundation / Developing / Practitioner / Distinction with 0.25/0.45/0.70/1.0 thresholds), `skillScoringEmaHalfLifeDays: 21`, `progressSignals: null` (explicit disable per silent-scoring pedagogy) |

## Why two surfaces

Only IELTS has a `prisma/seed-*.ts` script that creates the playbook
(`seed-ielts-course.ts`). The other 3 are wizard-created (see DB
bindings note in `MEMORY.md` — 4 PUBLISHED playbooks on hf_staging
post-pivot). A new conservative merge-if-unset seed
(`prisma/seed-2225-b4-cascade-values.ts`) handles them — same shape
as `scripts/backfill-cio-cto-playbook-configs.ts` (#1081): dry-run
default, `--apply` to write, never overwrites pre-existing operator
choices.

Per operator discipline: existing keys preserved (IELTS already had
8 config keys; this PR adds 3 — no removals).

## Approved by

Operator approval comment:
https://github.com/WANDERCOLTD/HF/issues/2225#issuecomment-4763486228

B4 proposal:
https://github.com/WANDERCOLTD/HF/issues/2225#issuecomment-4763475679

## Verified by

**Lattice survey** per `.claude/rules/lattice-survey.md`:

- **Sibling-writer drift**: surveyed `prisma.playbook.{create,upsert,update}`
  writers. Convergence confirmed disjoint with `scripts/seed-ielts-prosody.ts`
  (only sets `tierPresetId="ielts-speaking"` on IELTS-name-pattern playbooks,
  which my IELTS edit matches), `scripts/backfill-cio-cto-playbook-configs.ts`
  (disjoint keys — `useFreshMastery`/`maxMasteryTier` vs my `voiceConfig`/
  `tierPresetId`/etc.), `scripts/fix-cio-cto-playbooks.ts` (writes Playbook
  columns + linked rows, not `config` keys I touch). Merge-if-unset semantics
  in the new seed prevent clobbering any operator override.
- **Default-deny gates**: no per-key write-gate ESLint rule fires here —
  `tierPresetId` / `skillScoringEmaHalfLifeDays` / `skillTierMapping` /
  `voiceConfig` are operator-set config keys with no write-restriction rule.
- **Cascade respect**: confirmed `tierPresetId`, `skillScoringEmaHalfLifeDays`,
  `skillTierMapping`, `progressSignals` are all in `CASCADABLE_KEYS` at
  `lib/cascade/resolvers/mastery-policy.ts:75-82`. `playbook.voiceConfig.*`
  cascade lives in `lib/settings/voice-setting-contracts.ts:195` with
  domain-level fallback at `domain.voiceConfig.maxDurationSeconds` — the
  per-course write here is the canonical layer.
- **Convention conflict**: `tierPresetId: "custom"` verified as a valid
  TierPresetId at `lib/banding/presets.ts:170-189`; co-seeded
  `skillTierMapping` is the documented opt-out-of-preset pattern.
  `progressSignals: null` survives runtime — reader at
  `lib/prompt/composition/scoring-config.ts:80-81` uses optional chain
  (`config.progressSignals?.lowWater`), so `null` → `undefined` → no
  signal rendered.

**Storage-path verification** for `voiceConfig.maxDurationSeconds`:
contract at `lib/settings/voice-setting-contracts.ts:190-195` declares
`storagePath: "playbook.voiceConfig.maxDurationSeconds"`. Applier at
`lib/journey/storage-path-applier.ts:107-108` maps the `playbook.voiceConfig.`
prefix to `playbookConfig.voiceConfig.<rest>` — so writing the JSON
key `voiceConfig.maxDurationSeconds` into `Playbook.config` IS the
canonical destination.

**`tsc --noEmit`**: 38 errors (baseline 42; pre-push gate confirms
−4 vs baseline). No new errors on changed files.

**ESLint**: 0 errors on changed files. 2 pre-existing warnings in
`prisma/seed-ielts-course.ts` (lines 394, 396) are at code I did not
modify.

**vitest**: ran the cascade + journey surfaces (`tests/lib/cascade/`,
`tests/lib/journey/`) + every seed-related vitest
(`tests/lib/seed-contracts.test.ts`,
`tests/lib/find-or-create-seed-playbook.test.ts`,
`tests/lib/seed-ielts-fixture.test.ts`,
`tests/lib/seed-cio-cto-beh-targets.test.ts`,
`tests/scripts/seed-system-behavior-defaults.test.ts`,
`tests/scripts/seed-ielts-prosody.test.ts`): **355/355 passing**.

## Test plan

- [ ] Operator review of the per-playbook value cells in the table
      above against the approval comment
- [ ] On hf-dev: `npx tsx prisma/seed-2225-b4-cascade-values.ts`
      (dry-run) → confirm 3 PATCH lines for the 3 target playbooks
      with the expected diffs
- [ ] On hf-dev: `npx tsx prisma/seed-2225-b4-cascade-values.ts --apply`
      → confirm writes land + re-run produces 3 NOOP lines
- [ ] On hf-dev: Inspector cascade chips for the seeded knobs show
      "from Course" provenance. Use the `welcomeMessage` chip as a
      control (already working) and the newly-seeded `tierPresetId`
      chip as the validation case
- [ ] No migration needed — `Playbook.config` is an existing `Json?`
      column. Use `/vm-cp`

Closes B4 of #2225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)