### PR TITLE
feat(teaching): #2243 — Teaching tab Inspector drops scope=module contracts (U? of #2185)

### DIFF
--- a/apps/admin/components/journey-tab/JourneyInspectorPanel.tsx
+++ b/apps/admin/components/journey-tab/JourneyInspectorPanel.tsx
@@ -63,6 +63,14 @@ interface JourneyInspectorPanelProps {
    *  visible feedback (instead of the React-skips-effect-on-unchanged
    *  value behaviour). */
   interactionTick?: number;
+  /** #2243 — when true, drop `scope: "module"` contracts from the
+   *  rendered bucket. The Teaching tab passes this because it has no
+   *  `arraySelector` context — without a selected module the array-
+   *  keyed read path resolves to null and the array editor renders
+   *  "No entries yet" against the operator's eyes. Per-module authoring
+   *  is the Modules tab's job; Teaching is a tuner per the
+   *  `project_modules_tab_tuner_not_authoring` memory. */
+  excludeModuleScope?: boolean;
 }
 
 function SettingsStack({
@@ -250,6 +258,7 @@ export function JourneyInspectorPanel({
   focusedSettingId,
   onRowFocus,
   interactionTick,
+  excludeModuleScope,
 }: JourneyInspectorPanelProps) {
   // Slice 6 grey-out epic — LH bucket click glow. When bucketId changes,
   // accent-pulse the whole Inspector area for ~900ms so the operator
@@ -320,7 +329,34 @@ export function JourneyInspectorPanel({
   }
 
   const { course, module: moduleScope } = splitBucketByScope(selectedBucketId);
-  const hasMixedScope = course.length > 0 && moduleScope.length > 0;
+  // #2243 — when `excludeModuleScope` is true (Teaching tab), drop the
+  // module subgroup entirely. Module-scoped contracts use array-keyed
+  // storagePaths that need a `selectedModuleId` arraySelector; Teaching
+  // tab can't supply one, so the read path resolves to null and the
+  // array-editor primitive renders "No entries yet" (the observed bug).
+  // Per-module authoring lives in the Modules tab; Teaching is a tuner.
+  const visibleAll = excludeModuleScope ? course : all;
+  const hasMixedScope =
+    !excludeModuleScope && course.length > 0 && moduleScope.length > 0;
+
+  // The visible course-only subset may now be empty even when the bucket
+  // has settings — surface the same empty state we use for empty buckets
+  // so the operator sees the bucket label and a hint instead of a blank
+  // pane.
+  if (visibleAll.length === 0) {
+    return (
+      <div
+        className="hf-journey-inspector-empty"
+        data-testid={`hf-journey-inspector-module-only-${selectedBucketId}`}
+      >
+        <div className="hf-section-title">{bucket.label}</div>
+        <p>
+          Per-module settings for this bucket are edited in the Modules tab.
+          Select a module there to edit its settings.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div
@@ -359,7 +395,7 @@ export function JourneyInspectorPanel({
         </>
       ) : (
         <SettingsStack
-          settings={all}
+          settings={visibleAll}
           focusedSettingId={focusedSettingId}
           onRowFocus={onRowFocus}
         />

--- a/apps/admin/components/teaching-tab/CourseTeachingTab.tsx
+++ b/apps/admin/components/teaching-tab/CourseTeachingTab.tsx
@@ -150,7 +150,16 @@ export function CourseTeachingTab({
               onJump={jumpToOwningTab}
             />
           ) : (
-            <JourneyInspectorPanel selectedBucketId={selectedId} />
+            /* #2243 — Teaching tab is a tuning surface, not a per-module
+             * authoring surface (per project_modules_tab_tuner_not_authoring
+             * memory). Module-scoped contracts use array-keyed storagePaths
+             * that need a `selectedModuleId` arraySelector; Teaching tab
+             * can't supply one. Drop the module-scope subset; operators
+             * edit per-module settings in the Modules tab. */
+            <JourneyInspectorPanel
+              selectedBucketId={selectedId}
+              excludeModuleScope
+            />
           )
         }
       />

--- a/apps/admin/tests/components/journey-tab/JourneyInspectorPanel.test.tsx
+++ b/apps/admin/tests/components/journey-tab/JourneyInspectorPanel.test.tsx
@@ -55,3 +55,90 @@ describe("JourneyInspectorPanel — Slice C (#1721) bucket-stacking", () => {
     expect(screen.getByText(/Sign-up & pre-call profile/)).toBeInTheDocument();
   });
 });
+
+// #2243 (U? of #2185) — Teaching tab is a tuner, not a per-module
+// authoring surface. When the consumer passes `excludeModuleScope`, the
+// Inspector drops every `scope: "module"` contract from the rendered
+// bucket. The Modules tab is the canonical editor for per-module
+// settings (it supplies the `selectedModuleId` arraySelector). Without
+// this filter, the Teaching tab Inspector renders empty
+// array-editors for module-scope contracts ("No entries yet") because
+// the array-keyed read path lands without a selector → the inline cue
+// cards on the Playbook are unreachable.
+describe("JourneyInspectorPanel — #2243 excludeModuleScope filter", () => {
+  it("drops module-scope rows from a mixed-scope bucket", () => {
+    // A_intake mixes course-scope and module-scope settings; the only
+    // module-scope contract is `moduleProfileFieldsToCapture`.
+    render(
+      <JourneySettingMutatorProvider courseId="c1" playbookConfig={{}}>
+        <JourneyInspectorPanel selectedBucketId="A_intake" excludeModuleScope />
+      </JourneySettingMutatorProvider>,
+    );
+    // Bucket renders as a single (course-only) stack — no `course` /
+    // `module` subgroups.
+    expect(
+      screen.queryByTestId("hf-journey-subgroup-module-A_intake"),
+    ).toBeNull();
+    expect(
+      screen.queryByTestId("hf-journey-subgroup-course-A_intake"),
+    ).toBeNull();
+    // The module-scope row does NOT mount.
+    expect(
+      screen.queryByTestId(
+        "hf-journey-inspector-row-moduleProfileFieldsToCapture",
+      ),
+    ).toBeNull();
+    // The bucket container itself IS present (course-scope settings render).
+    expect(
+      screen.getByTestId("hf-journey-inspector-bucket-A_intake"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the modules-tab hint when a bucket is all-module-scope", () => {
+    // E_learner_visual is the bucket the operator's screenshot showed —
+    // it carries `moduleCueCardPool`, `moduleTopicPool`, and
+    // `modulePinFocusArea`, all `scope: "module"`. With excludeModuleScope,
+    // the visible set is empty → the hint fires.
+    render(
+      <JourneySettingMutatorProvider courseId="c1" playbookConfig={{}}>
+        <JourneyInspectorPanel
+          selectedBucketId="E_learner_visual"
+          excludeModuleScope
+        />
+      </JourneySettingMutatorProvider>,
+    );
+    expect(
+      screen.getByTestId(
+        "hf-journey-inspector-module-only-E_learner_visual",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Modules tab/)).toBeInTheDocument();
+    // The would-be broken array-editor row never mounts.
+    expect(
+      screen.queryByTestId("hf-journey-inspector-row-moduleCueCardPool"),
+    ).toBeNull();
+  });
+
+  it("does NOT drop module-scope rows when excludeModuleScope is false (Journey tab default)", () => {
+    // Sanity — the default Inspector still renders the mixed-scope
+    // subgroups, so this regression is Teaching-tab-scoped.
+    render(
+      <JourneySettingMutatorProvider courseId="c1" playbookConfig={{}}>
+        <JourneyInspectorPanel selectedBucketId="A_intake" />
+      </JourneySettingMutatorProvider>,
+    );
+    // A_intake → mixed → renders both subgroups.
+    expect(
+      screen.getByTestId("hf-journey-subgroup-course-A_intake"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("hf-journey-subgroup-module-A_intake"),
+    ).toBeInTheDocument();
+    // The module-scope row mounts.
+    expect(
+      screen.getByTestId(
+        "hf-journey-inspector-row-moduleProfileFieldsToCapture",
+      ),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `excludeModuleScope?: boolean` prop to `JourneyInspectorPanel`. `CourseTeachingTab` passes it; module-scope contracts are filtered from the rendered bucket. Per-module authoring lives in the Modules tab.
- Before this change, the Teaching tab Inspector for the "What the learner sees during sessions" bucket (`E_learner_visual`) tried to render `moduleCueCardPool` / `moduleTopicPool` / `modulePinFocusArea` — all `scope: "module"` with `arrayKey: "id"` storagePaths. Without a `selectedModuleId` arraySelector context, the array-keyed read path resolved to null; `JourneyArrayEditor` rendered "No entries yet" against the operator's 88 inline cue cards on the IELTS Playbook (verified on hf_sandbox 2026-06-21).
- Buckets with mixed scope (e.g. `A_intake`) render only the course-scope subset on Teaching. All-module-scope buckets render a hint pointing the operator to the Modules tab.

## Operator complaint that drove this (verbatim, 2026-06-21)

> "2 Cue cards are there but not shown in Teaching tab"

## Verified by

- vitest `tests/components/journey-tab/JourneyInspectorPanel.test.tsx` — 6/6 (existing 3 + 3 new tests: mixed-scope filter, all-module-scope hint, default-still-renders-module regression pin)
- vitest `tests/components/teaching-tab/CourseTeachingTab.test.tsx` — green (no regression on existing behavior)
- vitest `tests/lib/journey/registry-consumer-coverage.test.ts` — green
- npx tsc --noEmit clean for touched files
- Live data probe on hf_sandbox: `Playbook.config.modules[i].settings.cueCardPool` is an inline `Array<{topic, bullets}>` of 88 cards for baseline + part2 + mock modules — Inspector behavior intentionally changed so module-scope contracts don't render without a selector.
- Lattice survey (per `.claude/rules/lattice-survey.md`): UI-only filter; no DB mutation; sibling readers Modules tab + Journey tab unchanged; matches "Teaching = tuner, Modules = authoring" framing (memory `project_modules_tab_tuner_not_authoring`); Coverage gates mode-ui-coverage / shell-coverage / admin-tab-coverage ratchets unaffected.

## Pre-existing main red (not introduced by this PR)

`tests/lib/journey/cascade-classification-coverage.test.ts` has 3 ratchet failures — the rule file itself documents that this is pre-A1b state on main (`bb61e425 = feat/2228-a1b-teachingstyle-cascade-families` not yet merged). KB Integrity / Lint / Unit Tests failures match recent sibling PRs (#2227 / #2229 / #2240).

## Out of scope (deferred to follow-on)

- Same fix on **Journey tab + Scoring tab** — they're structurally identical (both mount `JourneyInspectorPanel` without an arraySelector). Out of scope here because operator screenshot was Teaching-specific; a follow-on can pass `excludeModuleScope` on those tabs OR add an `arraySelector` source on them.
- **Discoverability chip** pointing at the Modules tab from the Inspector hint — current hint is text-only.

Closes #2243. Umbrella #2185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)