### PR TITLE
fix(docker): install python3/make/g++ in deps stage — unblocks Cloud Build

### DIFF
--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -31,6 +31,9 @@ COPY package.json package-lock.json ./
 # latent; #1012 added 13 file: references and #1013 resynced the lock, which
 # is when Cloud Build started failing with ENOENT on the tarballs.
 COPY vendor ./vendor
+# Toolchain for native deps (e.g. better-sqlite3 via promptfoo devDep) — node-gyp needs Python + C++ on Alpine.
+# Lives in deps stage only; runner image copies only node_modules + .next from builder, so the toolchain doesn't ship to prod.
+RUN apk add --no-cache python3 make g++
 RUN npm ci
 # Prisma generate happens once here so all downstream targets share the cached client.
 COPY prisma ./prisma


### PR DESCRIPTION
## Summary

One-line edit to `apps/admin/Dockerfile`: install `python3 make g++` in the `deps` stage so `npm ci` can compile `better-sqlite3`'s native binding.

Unblocks Cloud Build `dbdb7064-9041-41dd-ac8a-7bd40c9af5d4` (and every subsequent run) at the `migrate` step.

## Why

- `promptfoo@^0.120.19` (correctly placed in `devDependencies`) brings `better-sqlite3@^12.6.2` as a **hard transitive** — no longer optional as of v12.
- `Dockerfile:24` uses `FROM node:20-alpine` (no Python / make / g++ in the base image).
- `Dockerfile:34` runs bare `RUN npm ci`. Can't `--omit=dev` here because the `builder` stage needs devDeps for `next build`.
- → `node-gyp` fails to compile `better-sqlite3` → `npm ci` exits 1 → build dies before reaching downstream targets.

Operator earlier disproved an alternative "move promptfoo to devDeps" path (it's already there). Toolchain in deps stage is the structural fix.

## Verified by

**Lattice survey** per [`.claude/rules/lattice-survey.md`](.claude/rules/lattice-survey.md):

- **Sibling-writer drift**: Only one Dockerfile in `apps/admin/`. `apps/foh/Dockerfile` has same shape but isn't a sibling writer to this surface; if/when promptfoo lands there, same fix will apply.
- **Default-deny gates**: No ESLint rule on Dockerfile surface. CI-docs-parity rule covered via `## CI Docs Skip` below.
- **Cascade respect**: N/A — Dockerfile build args have no cascade resolver.
- **Convention conflict**: Alpine + native deps + `apk add python3 make g++` is the canonical node-gyp pattern. No competing convention.

**Runner-stage size impact: UNCHANGED.** Confirmed by reading the runner target (`Dockerfile:58-70`):
- Runner does `COPY --from=builder /app/.next/standalone ./` + `.next/static` + `public`.
- Runner does NOT `COPY --from=deps /` or do its own `apk add`.
- The Next.js standalone output bundles its minimal `node_modules` subset into `.next/standalone/node_modules` — no system-level `/usr/bin/python3` is included.
- `seed` (line 79-88) and `migrate` (line 95-99) do `COPY --from=deps /app/node_modules ./node_modules` — file copy of a specific path. System packages from `apk add` live in `/usr/bin` + `/usr/lib`, not `/app/node_modules`, so they don't ship to those images either.

**Cloud Build configs** (`cloudbuild-all.yaml`, `cloudbuild-migrate.yaml`, `cloudbuild-runner.yaml`, `cloudbuild-seed.yaml`) all reference `--dockerfile=Dockerfile` + `--target=<stage>`. The shared `deps` stage feeds all three downstream targets via Kaniko cache — one warmup, three consumers. Unchanged by this edit.

**Git diff** — exactly 1 functional line + 2 comment lines added; no other code touched:

```diff
 COPY vendor ./vendor
+# Toolchain for native deps (e.g. better-sqlite3 via promptfoo devDep) — node-gyp needs Python + C++ on Alpine.
+# Lives in deps stage only; runner image copies only node_modules + .next from builder, so the toolchain doesn't ship to prod.
+RUN apk add --no-cache python3 make g++
 RUN npm ci
```

## CI Docs Skip

tooling fix — Dockerfile build-arg restoring node-gyp toolchain; no operator-runbook content changes

## Test plan

- [ ] After merge, re-trigger Cloud Build: `gcloud builds submit --config cloudbuild-all.yaml --substitutions=_TAG=dev,_APP_ENV=DEV .` (from `apps/admin/`)
- [ ] Confirm the `migrate` step completes (cache miss expected on this build since deps layer SHA changes; warm cache returns on subsequent builds)
- [ ] Confirm `seed` + `runner` steps run in parallel after `migrate` and complete successfully
- [ ] Confirm `hf-admin-dev` Cloud Run service can be deployed from the new image tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)