### PR TITLE
chore: Content tab chip counts + IELTS LO-ref demo backfill

### DIFF
--- a/apps/admin/components/content-tab/ContentDetailPanel.tsx
+++ b/apps/admin/components/content-tab/ContentDetailPanel.tsx
@@ -88,6 +88,32 @@ export function ContentDetailPanel({
     [selectedKind, groups.reflectionPrompts],
   );
 
+  // Per-chip counts for the active kind's filter axis. Client-derived from
+  // the groups already in props — no API change. (Pattern 1.)
+  const countsByModule = useMemo<Record<string, number>>(() => {
+    const acc: Record<string, number> = {};
+    if (selectedKind === "cueCards") {
+      for (const c of groups.cueCards) {
+        acc[c.module.moduleId] = (acc[c.module.moduleId] ?? 0) + 1;
+      }
+    } else if (selectedKind === "topicPrompts") {
+      for (const t of groups.topicPrompts) {
+        acc[t.module.moduleId] = (acc[t.module.moduleId] ?? 0) + 1;
+      }
+    }
+    return acc;
+  }, [selectedKind, groups.cueCards, groups.topicPrompts]);
+
+  const countsBySource = useMemo<Record<string, number>>(() => {
+    const acc: Record<string, number> = {};
+    if (selectedKind === "mcqs") {
+      for (const m of groups.mcqs) {
+        acc[m.source.sourceId] = (acc[m.source.sourceId] ?? 0) + 1;
+      }
+    }
+    return acc;
+  }, [selectedKind, groups.mcqs]);
+
   const isEmpty = (() => {
     switch (selectedKind) {
       case "mcqs":
@@ -137,6 +163,7 @@ export function ContentDetailPanel({
         >
           <FilterChip
             label="All modules"
+            count={totalForKind}
             isActive={moduleFilter == null}
             onClick={() => setModuleFilter(null)}
             testId="hf-content-chip-module-all"
@@ -145,6 +172,7 @@ export function ContentDetailPanel({
             <FilterChip
               key={m.moduleId}
               label={m.moduleLabel}
+              count={countsByModule[m.moduleId] ?? 0}
               isActive={moduleFilter === m.moduleId}
               onClick={() => setModuleFilter(m.moduleId)}
               testId={`hf-content-chip-module-${m.moduleId}`}
@@ -162,6 +190,7 @@ export function ContentDetailPanel({
         >
           <FilterChip
             label="All sources"
+            count={totalForKind}
             isActive={sourceFilter == null}
             onClick={() => setSourceFilter(null)}
             testId="hf-content-chip-source-all"
@@ -170,6 +199,7 @@ export function ContentDetailPanel({
             <FilterChip
               key={s.sourceId}
               label={s.sourceName}
+              count={countsBySource[s.sourceId] ?? 0}
               isActive={sourceFilter === s.sourceId}
               onClick={() => setSourceFilter(s.sourceId)}
               testId={`hf-content-chip-source-${s.sourceId}`}
@@ -220,21 +250,26 @@ export function ContentDetailPanel({
 
 interface FilterChipProps {
   label: string;
+  count: number;
   isActive: boolean;
   onClick: () => void;
   testId: string;
 }
 
-function FilterChip({ label, isActive, onClick, testId }: FilterChipProps) {
+function FilterChip({ label, count, isActive, onClick, testId }: FilterChipProps) {
+  const isEmpty = count === 0;
   return (
     <button
       type="button"
-      className={`hf-content-chip ${isActive ? "hf-content-chip-active" : ""}`}
+      className={`hf-content-chip ${isActive ? "hf-content-chip-active" : ""} ${isEmpty ? "hf-content-chip-empty" : ""}`}
       onClick={onClick}
       data-testid={testId}
       aria-pressed={isActive}
     >
-      {label}
+      <span className="hf-content-chip-label">{label}</span>
+      <span className="hf-content-chip-count" data-testid={`${testId}-count`}>
+        {count}
+      </span>
     </button>
   );
 }

--- a/apps/admin/components/content-tab/content-tab.css
+++ b/apps/admin/components/content-tab/content-tab.css
@@ -88,7 +88,8 @@
 .hf-content-chip {
   display: inline-flex;
   align-items: center;
-  padding: 4px 12px;
+  gap: 6px;
+  padding: 4px 8px 4px 12px;
   border-radius: 999px;
   background: var(--surface-primary);
   border: 1px solid var(--border-default);
@@ -105,6 +106,30 @@
   border-color: var(--accent-primary);
   color: var(--accent-primary);
   font-weight: 600;
+}
+.hf-content-chip-empty {
+  opacity: 0.55;
+}
+.hf-content-chip-label {
+  flex: 0 1 auto;
+}
+.hf-content-chip-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  padding: 0 6px;
+  height: 18px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface-secondary) 90%, transparent);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+.hf-content-chip-active .hf-content-chip-count {
+  background: color-mix(in srgb, var(--accent-primary) 18%, var(--surface-primary));
+  color: var(--accent-primary);
 }
 
 /* Item list — stacked cards. */

--- a/apps/admin/scripts/backfill-ielts-lo-refs.ts
+++ b/apps/admin/scripts/backfill-ielts-lo-refs.ts
@@ -1,0 +1,63 @@
+/**
+ * Demo-fix: backfill ContentAssertion.learningOutcomeRef for IELTS Speaking
+ * Practice by parsing the "(REF-NN)" token from assertion.
+ *
+ * Durable fix tracked separately — this is a one-shot for the Market Test
+ * demo so the Curriculum tab stops grouping every TP under "Unassigned".
+ */
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+const PLAYBOOK_ID = process.argv[2];
+if (!PLAYBOOK_ID) {
+  console.error("Usage: tsx backfill-ielts-lo-refs.ts <playbookId>");
+  process.exit(1);
+}
+
+const REF_RE = /\(([A-Z]+-\d+)\)/;
+
+async function main() {
+  const ps = await prisma.playbookSource.findMany({
+    where: { playbookId: PLAYBOOK_ID },
+    select: { sourceId: true },
+  });
+  const sourceIds = ps.map((p) => p.sourceId);
+  if (sourceIds.length === 0) {
+    console.log("[backfill] no PlaybookSource rows");
+    return;
+  }
+
+  const tps = await prisma.contentAssertion.findMany({
+    where: {
+      sourceId: { in: sourceIds },
+      learningOutcomeRef: null,
+    },
+    select: { id: true, assertion: true },
+  });
+  console.log(`[backfill] ${tps.length} TPs with null learningOutcomeRef`);
+
+  let updated = 0;
+  let skipped = 0;
+  for (const tp of tps) {
+    const m = tp.assertion?.match(REF_RE);
+    if (!m) {
+      skipped++;
+      continue;
+    }
+    const ref = m[1];
+    await prisma.contentAssertion.update({
+      where: { id: tp.id },
+      data: { learningOutcomeRef: ref },
+    });
+    updated++;
+    console.log(`  ${tp.id} -> ${ref}`);
+  }
+  console.log(`[backfill] updated=${updated} skipped=${skipped}`);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Summary

- **Pattern 1 — chip item counts** on the Content tab. Filter chips (Per Module / Per Source) now carry a small numeric badge showing items in that bucket. Empty chips dim. Client-derived from groups already in props; no API change.
- **IELTS LO-ref backfill script** — \`scripts/backfill-ielts-lo-refs.ts\`. Extracts the \"(REF-NN)\" token from \`ContentAssertion.assertion\` text into \`learningOutcomeRef\` for assertions that have one in the prose but a null column. Demo-only fix so the Curriculum tab on sandbox IELTS stops grouping all 10 TPs under \"Unassigned\".

## Verified by

- \`npx tsc --noEmit\` clean on touched files.
- Manual: counts derived purely from groups[selectedKind].
- The backfill script is idempotent (only touches rows with \`learningOutcomeRef\` NULL) and matches the convention already in repair-lo-linkage.

## Test plan

- [ ] On dev: open Course → Content tab → chips show counts; clicking a chip filters as before.
- [ ] On sandbox: run \`npx tsx scripts/backfill-ielts-lo-refs.ts 20b21160-0516-49c9-a8da-105772f41e64\` and confirm Curriculum tab on IELTS stops grouping under \"Unassigned\".
- [ ] Durable fix: file follow-on so the wizard's content extractor parses the ref token at write time, not via a post-hoc script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)