### PR TITLE
fix(modules-tab): show authored modules regardless of lessonPlanMode

### DIFF
--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -1360,6 +1360,20 @@ html.light {
   color: var(--text-muted);
 }
 
+/* When an empty state contains a section title + description (the
+   widely-used title-over-desc pattern), stack the children vertically
+   and centre-align the text. Without this scoped rule, the base
+   .hf-empty flex-row collapses the vertical margins on
+   .hf-section-title / .hf-section-desc and the title visually
+   mashes into the description. Scoped via `:has(...)` so single-text
+   empty states (`<div class="hf-empty">No items.</div>`) keep the
+   original centred-row behaviour. */
+.hf-empty:has(.hf-section-title) {
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
 /* List rows (icon + label + value pattern) */
 .hf-list-row {
   display: flex;

--- a/apps/admin/components/modules-tab/CourseModulesTab.tsx
+++ b/apps/admin/components/modules-tab/CourseModulesTab.tsx
@@ -40,13 +40,21 @@ type ModuleRow = ModuleEditorRow;
 
 interface CourseModulesTabProps {
   courseId: string;
-  /** From `PlaybookConfig.lessonPlanMode`. `"continuous"` (or missing) →
-   *  modules don't apply; we show the empty state instead of the picker. */
+  /** From `PlaybookConfig.lessonPlanMode`. The continuous-course empty
+   *  state fires ONLY when BOTH `courseStyle === "continuous"` AND
+   *  `playbookConfig.modules.length === 0`. A course can have
+   *  `lessonPlanMode` unset (parent-fork casts to `"continuous"`) AND
+   *  still carry authored modules in `Playbook.config.modules` —
+   *  e.g. IELTS Speaking Practice ships 5 modules with no
+   *  `lessonPlanMode` flag. In that case modules-present overrides
+   *  the empty state; the operator sees their authored modules. */
   courseStyle?: string;
   /** Full PlaybookConfig — threaded through to ModuleInspectorPanel so
-   *  it can derive the editor-facing CourseShape (P3d, #1850). Optional;
-   *  legacy callers without it fall back to the binary courseStyle and
-   *  exam-only G8 entries render as `out-of-shape`. */
+   *  it can derive the editor-facing CourseShape (P3d, #1850). Also
+   *  read here to count `config.modules.length` for the empty-state
+   *  gate (see `courseStyle` above). Optional; legacy callers without
+   *  it fall back to the binary courseStyle and exam-only G8 entries
+   *  render as `out-of-shape`. */
   playbookConfig?: Record<string, unknown> | null;
 }
 
@@ -58,15 +66,43 @@ export function CourseModulesTab({
   const [selectedModuleId, setSelectedModuleId] = useState<string | null>(null);
   const [modules, setModules] = useState<ModuleRow[]>([]);
 
+  // P3d (#1850) — cast once at the boundary; ModuleInspectorPanel
+  // consumes the typed shape and falls back to "continuous" when null.
+  // Hoisted above the continuous-course early return to keep hook order
+  // stable across renders (react-hooks/rules-of-hooks). Also drives the
+  // `authoredModuleCount` gate that overrides the continuous empty
+  // state when the playbook still carries authored modules.
+  const typedPlaybookConfig = useMemo<PlaybookConfig | null>(
+    () =>
+      playbookConfig === null || playbookConfig === undefined
+        ? null
+        : (playbookConfig as unknown as PlaybookConfig),
+    [playbookConfig],
+  );
+
+  // When `lessonPlanMode` is unset, the parent-fork casts `courseStyle`
+  // to `"continuous"` — but the playbook may still carry authored
+  // modules (e.g. IELTS Speaking Practice ships 5 modules with no
+  // `lessonPlanMode`). The empty-state should only render when BOTH
+  // gates hold: continuous courseStyle AND no authored modules. When
+  // modules are present, we still fetch and show them so the operator
+  // can tune what they authored.
+  const authoredModuleCount = typedPlaybookConfig?.modules?.length ?? 0;
+  const showContinuousEmpty =
+    courseStyle === "continuous" && authoredModuleCount === 0;
+
   // Mirror the LH picker fetch so the Inspector can read each module's
   // `settings` sub-object without a second round-trip. The LH picker
   // owns its own fetch (it renders without waiting on the parent), and
   // this one feeds the Inspector — both target the same dedicated
   // /modules route so the cache will collapse them. `reloadKey` bumps
-  // after each save so the Inspector reflects persisted state.
+  // after each save so the Inspector reflects persisted state. Skip
+  // the fetch only when the empty-state is about to fire (continuous
+  // AND zero authored modules) — otherwise authored modules need to
+  // hydrate the Inspector regardless of `lessonPlanMode`.
   const [reloadKey, setReloadKey] = useState(0);
   useEffect(() => {
-    if (!courseId || courseStyle === "continuous") {
+    if (!courseId || showContinuousEmpty) {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset list on course/style change, matches sibling ModulesLhPicker pattern
       setModules([]);
       return;
@@ -88,25 +124,13 @@ export function CourseModulesTab({
     return () => {
       cancelled = true;
     };
-  }, [courseId, courseStyle, reloadKey]);
+  }, [courseId, showContinuousEmpty, reloadKey]);
 
   const handleSaved = useCallback(() => {
     setReloadKey((k) => k + 1);
   }, []);
 
-  // P3d (#1850) — cast once at the boundary; ModuleInspectorPanel
-  // consumes the typed shape and falls back to "continuous" when null.
-  // Hoisted above the continuous-course early return to keep hook order
-  // stable across renders (react-hooks/rules-of-hooks).
-  const typedPlaybookConfig = useMemo<PlaybookConfig | null>(
-    () =>
-      playbookConfig === null || playbookConfig === undefined
-        ? null
-        : (playbookConfig as unknown as PlaybookConfig),
-    [playbookConfig],
-  );
-
-  if (courseStyle === "continuous") {
+  if (showContinuousEmpty) {
     return (
       <div className="hf-empty">
         <h2 className="hf-section-title">No modules</h2>

--- a/apps/admin/tests/components/modules-tab/CourseModulesTab.test.tsx
+++ b/apps/admin/tests/components/modules-tab/CourseModulesTab.test.tsx
@@ -82,7 +82,7 @@ afterEach(() => {
 });
 
 describe("CourseModulesTab — P3 (#1850) Inspector wiring", () => {
-  it("renders the continuous-course empty state when courseStyle='continuous'", () => {
+  it("renders the continuous-course empty state when courseStyle='continuous' AND no authored modules", () => {
     render(<CourseModulesTab courseId="c1" courseStyle="continuous" />);
     expect(screen.getByText(/No modules/i)).toBeInTheDocument();
     expect(
@@ -92,12 +92,11 @@ describe("CourseModulesTab — P3 (#1850) Inspector wiring", () => {
     expect(screen.queryByTestId("hf-modules-lh-picker")).toBeNull();
   });
 
-  it("mounts the empty-state Inspector when no module is selected", async () => {
+  it("mounts the canvas empty-state when no module is selected", async () => {
     render(<CourseModulesTab courseId="c1" courseStyle="structured" />);
-    // ModuleInspectorPanel renders this testid when selectedModuleId is null.
-    expect(
-      screen.getByTestId("hf-module-inspector-empty"),
-    ).toBeInTheDocument();
+    // Post-#2120/#2121, the canvas is `ModuleEditor`; when no module
+    // is selected it renders its own "Pick a module to tune" empty.
+    expect(screen.getByTestId("hf-module-editor-empty")).toBeInTheDocument();
   });
 
   it("lists modules from the dedicated /api/courses/<id>/modules route", async () => {
@@ -135,7 +134,99 @@ describe("CourseModulesTab — P3 (#1850) Inspector wiring", () => {
     ).toBeInTheDocument();
   });
 
-  it("surfaces the course-wide-preview banner only — P3c (#1850) removed the Inspector read-only banner", async () => {
+  // 4-cell matrix pinning the (lessonPlanMode × modules.length) gate:
+  // the empty-state must fire only when BOTH continuous AND zero
+  // authored modules — modules-present always wins. Live evidence:
+  // IELTS Speaking Practice ships 5 modules with `lessonPlanMode`
+  // unset; the parent-fork casts `courseStyle` to `"continuous"`, but
+  // the Modules tab must still show the 5 authored modules.
+  describe("modules-present overrides continuous empty-state", () => {
+    const playbookConfigWithModules = {
+      modules: [
+        { id: "part1", label: "Part 1" },
+        { id: "part2", label: "Part 2" },
+        { id: "part3", label: "Part 3" },
+        { id: "baseline", label: "Baseline" },
+        { id: "mock", label: "Mock" },
+      ],
+    };
+
+    it("structured + 0 modules → modules surface (NOT continuous empty-state)", () => {
+      render(
+        <CourseModulesTab
+          courseId="c1"
+          courseStyle="structured"
+          playbookConfig={{ modules: [] }}
+        />,
+      );
+      // Continuous empty-state copy must be absent.
+      expect(
+        screen.queryByText(/Continuous courses don't have authored modules/i),
+      ).toBeNull();
+      // The modules-tab surface renders — picker mounts. The canvas
+      // shows the editor's "Pick a module to tune" empty state when
+      // no module is selected.
+      expect(screen.getByTestId("hf-modules-lh-picker")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("hf-module-editor-empty"),
+      ).toBeInTheDocument();
+    });
+
+    it("structured + 5 modules → modules surface populated", async () => {
+      render(
+        <CourseModulesTab
+          courseId="c1"
+          courseStyle="structured"
+          playbookConfig={playbookConfigWithModules}
+        />,
+      );
+      expect(
+        screen.queryByText(/Continuous courses don't have authored modules/i),
+      ).toBeNull();
+      await waitFor(() => {
+        expect(screen.getByTestId("hf-modules-row-part1")).toBeInTheDocument();
+        expect(screen.getByTestId("hf-modules-row-part2")).toBeInTheDocument();
+      });
+    });
+
+    it("continuous + 0 modules → continuous empty-state (the canonical empty case)", () => {
+      render(
+        <CourseModulesTab
+          courseId="c1"
+          courseStyle="continuous"
+          playbookConfig={{ modules: [] }}
+        />,
+      );
+      expect(
+        screen.getByText(/Continuous courses don't have authored modules/i),
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId("hf-modules-lh-picker")).toBeNull();
+    });
+
+    it("continuous + 5 modules → modules surface populated (the bug fix)", async () => {
+      // Live fingerprint: IELTS Speaking Practice ships 5 modules with
+      // `lessonPlanMode` unset → parent-fork casts to "continuous" →
+      // pre-fix the operator saw the continuous empty-state instead of
+      // their authored modules.
+      render(
+        <CourseModulesTab
+          courseId="c1"
+          courseStyle="continuous"
+          playbookConfig={playbookConfigWithModules}
+        />,
+      );
+      expect(
+        screen.queryByText(/Continuous courses don't have authored modules/i),
+      ).toBeNull();
+      expect(screen.queryByText(/No modules/i)).toBeNull();
+      await waitFor(() => {
+        expect(screen.getByTestId("hf-modules-row-part1")).toBeInTheDocument();
+        expect(screen.getByTestId("hf-modules-row-part2")).toBeInTheDocument();
+      });
+    });
+  });
+
+  it("Inspector read-only banner is GONE — P3c (#1850) wired the mutator", async () => {
     render(<CourseModulesTab courseId="c1" courseStyle="structured" />);
     const row = await waitFor(() =>
       screen.getByTestId("hf-modules-row-part1"),
@@ -144,13 +235,9 @@ describe("CourseModulesTab — P3 (#1850) Inspector wiring", () => {
     await waitFor(() =>
       screen.getByTestId("hf-module-inspector-part1"),
     );
-    // The canvas-side "Showing course-wide preview" banner persists
-    // until the preview-scope follow-on lands.
-    expect(
-      screen.getByText(/Showing course-wide preview/i),
-    ).toBeInTheDocument();
     // The Inspector-side "Read-only preview" banner is GONE — the
-    // mutator is wired in P3c.
+    // mutator is wired in P3c. (The post-#2120/#2121 refactor also
+    // dropped the canvas-side "Showing course-wide preview" banner.)
     expect(
       screen.queryByText(/Read-only preview/i),
     ).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

Admin Modules tab now shows authored modules whenever they exist in `Playbook.config.modules`, even if `lessonPlanMode` is not explicitly `"structured"`. Pipeline + scheduler contracts untouched — they keep strict-equal `"structured"` default-deny.

Live evidence: IELTS Speaking Practice on staging has 5 authored modules but `lessonPlanMode` unset; Modules tab was showing "Continuous courses don't have authored modules" → operator couldn't see modules they had authored. Operator screenshot 2026-06-22.

The empty-state now fires only when BOTH `courseStyle === "continuous"` AND `playbookConfig.modules.length === 0`. Modules-present overrides the empty-state regardless of `lessonPlanMode`.

Also fixes a typography mash in `.hf-empty`: the base flex-row layout collapsed the vertical margins on `.hf-section-title` + `.hf-section-desc` so the title visually ran into the description. Scoped `:has(.hf-section-title)` rule adds `flex-direction: column` for that pattern only — single-text empty states keep the original centred-row behaviour.

## Verified by

- **Lattice survey (`.claude/rules/lattice-survey.md`)**: 6 pipeline sites + `course-shape.ts` helper retain strict-equal `"structured"` default-deny (convention untouched — `lib/pipeline/course-style.ts:42`, `lib/pipeline/adaptive-loop-invariants.ts:227`, `lib/pipeline/scheduler-presets.ts:255`, `lib/journey/course-shape.ts:21`, `lib/enrollment/instantiate-module-progress.ts:7`, `lib/prompt/composition/transforms/modules.ts:391`). Sibling UI consumer in `app/x/courses/[courseId]/_components/LearnerModulePicker.tsx:224` (picks rail-vs-tiles LAYOUT — not a hide gate) also untouched. The Modules-tab admin UI gate now considers `modules.length` in addition to `courseStyle`. [verified] — survey result from this turn's exploration.
- **4-cell matrix test** at `apps/admin/tests/components/modules-tab/CourseModulesTab.test.tsx` lines 152-227 pins (lessonPlanMode × modules.length) behaviour: structured+0, structured+5, continuous+0, continuous+5. The continuous+5 case is the bug fix — pre-fix it failed; post-fix it shows the picker + populated module rows.
- `npx vitest run tests/components/modules-tab/CourseModulesTab.test.tsx`: 9 passed (9). [verified] — full file green.
- `npx vitest run tests/lib/pipeline tests/lib/journey/course-shape`: 488 passed / 1 failed (pre-existing `mode-spec-selection-coverage.test.ts` "no exempt entry is contradicted" — confirmed unchanged on `main` via `git stash` rerun). [verified] — pipeline + course-shape regressions unchanged.
- `npx tsc --noEmit` filtered to touched files: zero errors on `CourseModulesTab.tsx` / `CourseModulesTab.test.tsx` / `globals.css`. Pre-push tsc ratchet went 42 → 38 (4 below baseline — improvement). [verified] — pre-push hook reported `tsc: 38 errors (baseline 42, -4)`.
- `npx eslint components/modules-tab/CourseModulesTab.tsx tests/components/modules-tab/CourseModulesTab.test.tsx`: zero errors / warnings. [verified] — pre-push hook reported `lint: no errors in changed files`.

Per `.claude/rules/verify-before-fix.md`: the operator's screenshot was the trigger; the symptom matches exactly the gate logic the diff changes. No DB query needed because the fix is purely conditional logic at the JSX render boundary — fully reproducible from the screenshot + code read of the 3 cited gate sites.

## Screenshot caption

> Post-PR: staging Modules tab for IELTS Speaking Practice will show the 5 authored modules (Baseline, Part 1, Part 2, Part 3, Mock) instead of "Continuous courses don't have authored modules". Empty-state copy is preserved verbatim for the genuinely-continuous case (no `lessonPlanMode` AND no `modules[]`).

## What was NOT touched (deliberately)

- `app/x/courses/[courseId]/page.tsx` parent-fork — the `lessonPlanMode === "structured" ? "structured" : "continuous"` cast stays. The Modules tab now handles the dual-state correctly without rewriting the parent contract.
- `lib/pipeline/**` — strict-equal default-deny preserved per chain-contract convention.
- `lib/journey/course-shape.ts` — same.
- `LearnerModulePicker.tsx` rail-vs-tiles gate — same.
- Staging DB — no data migration. Operator may choose to flip `lessonPlanMode: "structured"` on IELTS Speaking Practice, but the code fix stands independently and applies to every existing playbook with authored modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)