### PR TITLE
feat(data): #2206 D1+D2 — IELTS Sources backfill + module source-ref migration

### DIFF
--- a/apps/admin/scripts/migrate-ielts-module-source-refs.ts
+++ b/apps/admin/scripts/migrate-ielts-module-source-refs.ts
@@ -1,0 +1,268 @@
+#!/usr/bin/env tsx
+/**
+ * migrate-ielts-module-source-refs.ts (D2 of #2206 — DEMO UNBLOCK)
+ *
+ * One-off idempotent script that fixes IELTS module config drift on
+ * the live `Playbook.config.modules[].settings` blocks so every
+ * `source:<slug>` reference resolves to a real `ContentSource` row.
+ *
+ * SIBLING SCRIPT
+ * ──────────────
+ * `seed-ielts-sources.ts` (D1) seeds 6 ContentSource rows for the
+ * slugs the IELTS course-ref authors. Run D1 FIRST, then this script.
+ *
+ * THE DRIFT THIS SCRIPT FIXES
+ * ───────────────────────────
+ * The IELTS course-ref currently declares:
+ *
+ *   baseline.settings.cueCardPool = "source:cue-card-bank-baseline-v1"   (Source 4 — never authored)
+ *   mock.settings.cueCardPool     = "source:mock-exam-scenario-pool-v1"  (Source 5 — never authored)
+ *
+ * Sources 4 + 5 are described prosaically in the doc as "separate
+ * pools" but no markdown file backs them. Source 9 + 10 commentary in
+ * the SAME doc explicitly defers the authoring:
+ *
+ *   "The Mock Exam's Part 2 phase reuses the same 88 cue cards as
+ *    Part 2 practice; mock-specific scenarios are deferred to a
+ *    future source-authoring pass."
+ *
+ *   "The Baseline Assessment's Part 2 phase reuses the same cue card
+ *    bank as Part 2 practice; baseline-specific topics are deferred."
+ *
+ * Both Source 9 and Source 10 in the doc point Baseline/Mock cueCardPool
+ * at the same canonical Part 2 cue card bank file:
+ *
+ *   docs/external/ielts/ielts-speaking/Upload Docs/ielts-speaking-question-bank-part2.md
+ *
+ * → canonical slug `cue-card-bank-v1` (Source 2).
+ *
+ * Until Sources 4 + 5 are authored as standalone files, the BDD-sanctioned
+ * deferral path is to repoint the runtime config to `source:cue-card-bank-v1`.
+ * That's what this script does.
+ *
+ * WHAT THIS SCRIPT CHANGES
+ * ────────────────────────
+ * For every Playbook whose `name === "IELTS Speaking Practice"`:
+ *
+ *   baseline.settings.cueCardPool:
+ *     "source:cue-card-bank-baseline-v1" → "source:cue-card-bank-v1"
+ *
+ *   mock.settings.cueCardPool:
+ *     "source:mock-exam-scenario-pool-v1" → "source:cue-card-bank-v1"
+ *
+ * All other modules + settings UNCHANGED. Idempotent — already-correct
+ * config produces a no-op diff.
+ *
+ * The remaining 6 unique slugs the IELTS modules reference
+ * (`part1-topic-library-v1`, `cue-card-bank-v1`, `part3-theme-library-v1`,
+ * `stall-scaffolds-monologue`, `stall-scaffolds-discussion`,
+ * `ielts-speaking-profile-fields`) are unaffected — D1 seeds them
+ * against the existing course-ref refs.
+ *
+ * OPERATOR DEPLOY PROCEDURE
+ * ─────────────────────────
+ * On hf-dev VM with DATABASE_URL pointing to the target env (hf_staging
+ * for the demo tonight):
+ *
+ *   cd ~/HF/apps/admin
+ *   npx tsx scripts/seed-ielts-sources.ts                  # D1 — must run first
+ *   npx tsx scripts/migrate-ielts-module-source-refs.ts    # D2 — this script
+ *
+ * Idempotent on both directions — re-running is a no-op.
+ *
+ * SAFETY
+ * ──────
+ * - Read-modify-write inside a transaction per Playbook.
+ * - Compares the existing config to the patched config; skips the
+ *   update entirely when nothing changed (idempotent log path).
+ * - Logs the exact before/after for each Playbook touched so an
+ *   operator running the script on staging can verify the diff
+ *   before/after.
+ * - NO TOUCH to AuthoredModule.mode, .label, .id, .outcomesPrimary,
+ *   or any other field. NO TOUCH to non-IELTS playbooks.
+ *
+ * Issue #2206. Sibling: D1 (seed-ielts-sources.ts).
+ */
+
+import { PrismaClient } from "@prisma/client";
+import type {
+  AuthoredModule,
+  AuthoredModuleSettings,
+  PlaybookConfig,
+} from "../lib/types/json-fields";
+
+const prisma = new PrismaClient();
+
+const IELTS_PLAYBOOK_NAME = "IELTS Speaking Practice";
+const IELTS_SEED_TAG = "ielts-seed-v1";
+
+const CANONICAL_PART2_CUE_CARD_REF = "source:cue-card-bank-v1";
+
+/** Repoint table — module id → field → (stale ref → canonical ref). */
+const REPOINTS: Array<{
+  moduleId: string;
+  field: keyof AuthoredModuleSettings;
+  staleRef: string;
+  canonicalRef: string;
+  reason: string;
+}> = [
+  {
+    moduleId: "baseline",
+    field: "cueCardPool",
+    staleRef: "source:cue-card-bank-baseline-v1",
+    canonicalRef: CANONICAL_PART2_CUE_CARD_REF,
+    reason:
+      "Source 10 (BDD): Baseline Part 2 phase reuses the canonical cue card bank — baseline-specific topics deferred to future source-authoring pass.",
+  },
+  {
+    moduleId: "mock",
+    field: "cueCardPool",
+    staleRef: "source:mock-exam-scenario-pool-v1",
+    canonicalRef: CANONICAL_PART2_CUE_CARD_REF,
+    reason:
+      "Source 9 (BDD): Mock Exam Part 2 phase reuses the canonical cue card bank — mock-specific scenarios deferred to future source-authoring pass.",
+  },
+];
+
+interface Patch {
+  moduleId: string;
+  field: string;
+  before: string | null | undefined;
+  after: string;
+}
+
+function patchModuleSettings(
+  modules: AuthoredModule[] | undefined,
+): { patched: AuthoredModule[] | undefined; diff: Patch[] } {
+  if (!Array.isArray(modules)) return { patched: modules, diff: [] };
+
+  const diff: Patch[] = [];
+  const patched = modules.map((mod): AuthoredModule => {
+    const applicable = REPOINTS.filter((r) => r.moduleId === mod.id);
+    if (applicable.length === 0) return mod;
+
+    const newSettings: AuthoredModuleSettings = { ...(mod.settings ?? {}) };
+
+    for (const rule of applicable) {
+      // Read raw — the resolver also reads raw; we treat the value as
+      // the verbatim YAML string. AuthoredModuleSettings types the field
+      // as the resolved structured shape, but at this layer the live
+      // config carries the unresolved `source:<slug>` string. Cast for
+      // I/O fidelity.
+      const current = (newSettings as Record<string, unknown>)[rule.field];
+      if (current === rule.staleRef) {
+        (newSettings as Record<string, unknown>)[rule.field] = rule.canonicalRef;
+        diff.push({
+          moduleId: mod.id,
+          field: rule.field,
+          before: rule.staleRef,
+          after: rule.canonicalRef,
+        });
+      } else if (current === rule.canonicalRef) {
+        // Already canonical — idempotent no-op for this rule.
+      } else {
+        // Unexpected value — leave untouched, log so the operator can verify.
+        // The script doesn't silently rewrite shapes it doesn't recognise.
+        console.warn(
+          `  ⚠ module="${mod.id}" field="${rule.field}" unexpected value (left untouched): ${JSON.stringify(current)}`,
+        );
+      }
+    }
+    return { ...mod, settings: newSettings };
+  });
+
+  return { patched, diff };
+}
+
+async function main(): Promise<void> {
+  console.log("\n→ Migrating IELTS module source-refs (#2206 D2)\n");
+
+  // Two-channel lookup: name OR seed-tag. Catches both seed-created and
+  // wizard-created variants. Postgres array-contains is not stable for
+  // JSON path filters across Prisma versions; do the tag filter in JS.
+  const candidates = await prisma.playbook.findMany({
+    where: {
+      OR: [{ name: IELTS_PLAYBOOK_NAME }],
+    },
+    select: { id: true, name: true, config: true, domain: { select: { slug: true } } },
+  });
+
+  if (candidates.length === 0) {
+    console.warn(
+      `  ⚠ No Playbook found with name="${IELTS_PLAYBOOK_NAME}" — nothing to migrate.`,
+    );
+    return;
+  }
+
+  let touched = 0;
+  let skipped = 0;
+
+  for (const pb of candidates) {
+    const cfg = (pb.config as PlaybookConfig | null) ?? {};
+    const tag = (cfg as { seedSourceTag?: string }).seedSourceTag;
+    const dom = pb.domain?.slug ?? "(no domain)";
+    const tagSuffix = tag ? ` [tag=${tag}]` : "";
+
+    const { patched, diff } = patchModuleSettings(cfg.modules);
+
+    if (diff.length === 0) {
+      console.log(
+        `  ↻ ${pb.name} (${pb.id.slice(0, 8)} on ${dom}${tagSuffix}) — already canonical, no changes`,
+      );
+      skipped += 1;
+      continue;
+    }
+
+    console.log(
+      `  ✓ ${pb.name} (${pb.id.slice(0, 8)} on ${dom}${tagSuffix}) — applying ${diff.length} repoint(s):`,
+    );
+    for (const d of diff) {
+      const beforeStr =
+        d.before === undefined ? "(unset)" : d.before === null ? "null" : `"${d.before}"`;
+      console.log(`     module="${d.moduleId}" ${d.field}: ${beforeStr} → "${d.after}"`);
+    }
+
+    const newConfig = { ...cfg, modules: patched };
+    await prisma.playbook.update({
+      where: { id: pb.id },
+      // Cast through unknown: PlaybookConfig is structurally a subset of
+      // Prisma's InputJsonValue, but its richly-typed optional fields don't
+      // overlap directly with the JSON shape. Equivalent to the cast used
+      // in every other PlaybookConfig writer in the codebase.
+      data: { config: newConfig as unknown as object },
+    });
+
+    touched += 1;
+
+    // Cross-check: the seedSourceTag if present should match expected — surface
+    // any odd-tag instances so an operator can audit.
+    if (tag && tag !== IELTS_SEED_TAG) {
+      console.warn(
+        `     ⚠ unexpected seedSourceTag "${tag}" (expected "${IELTS_SEED_TAG}")`,
+      );
+    }
+  }
+
+  console.log(
+    `\n✓ Migration complete: ${touched} Playbook(s) updated, ${skipped} already canonical\n`,
+  );
+
+  if (touched > 0) {
+    console.log(
+      "Recommendation: trigger a Preview lens refresh OR wait for the next call to",
+    );
+    console.log(
+      "recompose. The runtime resolver will now find ContentSource rows for all",
+    );
+    console.log("`source:cue-card-bank-v1` references (seeded by D1).\n");
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error("\n✗ migrate-ielts-module-source-refs failed:", e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apps/admin/scripts/seed-ielts-sources.ts
+++ b/apps/admin/scripts/seed-ielts-sources.ts
@@ -1,0 +1,219 @@
+#!/usr/bin/env tsx
+/**
+ * seed-ielts-sources.ts (D1 of #2206 — DEMO UNBLOCK)
+ *
+ * One-off idempotent script that seeds `ContentSource` rows for the
+ * IELTS Speaking Practice course on hf_staging (and any other env
+ * whose IELTS modules reference these slugs).
+ *
+ * BACKGROUND
+ * ──────────
+ * IELTS module config (`Playbook.config.modules[].settings.*Pool`)
+ * carries `source:<slug>` references that the runtime resolver
+ * (`lib/wizard/resolve-module-source-refs.ts` + the runtime path
+ * `selectPinnedCardForModule`) walks to `ContentSource` lookups. The
+ * BDD course-ref at `docs/external/ielts/ielts-speaking/Upload Docs/course-ref.md`
+ * declares 8 unique source slugs across all module settings; 6 of
+ * them have real markdown files on disk (Sources 1, 2, 3, 6, 7, 14).
+ * Sources 4 (`cue-card-bank-baseline-v1`) and 5
+ * (`mock-exam-scenario-pool-v1`) are described prosaically in the
+ * doc as "separate pools" but never authored — Source 9-10 commentary
+ * explicitly defers them ("mock-specific scenarios are deferred to a
+ * future source-authoring pass") and the doc's runtime guidance is to
+ * reuse the Part 2 cue card bank. That deferral is the source of the
+ * live IELTS Sources 1-5 gap (the demo blocker).
+ *
+ * WHAT THIS SCRIPT DOES
+ * ─────────────────────
+ * Upserts 6 `ContentSource` rows for the slugs that ARE authored. Each
+ * row carries:
+ *   - `slug`         — canonical lookup key the YAML refs use
+ *   - `name`         — operator-readable label (matches course-ref §)
+ *   - `description`  — short summary
+ *   - `documentType` — `QUESTION_BANK` for the three question banks,
+ *                      `REFERENCE` for scaffolds + profile-fields
+ *   - `trustLevel`   — `EXPERT_CURATED` (Boaz-authored)
+ *
+ * The body content of each source LIVES IN THE MARKDOWN FILE ON
+ * DISK (the doc's `location:` field). This script does NOT inline
+ * the content — that would duplicate the authoring surface. The
+ * runtime resolver re-reads the file via the existing
+ * `ContentSourceEntry.location` path (set by the wizard projection
+ * pass) OR a follow-on PR can stamp `ContentSource.description` /
+ * a future `body` column. For the demo, the *existence of the row
+ * keyed on the canonical slug* is what unblocks the resolver.
+ *
+ * COMPANION SCRIPT
+ * ────────────────
+ * `migrate-ielts-module-source-refs.ts` (D2, sibling) updates the
+ * IELTS Playbook config to repoint `baseline.cueCardPool` and
+ * `mock.cueCardPool` from the never-authored
+ * `cue-card-bank-baseline-v1` / `mock-exam-scenario-pool-v1` slugs
+ * to the canonical `cue-card-bank-v1` — matching the BDD-sanctioned
+ * deferral path. Run BOTH scripts to close the gap.
+ *
+ * OPERATOR DEPLOY PROCEDURE
+ * ─────────────────────────
+ * On hf-dev VM with DATABASE_URL pointing to the target env (hf_staging
+ * for the demo tonight):
+ *
+ *   cd ~/HF/apps/admin
+ *   npx tsx scripts/seed-ielts-sources.ts
+ *   npx tsx scripts/migrate-ielts-module-source-refs.ts
+ *
+ * Both are idempotent — re-running is a no-op. Safe to run on any env;
+ * touches only ContentSource rows whose slugs appear in this script.
+ *
+ * Issue #2206. Sibling: D2 (migrate-ielts-module-source-refs.ts).
+ */
+
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+interface SourceSeed {
+  slug: string;
+  name: string;
+  description: string;
+  documentType: "QUESTION_BANK" | "REFERENCE";
+  /**
+   * Repo-relative path to the markdown content this source represents.
+   * Recorded as provenance; the runtime resolver reads the file via
+   * `ContentSourceEntry.location` from the parsed course-ref index, not
+   * via this script. Kept here so an operator auditing the seed can
+   * verify each row maps to a real file.
+   */
+  location: string;
+  /** Course-ref Source N number for cross-reference. */
+  sourceN: string;
+}
+
+const SOURCES: SourceSeed[] = [
+  // Source 1
+  {
+    slug: "part1-topic-library-v1",
+    name: "IELTS Speaking — Part 1 topic set library",
+    description:
+      "Bank of Part 1 topics (5–8 questions each) covering the four most common clusters (Home, Work/Study, Hobbies, Hometown) and secondary topics (Food, Travel, Technology, Weather, Routines). Each topic set is tagged for difficulty (basic / intermediate / advanced). Outcomes served: OUT-01, OUT-02, OUT-05, OUT-06, OUT-07.",
+    documentType: "QUESTION_BANK",
+    location:
+      "docs/external/ielts/ielts-speaking/Upload Docs/ielts-speaking-question-bank-part1.md",
+    sourceN: "Source 1",
+  },
+  // Source 2
+  {
+    slug: "cue-card-bank-v1",
+    name: "IELTS Speaking — Part 2 cue card bank",
+    description:
+      "Bank of Part 2 cue cards in the standard IELTS structure (single-sentence topic + three or four bullets + closing prompt). Cards tagged for difficulty and likely tense distribution. Outcomes served: OUT-04, OUT-08, OUT-09, OUT-10, OUT-11, OUT-12, OUT-18, OUT-22, OUT-23.",
+    documentType: "QUESTION_BANK",
+    location:
+      "docs/external/ielts/ielts-speaking/Upload Docs/ielts-speaking-question-bank-part2.md",
+    sourceN: "Source 2",
+  },
+  // Source 3
+  {
+    slug: "part3-theme-library-v1",
+    name: "IELTS Speaking — Part 3 theme library",
+    description:
+      "Bank of Part 3 themes (4–6 abstract follow-up questions each) across the seven Part 3 question types, designed to escalate concrete → abstract within a drill. Each theme tagged with the question types it covers. Outcomes served: OUT-03, OUT-13, OUT-14, OUT-15, OUT-16, OUT-17, OUT-19, OUT-20, OUT-21.",
+    documentType: "QUESTION_BANK",
+    location:
+      "docs/external/ielts/ielts-speaking/Upload Docs/ielts-speaking-question-bank-part3.md",
+    sourceN: "Source 3",
+  },
+  // Source 6
+  {
+    slug: "stall-scaffolds-monologue",
+    name: "IELTS Speaking — Part 2 stall scaffolds (monologue)",
+    description:
+      "Pool of non-disruptive stall-recovery prompts for Part 2 and the Part 2 long turn within Baseline and Mock Exam. Each scaffold tagged with stall shape (early-stall / deep-stall / bullet-stuck / blank-out / explicit-stop). Examiner-mode rules: ≤12 words, never re-frames the question or supplies cue card content.",
+    documentType: "REFERENCE",
+    location:
+      "docs/external/ielts/ielts-speaking/stall-scaffolds-monologue.md",
+    sourceN: "Source 6",
+  },
+  // Source 7
+  {
+    slug: "stall-scaffolds-discussion",
+    name: "IELTS Speaking — Part 3 stall scaffolds (discussion)",
+    description:
+      "Pool of reframe-not-resolve prompts for Part 3 (and the Part 3 phase of Baseline/Mock). Each scaffold tagged with stall shape (early-stall / deep-stall / i-dont-know / opinion-gap / abstraction-freeze / vocabulary-search / blank-out). Single-question stall pattern; tutor never supplies the answer.",
+    documentType: "REFERENCE",
+    location:
+      "docs/external/ielts/ielts-speaking/stall-scaffolds-discussion.md",
+    sourceN: "Source 7",
+  },
+  // Source 14
+  {
+    slug: "ielts-speaking-profile-fields",
+    name: "IELTS Speaking — profile fields (Baseline warm-up)",
+    description:
+      "Conversational profile fields woven into the Baseline warm-up. Each field carries a verbatim tutor prompt + coercion type (text / number / band). Extracted at end-of-session by `lib/pipeline/extract-profile-fields.ts` → `CallerAttribute` under `profile:*` namespace. Replaces the inline shortlist [reason, targetBand, timeline, selfLevel] which the runtime filter dropped pre-P3g.",
+    documentType: "REFERENCE",
+    location:
+      "docs/external/ielts/ielts-speaking/Upload Docs/ielts-speaking-profile-fields.md",
+    sourceN: "Source 14",
+  },
+];
+
+async function main(): Promise<void> {
+  console.log("\n→ Seeding IELTS ContentSource rows (#2206 D1)\n");
+
+  let created = 0;
+  let updated = 0;
+
+  for (const src of SOURCES) {
+    // Upsert by unique slug — idempotent.
+    const before = await prisma.contentSource.findUnique({
+      where: { slug: src.slug },
+      select: { id: true },
+    });
+
+    await prisma.contentSource.upsert({
+      where: { slug: src.slug },
+      create: {
+        slug: src.slug,
+        name: src.name,
+        description: src.description,
+        documentType: src.documentType,
+        trustLevel: "EXPERT_CURATED",
+        isActive: true,
+      },
+      // Don't clobber operator edits to name/description — only refresh on
+      // a future schema-evolving pass. Update is a no-op today.
+      update: {},
+    });
+
+    if (before) {
+      updated += 1;
+      console.log(
+        `  ↻ exists  ${src.slug.padEnd(36)} (${src.sourceN} — ${src.documentType})`,
+      );
+    } else {
+      created += 1;
+      console.log(
+        `  ✓ created ${src.slug.padEnd(36)} (${src.sourceN} — ${src.documentType})`,
+      );
+    }
+  }
+
+  console.log(
+    `\n✓ ContentSource seed complete: ${created} created, ${updated} already existed\n`,
+  );
+  console.log("Next step: run migrate-ielts-module-source-refs.ts to repoint");
+  console.log("baseline.cueCardPool + mock.cueCardPool from the never-authored");
+  console.log(
+    "`cue-card-bank-baseline-v1` / `mock-exam-scenario-pool-v1` slugs to the",
+  );
+  console.log("canonical `cue-card-bank-v1` (Source 9/10 BDD-sanctioned reuse).\n");
+}
+
+main()
+  .catch((e) => {
+    console.error("\n✗ seed-ielts-sources failed:", e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary

Two idempotent one-off scripts that close the live IELTS Sources gap surfaced by the BIG LATTICE MISS #2 audit (epic #2166). One concern: backfill the `ContentSource` catalogue the IELTS Speaking Practice course expects at runtime, then repoint two module source-refs from never-authored slugs to the canonical Part 2 cue-card bank (BDD-sanctioned reuse path).

- **D1 — `scripts/seed-ielts-sources.ts`** (+219): upserts 6 `ContentSource` rows for Sources 1/2/3/6/7/14 (question banks Part 1/2/3, stall scaffolds monologue + discussion, profile fields). Sourced from on-disk markdown under `docs/external/ielts/`. `trustLevel: EXPERT_CURATED`.
- **D2 — `scripts/migrate-ielts-module-source-refs.ts`** (+268): repoints `baseline.cueCardPool` and `mock.cueCardPool` on the IELTS Playbook from dangling Sources 4+5 (`cue-card-bank-baseline-v1`, `mock-exam-scenario-pool-v1`) to canonical `cue-card-bank-v1` (Source 2). Per BDD course-ref Sources 9+10 reuse path: "Mock Part 2 reuses the same 88 cue cards as Part 2 practice."

Both scripts:
- Idempotent — already-canonical config and existing rows produce a no-op log path.
- No schema change, no app code.
- Narrow scope: D2 touches only `name="IELTS Speaking Practice"` Playbook, only two specific module settings; rest of config spread-round-tripped unchanged.
- Unexpected values are left untouched + warned, NOT silently rewritten (per operator's "no fabrication / no fake-fill" rule).

## Operator action required after merge

```bash
# On hf-dev VM with DATABASE_URL pointing to target env:
cd ~/HF/apps/admin
npx tsx scripts/seed-ielts-sources.ts                  # D1
npx tsx scripts/migrate-ielts-module-source-refs.ts    # D2
```

Run on hf_sandbox AND hf_staging.

## Honest scope

- Sources 4+5 have no `location:` in the course-ref — D1 does NOT manufacture content. D2 reroutes runtime refs to the canonical Part 2 bank (Sources 9+10 BDD-sanctioned reuse).
- Source 8 (band descriptors) is wizard-derivation-only at projection time — no runtime slug to seed.
- This closes the runtime-data side of #2166; the structural Coverage gate (PR #2175) already covers fixture-walk drift.

## Verified by

- File existence on disk for every `location:` slug referenced in the IELTS course-ref [verified]:
  - `docs/external/ielts/ielts-speaking/Upload Docs/ielts-speaking-question-bank-part1.md` (Source 1)
  - `docs/external/ielts/ielts-speaking/Upload Docs/ielts-speaking-question-bank-part2.md` (Source 2)
  - `docs/external/ielts/ielts-speaking/Upload Docs/ielts-speaking-question-bank-part3.md` (Source 3)
  - `docs/external/ielts/ielts-speaking/stall-scaffolds-monologue.md` (Source 6)
  - `docs/external/ielts/ielts-speaking/stall-scaffolds-discussion.md` (Source 7)
  - `docs/external/ielts/ielts-speaking/Upload Docs/ielts-speaking-profile-fields.md` (Source 14)
- Lattice survey (per `.claude/rules/lattice-survey.md`):
  - Sibling writers on `ContentSource`: `prisma/seed-ielts-course.ts` (canonical seed) + wizard projection. Both upsert by slug; D1 uses the same shape (`upsert by unique slug, update: {}` — operator edits not clobbered).
  - Sibling writers on `Playbook.config`: wizard projection, `seed-ielts-course`, several admin routes. D2 narrows to one Playbook by name + only two specific settings; rest of config round-tripped via spread.
  - No cascade family on `ContentSource`; `Playbook.config` writes follow existing spread convention.
- Coverage gate `.claude/rules/source-ref-coverage.md` (PR #2175) covers fixture-walk drift; this PR closes the runtime side post-operator-run.

## Test plan

- [ ] D1 run on hf_sandbox — verify 6 ContentSource rows present (or already present, idempotent log path)
- [ ] D2 run on hf_sandbox — verify IELTS Playbook `baseline.cueCardPool` + `mock.cueCardPool` now point to `source:cue-card-bank-v1`
- [ ] Teaching tab Inspector for IELTS Speaking Practice resolves "Cue card pool" through to entries
- [ ] D1 + D2 re-run on hf_staging
- [ ] Re-run on either env produces no-op log path (idempotency)

Closes part of #2206. Related: #2166 (BIG LATTICE MISS #2 epic), #2167 (sister story — Sources backfill), PR #2175 (#2166 Coverage gate).