### PR TITLE
feat(prompt): UX-A — cue card + session focus directives say learner can see them on screen

### DIFF
--- a/apps/admin/evals/tutor/ux-a-pinned-visual-prompt-clarity.yaml
+++ b/apps/admin/evals/tutor/ux-a-pinned-visual-prompt-clarity.yaml
@@ -1,0 +1,130 @@
+description: "UX-A — pinned-visual prompt clarity (cue card + session focus visible on learner's screen)"
+
+# Run with: npx promptfoo eval -c evals/tutor/ux-a-pinned-visual-prompt-clarity.yaml --no-cache
+#
+# Closes findings 1 + 2 of the 2026-06-22 Learner SIM UX audit. Two prompt
+# directives now tell the AI that the learner can see the pinned content
+# on their screen:
+#
+#   1. CUE CARD directive (resolveModuleCueCard in
+#      lib/prompt/composition/transforms/instructions.ts) prefixed with
+#      "CUE CARD — visible on the learner's screen right now."
+#   2. SESSION FOCUS directive (resolveSessionFocus in
+#      lib/prompt/composition/transforms/session-focus.ts) prefixed with
+#      "Today's session focus (pinned on the learner's screen): ..."
+#
+# These evals pin behavioural intent against the upgraded prompts:
+#   - Cue card: AI references the card as a SHARED visual ("looking at
+#     your card…"), DOES NOT read the topic + bullets verbatim like a
+#     game-show host.
+#   - Session focus: AI references the pinned focus as a shared anchor
+#     ("the technique we're focusing on today"), DOES NOT re-explain that
+#     a focus exists.
+#
+# Source files:
+#   - apps/admin/lib/prompt/composition/transforms/instructions.ts
+#   - apps/admin/lib/prompt/composition/transforms/session-focus.ts
+# Companion vitests:
+#   - tests/lib/prompt/composition/transforms/instructions.test.ts (UX-A)
+#   - tests/lib/prompt/composition/transforms/session-focus.test.ts (UX-A)
+
+prompts:
+  - id: ux-a-pinned-visual-prompt
+    label: "Tutor opening — pinned cue card + session focus on screen"
+    raw: |
+      You are an IELTS Speaking tutor running a 1-to-1 voice session. The
+      learner has their screen in front of them showing pinned content.
+
+      ## How you communicate
+      - Warm, brief, conversational. 1-2 sentences for the opening.
+      - The learner can SEE pinned content on their screen — reference it
+        as a shared visual, do NOT narrate it back verbatim.
+      - NEVER expose internal field names. NEVER read lists verbatim.
+
+      ## Composed directives
+
+      {{cueCardDirective}}
+
+      {{sessionFocusDirective}}
+
+      ---
+      The learner has just joined. Speak first — your opening line plus
+      your first question to them.
+
+providers:
+  - id: anthropic:messages:claude-sonnet-4-6
+    config:
+      max_tokens: 400
+
+defaultTest:
+  vars: {}
+
+tests:
+
+  # ── CUE CARD — Findings 1 ──
+
+  - description: "UX-A.1 — Cue card: AI references it as a shared visual, does not narrate it back"
+    vars:
+      cueCardDirective: |
+        CUE CARD — visible on the learner's screen right now. Keep this topic central:
+        Topic: A book you enjoyed reading
+        Bullets:
+          - what it was about
+          - who wrote it
+          - why you enjoyed it
+      sessionFocusDirective: ""
+    assert:
+      - type: llm-rubric
+        value: "The AI references the cue card as a SHARED visual — e.g. 'looking at your card', 'on the card you can see', 'your card has…', or simply asks the learner to engage with the card. It does NOT read the cue card verbatim as if announcing it on a game show (e.g. 'Today your cue card is: A book you enjoyed reading. The bullets are: what it was about, who wrote it, why you enjoyed it'). It does NOT enumerate ALL three bullets in a list-dump."
+      - type: not-icontains
+        value: "Today your cue card is"
+      - type: not-icontains
+        value: "the bullets are"
+
+  - description: "UX-A.2 — Cue card: AI may name the topic to anchor, but does not robotically enumerate bullets"
+    vars:
+      cueCardDirective: |
+        CUE CARD — visible on the learner's screen right now. Keep this topic central:
+        Topic: A time you felt proud
+        Bullets:
+          - what happened
+          - who was there
+          - why it mattered
+      sessionFocusDirective: ""
+    assert:
+      - type: llm-rubric
+        value: "The opening is brief and warm. The AI does NOT read out all three bullets in a row like a list-dump (e.g. 'what happened, who was there, and why it mattered'). It treats the cue card as something the learner is looking at, not something the AI has to recite. Mentioning the topic name 'a time you felt proud' is fine; reciting the bullets is not."
+      - type: not-icontains
+        value: "what happened, who was there"
+
+  # ── SESSION FOCUS — Finding 2 ──
+
+  - description: "UX-A.3 — Session focus: AI references the pinned focus as a shared anchor, does not re-explain its existence"
+    vars:
+      cueCardDirective: ""
+      sessionFocusDirective: |
+        Today's session focus (pinned on the learner's screen): giving reasons. Steer your questions and feedback toward developing this technique throughout the session. Use the focus as the through-line — when the learner gives a brief answer, prompt them to apply giving reasons explicitly; when they do it well, name the technique back to them so they recognise the move.
+    assert:
+      - type: llm-rubric
+        value: "The AI references the focus 'giving reasons' as a SHARED anchor the learner can see — e.g. 'the technique we're focusing on today', 'as you can see at the top of your screen', 'today's focus on giving reasons', or simply incorporates it naturally into the first question. It does NOT re-explain that a focus exists from scratch (e.g. 'I want you to focus today on a technique called giving reasons — this means…'). The focus is the through-line, not a new concept being introduced."
+      - type: not-icontains
+        value: "I want you to focus today on a technique called"
+
+  - description: "UX-A.4 — Session focus: combined with cue card — AI uses both as visual anchors, asks first question quickly"
+    vars:
+      cueCardDirective: |
+        CUE CARD — visible on the learner's screen right now. Keep this topic central:
+        Topic: A skill you learned
+        Bullets:
+          - what skill
+          - how you learned it
+          - how you use it now
+      sessionFocusDirective: |
+        Today's session focus (pinned on the learner's screen): expanding an answer. Steer your questions and feedback toward developing this technique throughout the session. Use the focus as the through-line — when the learner gives a brief answer, prompt them to apply expanding an answer explicitly; when they do it well, name the technique back to them so they recognise the move.
+    assert:
+      - type: llm-rubric
+        value: "The AI references BOTH the cue card AND the session focus as things the learner can see, then moves to a first question that opens the practice. It does NOT enumerate the bullets verbatim, does NOT explain that there is a focus, and does NOT recite the topic + focus like a game-show host opening."
+      - type: not-icontains
+        value: "Today your cue card is"
+      - type: not-icontains
+        value: "I want you to focus today on a technique called"

--- a/apps/admin/lib/prompt/composition/transforms/instructions.ts
+++ b/apps/admin/lib/prompt/composition/transforms/instructions.ts
@@ -621,7 +621,7 @@ function resolveModuleQuestionTarget(
  * pick to `Session.metadata.pinnedCard` so the UI shows the same card
  * the prompt was composed with.
  */
-function resolveModuleCueCard(
+export function resolveModuleCueCard(
   config: PlaybookConfig,
   sharedState: AssembledContext["sharedState"],
 ): {
@@ -656,7 +656,12 @@ function resolveModuleCueCard(
   if (bullets.length === 0) return null;
 
   const bulletsList = bullets.map((b) => `  - ${b}`).join("\n");
-  const directive = `CUE CARD for this module — keep this topic central:\nTopic: ${picked.topic}\nBullets:\n${bulletsList}`;
+  // UX-A (Learner UX audit Finding 1): the learner can see this cue card
+  // on their screen right now — treat it as a SHARED reference, do not
+  // read it back verbatim. Wording aligned with `session-materials.ts`
+  // ("what the student can see on their screen") — the canonical voice
+  // for screen-shared content in composed prompts.
+  const directive = `CUE CARD — visible on the learner's screen right now. Keep this topic central:\nTopic: ${picked.topic}\nBullets:\n${bulletsList}`;
   return {
     kind: "cueCard",
     topic: picked.topic,

--- a/apps/admin/lib/prompt/composition/transforms/session-focus.ts
+++ b/apps/admin/lib/prompt/composition/transforms/session-focus.ts
@@ -110,7 +110,12 @@ export function resolveSessionFocus(
   const label = row.stringValue?.trim();
   if (!label) return null;
 
-  const directive = `Today's session focus: ${label}. Steer your questions and feedback toward developing this technique throughout the session. Use the focus as the through-line — when the learner gives a brief answer, prompt them to apply ${label} explicitly; when they do it well, name the technique back to them so they recognise the move.`;
+  // UX-A (Learner UX audit Finding 2): the focus label is pinned visibly
+  // at the top of the learner's screen — reference it as a shared anchor,
+  // do not re-explain its existence. Wording aligned with the canonical
+  // "visible on the learner's screen" voice used by `session-materials.ts`
+  // and the sibling cue-card directive in `transforms/instructions.ts`.
+  const directive = `Today's session focus (pinned on the learner's screen): ${label}. Steer your questions and feedback toward developing this technique throughout the session. Use the focus as the through-line — when the learner gives a brief answer, prompt them to apply ${label} explicitly; when they do it well, name the technique back to them so they recognise the move.`;
 
   const pinnedCard: PinnedCardContent = {
     kind: "topicFocus",

--- a/apps/admin/tests/lib/prompt/composition/transforms/instructions.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/transforms/instructions.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Behavioural tests for `lib/prompt/composition/transforms/instructions.ts`.
+ *
+ * Today this file pins ONE invariant — UX-A (Finding 1 of the 2026-06-22
+ * Learner UX audit): the cue-card directive must declare the card is
+ * visible on the learner's screen so the AI treats it as a SHARED
+ * reference, not narrates it back verbatim. Sibling assertion to the
+ * UX-A pin in `session-focus.test.ts`.
+ *
+ * Scope is deliberately narrow — the cue-card resolver has many other
+ * branches (flag-off / no locked module / empty pool / missing topic) but
+ * those are covered structurally by:
+ *   - `tests/lib/prompt/composition/coverage-producer-consumer.test.ts`
+ *     (producer ↔ renderer pairing)
+ *   - `tests/lib/sim-chat/bdd-typed-unions-coverage.test.ts`
+ *     (cue-card shape vs BDD union)
+ *   - the ESLint sentinel `composition-directive-needs-renderer`.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { resolveModuleCueCard } from "@/lib/prompt/composition/transforms/instructions";
+import type { AssembledContext } from "@/lib/prompt/composition/types";
+import type { AuthoredModule, PlaybookConfig } from "@/lib/types/json-fields";
+
+const ORIGINAL_FLAG = process.env.HF_FLAG_IELTS_MODULE_SETTINGS;
+
+beforeAll(() => {
+  process.env.HF_FLAG_IELTS_MODULE_SETTINGS = "true";
+});
+
+afterEach(() => {
+  // Keep flag ON between tests; clear at the very end. Vitest runs
+  // describe/it sequentially in this file so no interleaving.
+});
+
+afterAll(() => {
+  if (ORIGINAL_FLAG === undefined) {
+    delete process.env.HF_FLAG_IELTS_MODULE_SETTINGS;
+  } else {
+    process.env.HF_FLAG_IELTS_MODULE_SETTINGS = ORIGINAL_FLAG;
+  }
+});
+
+function buildConfig(card: { topic: string; bullets: string[] }): PlaybookConfig {
+  const authoredModule: AuthoredModule = {
+    id: "part2",
+    slug: "part2",
+    title: "Part 2 — Long-turn cue cards",
+    mode: "examiner",
+    settings: {
+      cueCardPool: [card],
+    },
+  } as unknown as AuthoredModule;
+  return { modules: [authoredModule] } as unknown as PlaybookConfig;
+}
+
+function buildSharedState(): AssembledContext["sharedState"] {
+  return {
+    lockedModule: { id: "part2", slug: "part2" },
+    callNumber: 1,
+  } as unknown as AssembledContext["sharedState"];
+}
+
+describe("resolveModuleCueCard", () => {
+  describe("UX-A — pinned-visual prompt clarity (audit Finding 1)", () => {
+    it("directive declares the cue card is visible on the learner's screen", () => {
+      // Without this signal the AI over-narrates ("Today your cue card is…").
+      // The literal phrase is pinned so a future refactor can't silently
+      // drop it.
+      const out = resolveModuleCueCard(
+        buildConfig({
+          topic: "A book you enjoyed reading",
+          bullets: ["what it was about", "who wrote it", "why you enjoyed it"],
+        }),
+        buildSharedState(),
+      );
+      expect(out).not.toBeNull();
+      expect(out!.directive).toContain("visible on the learner's screen");
+    });
+
+    it("directive still carries the topic + bullets so the AI can anchor to them", () => {
+      const out = resolveModuleCueCard(
+        buildConfig({
+          topic: "A time you felt proud",
+          bullets: ["what happened", "who was there", "why it mattered"],
+        }),
+        buildSharedState(),
+      );
+      expect(out).not.toBeNull();
+      expect(out!.directive).toContain("A time you felt proud");
+      expect(out!.directive).toContain("what happened");
+      expect(out!.directive).toContain("who was there");
+      expect(out!.directive).toContain("why it mattered");
+    });
+
+    it("directive does NOT leak internal labels (criterion names, parameter ids)", () => {
+      // Defensive pin sibling to `learner-ui-leak-coverage.test.ts`.
+      // The cue-card pool carries learner-safe topic + bullets only —
+      // confirm the directive does not splice in any internal taxonomy.
+      const out = resolveModuleCueCard(
+        buildConfig({
+          topic: "A skill you learned",
+          bullets: ["what skill", "how you learned it", "how you use it"],
+        }),
+        buildSharedState(),
+      );
+      expect(out).not.toBeNull();
+      expect(out!.directive).not.toMatch(/Lexical Resource/);
+      expect(out!.directive).not.toMatch(/Fluency and Coherence/);
+      expect(out!.directive).not.toMatch(/Grammatical Range/);
+      expect(out!.directive).not.toMatch(/skill_/);
+    });
+  });
+});

--- a/apps/admin/tests/lib/prompt/composition/transforms/session-focus.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/transforms/session-focus.test.ts
@@ -215,6 +215,28 @@ describe("resolveSessionFocus", () => {
       expect(out).toBeNull();
     });
 
+    it("UX-A: directive declares the focus is pinned on the learner's screen", () => {
+      // Finding 2 of the 2026-06-22 Learner UX audit: the AI must know the
+      // focus label is visible to the learner so it can reference it as a
+      // shared anchor ("the technique we're focusing on today") rather than
+      // re-explaining its existence. Pinning the literal phrase prevents a
+      // future refactor from silently dropping the visibility signal.
+      const out = resolveSessionFocus(
+        EMPTY_CONFIG,
+        buildContext({
+          lockedModule: { id: "part3", slug: "part3" },
+          callerAttributes: [
+            {
+              key: "session_focus:next_part3",
+              stringValue: "giving reasons",
+            },
+          ],
+        }),
+      );
+      expect(out).not.toBeNull();
+      expect(out!.directive).toContain("pinned on the learner's screen");
+    });
+
     it("prefers slug over id for the key suffix", () => {
       const out = resolveSessionFocus(
         EMPTY_CONFIG,


### PR DESCRIPTION
## Summary
Closes UX-A from today's Learner UX audit (findings 1 + 2). Two prompt directives now tell the AI the learner can SEE the pinned content on screen, preventing over-narration ("Today your cue card is…") and enabling shared-reference anchoring ("looking at your card…", "the technique we're focusing on today").

Two files; ~6 lines of substantive directive text change. Branch renamed from `feat/ux-a-pinned-visual-prompt-clarity` → `feat/ux-a-cue-card-session-focus-pinned` because the original name collided with a peer session's existing W7 branch.

### Directive after-states

- **Cue card** (`lib/prompt/composition/transforms/instructions.ts::resolveModuleCueCard`):
  - Before: ``CUE CARD for this module — keep this topic central: …``
  - After:  ``CUE CARD — visible on the learner's screen right now. Keep this topic central: …``
- **Session focus** (`lib/prompt/composition/transforms/session-focus.ts::resolveSessionFocus`):
  - Before: ``Today's session focus: ${label}. Steer your questions …``
  - After:  ``Today's session focus (pinned on the learner's screen): ${label}. Steer your questions …``

All existing steering rules (keep topic central / through-line / name the technique back) are preserved verbatim — no constraints removed.

## Verified by

### Mandatory pre-coding Lattice survey (`.claude/rules/lattice-survey.md`)
Surface: 2 prompt-composition transforms. Sibling-writer search across `lib/prompt/composition/transforms/*.ts` for `visible|screen|sees|can see`:

- `transforms/session-materials.ts` is the canonical voice: ``"Know what the student can see on their screen"`` + ``"don't read back questions the student can see"`` (literal sibling directive).
- `transforms/preamble.ts:123`: ``"The learner sees only what a real human tutor would say in person."``

Chosen wording aligns with `session-materials.ts` for both directives — no convention conflict. The new phrasing is additive: AI now knows the surface is shared and visual.

### Producer↔consumer pairing
Both directives already have `@renderer-consumed-at lib/prompt/composition/renderPromptSummary.ts` sentinels and PAIR rows in `tests/lib/prompt/composition/coverage-producer-consumer.test.ts` (keys `module_cue_card`, `session_focus`). No manifest change required — text-only edits inside an already-registered directive field.

### Read-grounding / leak rules
`ai-read-grounding.md` — WRITE surface (composing AI input), no read-side grounding fires. `learner-ui-leak-coverage.md` — directives carry only learner-safe content (`picked.topic`, `picked.bullets`, projected `label`); the 11 leak-coverage vitests stay green.

### prompt-diff analysis (inline)
| Change | Risk | Behavioural impact |
|---|---|---|
| Cue card prefix ``"CUE CARD — visible on the learner's screen right now."`` | LOW — additive context | AI now knows the card is shared, can stop announcing it verbatim |
| Session focus prefix ``"(pinned on the learner's screen)"`` | LOW — parenthetical | AI knows the focus is a visible anchor, can reference rather than re-introduce |
| `resolveModuleCueCard` exported | NEUTRAL | Test-surface only, no runtime semantics |

No removed rules. No tone shift. Net effect: AI gets one extra fact per directive (visibility) without losing any prior instruction.

### Tests
- `tests/lib/prompt/composition/transforms/instructions.test.ts` (NEW): 3 cases pinning the literal `"visible on the learner's screen"` phrase + topic/bullet preservation + negative leak assertions (no `skill_*`, no criterion names).
- `tests/lib/prompt/composition/transforms/session-focus.test.ts`: extended with the UX-A pin for `"pinned on the learner's screen"`. Existing 11 cases unchanged.
- Composition surface: **258/258 passing** (`tests/lib/prompt/composition`).
- Leak gate: **11/11 passing** (`tests/lib/sim-chat/learner-ui-leak-coverage.test.ts`).

### Promptfoo eval
- New `evals/tutor/ux-a-pinned-visual-prompt-clarity.yaml` — 4 cases:
  - **UX-A.1** Cue card: AI references it as a shared visual, does NOT recite ``"Today your cue card is…"``
  - **UX-A.2** Cue card: AI does NOT enumerate all bullets in a list-dump
  - **UX-A.3** Session focus: AI references it as a shared anchor, does NOT re-explain a focus from scratch
  - **UX-A.4** Combined: AI uses both as visual anchors and moves to the first question without game-show framing
- YAML validated via ``npx promptfoo validate -c evals/tutor/ux-a-pinned-visual-prompt-clarity.yaml`` → ``Configuration is valid.``
- Run command: ``cd apps/admin && npx promptfoo eval -c evals/tutor/ux-a-pinned-visual-prompt-clarity.yaml --no-cache``
- Not run locally — Anthropic LLM calls incur cost; the YAML's `not-icontains` assertions are the deterministic guards; the `llm-rubric` assertions need a real run.

### tsc / lint
- `npx tsc --noEmit` → 42 errors (== baseline 42; no new errors). All pre-existing, unrelated.
- `npx eslint` on the 4 changed source/test files → 0 errors, 0 warnings (after `module` → `authoredModule` rename per `@next/next/no-assign-module-variable`).
- Pre-push hook green.

## Test plan

- [x] `cd apps/admin && npm run test -- tests/lib/prompt/composition --run` (258/258)
- [x] `cd apps/admin && npm run test -- tests/lib/sim-chat/learner-ui-leak-coverage.test.ts --run` (11/11)
- [x] `cd apps/admin && npx tsc --noEmit` (== ratchet baseline 42)
- [x] `cd apps/admin && npx eslint <changed files>` (clean)
- [x] `npx promptfoo validate -c evals/tutor/ux-a-pinned-visual-prompt-clarity.yaml` (valid)
- [ ] Promptfoo run on hf-dev or operator workstation (LLM cost — deferred to reviewer)
- [ ] Manual SIM walk after merge — confirm AI no longer reads cue cards / focus labels verbatim