### PR TITLE
feat(journey,scoring): #2243 follow-on — same excludeModuleScope filter on Journey + Scoring tabs

### DIFF
--- a/apps/admin/components/journey-tab/CourseJourneyTab.tsx
+++ b/apps/admin/components/journey-tab/CourseJourneyTab.tsx
@@ -354,11 +354,19 @@ export function CourseJourneyTab({
               onJump={handleJump}
             />
           ) : (
+            /* #2243 — Journey tab is a journey-rail tuner, not a
+             * per-module authoring surface. The "This module" subgroup
+             * the Inspector renders for mixed-scope buckets was
+             * designed around a module-selector this tab never supplied
+             * — module-scope rows resolved to null and rendered "No
+             * entries yet" array editors. Per-module authoring lives in
+             * the Modules tab. */
             <JourneyInspectorPanel
               selectedBucketId={selection.bucketId}
               focusedSettingId={selection.focusedSettingId}
               onRowFocus={handleInspectorRowFocus}
               interactionTick={interactionTick}
+              excludeModuleScope
             />
           )}
         </aside>

--- a/apps/admin/components/scoring-tab/CourseScoringTab.tsx
+++ b/apps/admin/components/scoring-tab/CourseScoringTab.tsx
@@ -144,7 +144,16 @@ export function CourseScoringTab({
               onJump={jumpToOwningTab}
             />
           ) : (
-            <JourneyInspectorPanel selectedBucketId={selectedId} />
+            /* #2243 — Scoring tab is a tuning surface, not a per-module
+             * authoring surface. Module-scoped contracts need a
+             * `selectedModuleId` arraySelector this tab can't supply;
+             * without it, the array-keyed read path resolves to null and
+             * array editors render "No entries yet". Operators edit
+             * per-module settings in the Modules tab. */
+            <JourneyInspectorPanel
+              selectedBucketId={selectedId}
+              excludeModuleScope
+            />
           )
         }
       />

--- a/apps/admin/tests/components/journey-tab/JourneyInspectorPanel.test.tsx
+++ b/apps/admin/tests/components/journey-tab/JourneyInspectorPanel.test.tsx
@@ -119,9 +119,13 @@ describe("JourneyInspectorPanel — #2243 excludeModuleScope filter", () => {
     ).toBeNull();
   });
 
-  it("does NOT drop module-scope rows when excludeModuleScope is false (Journey tab default)", () => {
-    // Sanity — the default Inspector still renders the mixed-scope
-    // subgroups, so this regression is Teaching-tab-scoped.
+  it("does NOT drop module-scope rows when excludeModuleScope is false (default contract)", () => {
+    // Contract pin — the default still renders the mixed-scope
+    // subgroups so any future consumer that DOES supply an
+    // arraySelector (e.g. wizard / Modules-tab-equivalent) continues to
+    // get the full bucket. Today Teaching + Journey + Scoring all
+    // explicitly pass `excludeModuleScope`; the default path is
+    // exercised by no production consumer but the contract is pinned.
     render(
       <JourneySettingMutatorProvider courseId="c1" playbookConfig={{}}>
         <JourneyInspectorPanel selectedBucketId="A_intake" />
@@ -141,4 +145,38 @@ describe("JourneyInspectorPanel — #2243 excludeModuleScope filter", () => {
       ),
     ).toBeInTheDocument();
   });
+});
+
+// #2243 follow-on — pin that all three tab consumers (Teaching, Journey,
+// Scoring) thread `excludeModuleScope` through to JourneyInspectorPanel.
+// Source-level grep is the durable structural pin: a future refactor
+// that silently drops the prop on any of these mount points fails CI.
+// ModuleInspectorPanel is excluded — it supplies its own
+// selectedModuleId/arraySelector context and DOES render module-scope.
+describe("JourneyInspectorPanel consumers — #2243 excludeModuleScope wiring", () => {
+  const fs = require("node:fs") as typeof import("node:fs");
+  const path = require("node:path") as typeof import("node:path");
+
+  const CONSUMERS = [
+    "components/teaching-tab/CourseTeachingTab.tsx",
+    "components/journey-tab/CourseJourneyTab.tsx",
+    "components/scoring-tab/CourseScoringTab.tsx",
+  ];
+
+  for (const relPath of CONSUMERS) {
+    it(`${relPath} mounts <JourneyInspectorPanel> with excludeModuleScope`, () => {
+      const absPath = path.resolve(__dirname, "../../..", relPath);
+      const source = fs.readFileSync(absPath, "utf8");
+      // The mount must reference both the component and the prop.
+      expect(source).toContain("JourneyInspectorPanel");
+      expect(source).toContain("excludeModuleScope");
+      // Belt-and-braces — the prop is between the component name and
+      // the JSX close. A future refactor that imports the component
+      // but accidentally renames or comments out the prop fails this
+      // pin.
+      const mountRegex =
+        /<JourneyInspectorPanel\b[\s\S]*?excludeModuleScope[\s\S]*?\/>/;
+      expect(source).toMatch(mountRegex);
+    });
+  }
 });


### PR DESCRIPTION
## Summary

Extends PR #2244's `excludeModuleScope` filter to the two remaining sibling tabs with the same structural bug:

- **`CourseJourneyTab`** — mounts `<JourneyInspectorPanel>` without a `selectedModuleId` arraySelector context. The "This module" subgroup design (`JourneyInspectorPanel.tsx:14-18`) assumed a future module-selector that never shipped — module-scope contracts have been resolving to `null` and rendering "No entries yet" since Slice C (#1721).
- **`CourseScoringTab`** — same shape; same fix.

Modules tab is unaffected (`ModuleInspectorPanel` supplies its own arraySelector context and DOES render module-scope rows).

## Verified by

- vitest `tests/components/journey-tab/JourneyInspectorPanel.test.tsx` — 9/9 (existing 3 + 3 behavior pins from #2244 + 3 new source-grep consumer-wiring pins)
- vitest `tests/components/{teaching-tab,journey-tab,scoring-tab}` — 68/68 green
- `npx tsc --noEmit` clean for touched files
- Lattice survey (per `.claude/rules/lattice-survey.md`): UI-only filter; no DB mutation; sibling readers Teaching tab (already wired via #2244) and Modules tab (correct path) unchanged; matches "Teaching + Journey + Scoring = tuners, Modules = authoring" framing.
- Source-grep durable pin: the new vitest at the bottom of `JourneyInspectorPanel.test.tsx` asserts all three CourseXxxTab files reference `excludeModuleScope`. A future refactor that silently drops the prop on any consumer fails CI.

## What changed (3 files, +59 / −4)

| File | Change |
|---|---|
| `apps/admin/components/journey-tab/CourseJourneyTab.tsx` | passes `excludeModuleScope` on the Inspector mount with justifying comment |
| `apps/admin/components/scoring-tab/CourseScoringTab.tsx` | same |
| `apps/admin/tests/components/journey-tab/JourneyInspectorPanel.test.tsx` | +3 source-grep consumer-wiring pins (Teaching + Journey + Scoring) |

## Pre-existing main red (not introduced by this PR)

Same as #2244: `cascade-classification-coverage.test.ts` ratchets are pre-A1b state on main (`feat/2228-a1b-teachingstyle-cascade-families` not yet merged). KB Integrity / Lint failures match recent sibling PRs.

Closes the follow-on noted in PR #2244 body. Closes part of #2185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)