### PR TITLE
chore(journey,modules): drop dead useCrossTabHint + add cross-tab palette guard

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/page.tsx
+++ b/apps/admin/app/x/courses/[courseId]/page.tsx
@@ -1835,7 +1835,6 @@ export default function CourseDetailPage() {
               ? 'structured'
               : 'continuous'
           }
-          onTabSwitch={handleCrossTabSwitch}
           playbookConfig={detail?.config as Record<string, unknown> | null | undefined}
         />
       )}

--- a/apps/admin/components/journey-tab/CourseJourneyTab.tsx
+++ b/apps/admin/components/journey-tab/CourseJourneyTab.tsx
@@ -217,17 +217,29 @@ export function CourseJourneyTab({
   // Voice settings (registered under N_voice via Slice C follow-on) are
   // found in VOICE_SETTINGS_BY_ID — the same bucket select navigates to
   // them within the Journey tab; their Settings-tab home is preserved.
+  //
+  // Cross-tab guard: when the picked setting's owning bucket lives on a
+  // sibling tab (Teaching / Scoring / Voice), route through
+  // `onTabSwitch` so the destination tab seeds its Inspector with the
+  // bucket — instead of silently writing an out-of-scope `j_bucket=`
+  // that leaves the Journey LH with an unreachable selection.
   const handlePaletteSelect = useCallback(
     (settingId: string) => {
       const owner =
         JOURNEY_SETTINGS_BY_ID[settingId] ?? VOICE_SETTINGS_BY_ID[settingId];
-      if (owner?.menuGroupKey) {
-        selection.setBucketId(owner.menuGroupKey);
+      if (!owner?.menuGroupKey) return;
+      const owningTab = bucketToTab(owner.menuGroupKey);
+      if (owningTab && owningTab !== "journey") {
+        onTabSwitch?.(owningTab, { selectedBucket: owner.menuGroupKey });
         setPickStripSection(null);
         setCrossTabHint(null);
+        return;
       }
+      selection.setBucketId(owner.menuGroupKey);
+      setPickStripSection(null);
+      setCrossTabHint(null);
     },
-    [selection],
+    [selection, onTabSwitch],
   );
 
   // LH bucket click — clear pick-strip + hint in the same step.

--- a/apps/admin/components/modules-tab/CourseModulesTab.tsx
+++ b/apps/admin/components/modules-tab/CourseModulesTab.tsx
@@ -19,21 +19,16 @@
  * modules — they pull from a topic pool. We render an explanation
  * rather than an empty picker.
  *
- * P3b (#1850 cross-tab hints): the Modules tab has zero entries in
- * `BUCKETS_BY_TAB.modules` — every Preview bubble click resolves to a
- * bucket owned by another tab. The Inspector renders a
- * `<CrossTabHintCard>` in place of the per-module panel whenever the
- * hint state is set; clearing the hint (jumping or selecting a module)
- * restores the per-module Inspector.
+ * No cross-tab hint surface: `BUCKETS_BY_TAB.modules = []`, so no
+ * Preview bubble can ever resolve to a Modules-owned bucket. The
+ * Modules tab no longer mounts a PreviewLens (PR #2120/#2121 replaced
+ * the canvas Preview with the SIM-shell `ModulesPreviewLens`), so the
+ * `useCrossTabHint` branch never fired and has been removed.
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { CrossTabHintCard } from "@/components/shared/CrossTabHintCard";
 import { DesignerShell } from "@/components/shared/designer-shell/DesignerShell";
-import type { CourseDetailTabId } from "@/lib/journey/buckets-by-tab";
-import type { JourneyMenuBucketId } from "@/lib/journey/setting-contracts";
-import { useCrossTabHint } from "@/lib/journey/use-cross-tab-hint";
 import type { PlaybookConfig } from "@/lib/types/json-fields";
 
 import { ModuleEditor, type ModuleEditorRow } from "./ModuleEditor";
@@ -48,11 +43,6 @@ interface CourseModulesTabProps {
   /** From `PlaybookConfig.lessonPlanMode`. `"continuous"` (or missing) →
    *  modules don't apply; we show the empty state instead of the picker. */
   courseStyle?: string;
-  /** Parent-provided tab switcher. Phase P3b. */
-  onTabSwitch?: (
-    tabId: CourseDetailTabId,
-    options: { selectedBucket: JourneyMenuBucketId },
-  ) => void;
   /** Full PlaybookConfig — threaded through to ModuleInspectorPanel so
    *  it can derive the editor-facing CourseShape (P3d, #1850). Optional;
    *  legacy callers without it fall back to the binary courseStyle and
@@ -63,17 +53,10 @@ interface CourseModulesTabProps {
 export function CourseModulesTab({
   courseId,
   courseStyle,
-  onTabSwitch,
   playbookConfig,
 }: CourseModulesTabProps) {
   const [selectedModuleId, setSelectedModuleId] = useState<string | null>(null);
   const [modules, setModules] = useState<ModuleRow[]>([]);
-  const { crossTabHint, jumpToOwningTab } =
-    useCrossTabHint({
-      currentTab: "modules",
-      selectedBucketParam: null, // modules tab doesn't seed from URL
-      onTabSwitch: onTabSwitch ?? (() => {}),
-    });
 
   // Mirror the LH picker fetch so the Inspector can read each module's
   // `settings` sub-object without a second round-trip. The LH picker
@@ -148,11 +131,9 @@ export function CourseModulesTab({
   // Bi-pane shape: LH module picker + canvas as the editor. The Inspector
   // column from the prior tri-pane is folded into the canvas as the HOW
   // card so the operator works in one wide column rather than squeezing
-  // G8 fields into a 360px sticky panel. The Preview pane is removed
-  // because the Modules tab tunes per-module behaviour — the course-wide
-  // Preview never reflected the LH selection. Cross-tab hints retain the
-  // RH Inspector slot when a Preview-lens bubble click in a sibling tab
-  // surfaces here.
+  // G8 fields into a 360px sticky panel. The RH pane mounts the
+  // ModulesPreviewLens (SIM-shell preview, #2206 U5 of #2185) so the
+  // operator can validate per-module behaviour against the learner view.
   return (
     <DesignerShell
       nav={
@@ -180,22 +161,10 @@ export function CourseModulesTab({
         />
       }
       inspector={
-        crossTabHint ? (
-          <CrossTabHintCard
-            bucketLabel={crossTabHint.bucketLabel}
-            owningTabLabel={crossTabHint.owningTabLabel}
-            onJump={jumpToOwningTab}
-          />
-        ) : (
-          // #2206 U5 of #2185 — SIM-shell preview on RHS pane.
-          // Mounts the LearnerShell stub matching the selected module's
-          // resolved shellKind so the operator can validate the per-
-          // module behaviour against what the learner sees.
-          <ModulesPreviewLens
-            courseId={courseId}
-            selectedModule={selectedModule}
-          />
-        )
+        <ModulesPreviewLens
+          courseId={courseId}
+          selectedModule={selectedModule}
+        />
       }
     />
   );

--- a/docs/testing/tab-jump-tracer.js
+++ b/docs/testing/tab-jump-tracer.js
@@ -1,0 +1,85 @@
+(() => {
+  if (window.__T) { console.warn("[T] already armed — call __T.clear() to reset"); return; }
+  const L = [];
+  const t0 = Date.now();
+  const p = (m, d) => {
+    const e = {
+      dt: Date.now() - t0,
+      m,
+      d,
+      s: (new Error()).stack.split("\n").slice(2, 9).join(" | "),
+    };
+    L.push(e);
+    console.log("[T+" + e.dt + "ms]", m, d);
+  };
+
+  const origPush = history.pushState;
+  const origReplace = history.replaceState;
+  history.pushState = function () {
+    p("history.pushState", { url: arguments[2] });
+    return origPush.apply(this, arguments);
+  };
+  history.replaceState = function () {
+    p("history.replaceState", { url: arguments[2] });
+    return origReplace.apply(this, arguments);
+  };
+
+  addEventListener("popstate", () => p("popstate", { url: location.search }), true);
+
+  const origDispatch = EventTarget.prototype.dispatchEvent;
+  EventTarget.prototype.dispatchEvent = function (ev) {
+    if (ev && typeof ev.type === "string" && ev.type.indexOf("hf:") === 0) {
+      p("dispatchEvent " + ev.type, ev.detail);
+    }
+    return origDispatch.call(this, ev);
+  };
+
+  addEventListener("click", (e) => {
+    let n = e.target;
+    const path = [];
+    while (n && path.length < 5) {
+      const tid = n.dataset && n.dataset.testid ? "[" + n.dataset.testid + "]" : "";
+      path.push((n.tagName || "") + tid);
+      n = n.parentElement;
+    }
+    p("click", {
+      path: path.join(" > "),
+      text: (e.target.textContent || "").trim().slice(0, 60),
+    });
+  }, true);
+
+  const attachObs = () => {
+    const btn = document.querySelector('button[draggable="true"]');
+    const strip = btn ? btn.parentElement : null;
+    if (!strip) {
+      setTimeout(attachObs, 500);
+      return;
+    }
+    new MutationObserver((ms) => {
+      for (const m of ms) {
+        if (m.type === "attributes") {
+          p("tab DOM mut", {
+            tab: (m.target.textContent || "").trim().slice(0, 40),
+            border: m.target.style && m.target.style.borderBottom,
+          });
+        }
+      }
+    }).observe(strip, {
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["style", "aria-selected"],
+    });
+    p("observer attached", { tabs: strip.children.length });
+  };
+  attachObs();
+
+  window.__T = {
+    L,
+    c: () => navigator.clipboard.writeText("```\n" + JSON.stringify(L, null, 2) + "\n```")
+      .then(() => console.log("[T] copied", L.length, "entries to clipboard — paste back to Claude")),
+    clear: () => { L.length = 0; console.log("[T] cleared"); },
+  };
+
+  console.log("%c[T] armed — reproduce the bug, then run __T.c()",
+    "background:#1F1B4A;color:#F5B856;padding:6px 10px;border-radius:4px;font-weight:bold;");
+})();


### PR DESCRIPTION
## Summary
- Strips an unreachable `useCrossTabHint` branch from `CourseModulesTab` — the Modules tab has zero entries in `BUCKETS_BY_TAB` and no longer mounts a PreviewLens (post-#2120/#2121), so the hook's `handlePreviewSelect` was never invoked and `crossTabHint` was always null. Also drops the now-unused `onTabSwitch` prop.
- Adds a cross-tab guard to `CourseJourneyTab.handlePaletteSelect`: when Cmd+K picks a setting whose owning bucket lives on Teaching / Scoring / Voice, route through `onTabSwitch` instead of silently writing an out-of-scope ``j_bucket=`` that left the Journey LH with a selection the Inspector couldn't render.
- Adds ``docs/testing/tab-jump-tracer.js`` — a self-contained DevTools console tracer (history hooks + click-path log + tab-strip MutationObserver) for future tab-nav bug investigations.

## Context
Surfaced during a Journey→Modules tab-jump investigation today. The reported jump (operator clicks "Call 1 — opening & assessment shape" → preview spins → tab flips to Modules, every time) could not be reproduced from static analysis — most likely a stale Next.js dev-server HMR artifact that cleared after restart. These three cleanups are unrelated to that symptom but are real producer-only / out-of-scope issues found while surveying the same code surface.

## Verified by
- ``npx tsc --noEmit`` — 0 new errors in the touched files (the two pre-existing errors at ``page.tsx:1421`` and ``page.tsx:1769`` exist identically on ``main``).
- ``npx eslint`` on all three modified files — 0 new errors, 0 new warnings (the one pre-existing warning in ``CourseJourneyTab.tsx:303`` is on ``handlePreviewSectionSelect`` and exists identically on ``main``).
- Lattice survey done on the journey-tab / modules-tab nav surface (mapped every ``setActiveTab`` / ``handleCrossTabSwitch`` / ``hf:chord:tab:*`` writer; cross-checked sibling-writer + cascade-respect + default-deny + convention-conflict shapes). No new producer↔consumer pair added; this PR removes one structurally-unreachable consumer.

## Test plan
- [ ] Cmd+K in Journey tab → search a Teaching / Scoring setting → confirm the active tab actually switches to Teaching / Scoring with the right bucket seeded (previously silently failed).
- [ ] Open Modules tab on any course → confirm the bi-pane editor renders correctly (no UI regression from the inspector branch simplification).
- [ ] Confirm no PR-time CI red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)