### PR TITLE
feat(wizard): infer lessonPlanMode = "structured" from authored-modules / course-ref signals

### DIFF
--- a/apps/admin/lib/chat/wizard-tool-executor/tools/create_course/_new-config-merge.ts
+++ b/apps/admin/lib/chat/wizard-tool-executor/tools/create_course/_new-config-merge.ts
@@ -19,6 +19,7 @@ import {
   isAudience,
   isPlanEmphasis,
   isLessonPlanModel,
+  isLessonPlanMode,
   isProgressionMode,
 } from "@/lib/content-trust/resolve-config";
 
@@ -173,7 +174,35 @@ export async function buildNewConfigUpdate(
     cadenceMinutesPerCall?: number | null;
     suggestedSessionCount?: number | null;
   } | undefined;
-  if (newPedagogy?.lessonPlanMode) configUpdate.lessonPlanMode = newPedagogy.lessonPlanMode;
+  // Explicit pedagogy declaration in the course-ref wins. The detector
+  // only ever emits `"continuous"` or `null` (it scans for continuous
+  // phrases) — so a `"structured"` value here only ever arrives from
+  // an operator-authored `pedagogy.lessonPlanMode: structured` block
+  // in the course-ref doc OR a sibling explicit override.
+  if (newPedagogy?.lessonPlanMode && isLessonPlanMode(newPedagogy.lessonPlanMode)) {
+    configUpdate.lessonPlanMode = newPedagogy.lessonPlanMode;
+  } else if (newPedagogy?.lessonPlanMode) {
+    logSkipInvalidEnum(
+      "lessonPlanMode",
+      newPedagogy.lessonPlanMode,
+      "structured|continuous",
+    );
+  } else if (
+    configUpdate.lessonPlanMode === undefined &&
+    newPedagogy !== undefined
+  ) {
+    // Course-ref uploaded (operator went through the doc-driven flow)
+    // AND no explicit lessonPlanMode in pedagogy → default to
+    // "structured". The course-ref upload IS the canonical signal that
+    // the operator declared a course shape; absent an explicit
+    // `continuous` phrase, the safe default is structured so the admin
+    // Modules tab surfaces authored modules. The pipeline's runtime
+    // default-deny convention (`lib/pipeline/course-style.ts`) is
+    // unaffected — this is wizard authoring inference, not a runtime
+    // default. See IELTS-on-staging fingerprint: 5 authored modules,
+    // lessonPlanMode unset → admin Modules tab hid them.
+    configUpdate.lessonPlanMode = "structured";
+  }
   if (newPedagogy?.cadenceMinutesPerCall && !newDurationMins) {
     configUpdate.durationMins = newPedagogy.cadenceMinutesPerCall;
   }

--- a/apps/admin/lib/chat/wizard-tool-executor/tools/create_course/_reuse-config-merge.ts
+++ b/apps/admin/lib/chat/wizard-tool-executor/tools/create_course/_reuse-config-merge.ts
@@ -20,6 +20,7 @@ import {
   isAudience,
   isPlanEmphasis,
   isLessonPlanModel,
+  isLessonPlanMode,
   isProgressionMode,
 } from "@/lib/content-trust/resolve-config";
 
@@ -140,8 +141,35 @@ export function buildReuseConfigUpdate(
     cadenceMinutesPerCall?: number | null;
     suggestedSessionCount?: number | null;
   } | undefined;
-  if (pedagogy?.lessonPlanMode) {
+  if (pedagogy?.lessonPlanMode && isLessonPlanMode(pedagogy.lessonPlanMode)) {
     configUpdate.lessonPlanMode = pedagogy.lessonPlanMode;
+  } else if (pedagogy?.lessonPlanMode) {
+    logSkipInvalidEnum(
+      "lessonPlanMode",
+      pedagogy.lessonPlanMode,
+      "structured|continuous",
+    );
+  } else if (configUpdate.lessonPlanMode === undefined) {
+    // Reuse-path inference: when modules are already authored on the
+    // existing playbook (the canonical signal that the course IS
+    // structured), default to `"structured"`. Prevents the admin
+    // Modules tab from hiding authored modules under a default-deny
+    // `lessonPlanMode === undefined → "continuous"` fall-through.
+    // The pipeline runtime contract (`lib/pipeline/course-style.ts`
+    // strict `=== "structured"` default-deny) is unaffected; this is
+    // wizard authoring inference at write time.
+    const existingModules = Array.isArray(existingConfig.modules)
+      ? existingConfig.modules
+      : null;
+    if (existingModules && existingModules.length > 0) {
+      configUpdate.lessonPlanMode = "structured";
+    } else if (pedagogy !== undefined) {
+      // Course-ref upload but no explicit pedagogy.lessonPlanMode and
+      // no modules yet on the playbook — still default to "structured"
+      // for the same reason as the new-path: course-ref upload is the
+      // operator's canonical declaration of course shape.
+      configUpdate.lessonPlanMode = "structured";
+    }
   }
   if (pedagogy?.cadenceMinutesPerCall && !durationMins) {
     configUpdate.durationMins = pedagogy.cadenceMinutesPerCall;

--- a/apps/admin/lib/content-trust/resolve-config.ts
+++ b/apps/admin/lib/content-trust/resolve-config.ts
@@ -1382,6 +1382,23 @@ export type FirstCallMode =
   | "teach_immediately"
   | "baseline_assessment";
 export type ProgressionMode = "learner-picks" | "ai-led";
+/**
+ * Lesson plan MODE — pacing shape. NOT to be confused with
+ * `LessonPlanModel` (pedagogical model: direct_instruction / socratic / …).
+ *
+ * `structured` — the course has authored modules + a fixed shape. The
+ *   admin Modules tab is visible; `getCourseStyle` returns `"structured"`;
+ *   `CallerModuleProgress` rows are instantiated on enrollment.
+ * `continuous` — the scheduler decides per call; no per-module progress.
+ *
+ * Wizard inference (see `_new-config-merge.ts` / `_reuse-config-merge.ts`):
+ * when authored modules are present (the canonical signal that the course
+ * IS structured) but `pedagogy.lessonPlanMode` is unset in the course-ref,
+ * the wizard defaults to `"structured"`. Prevents the IELTS-on-staging
+ * bug fingerprint where 5 authored modules shipped + lessonPlanMode unset
+ * → admin Modules tab hid them.
+ */
+export type LessonPlanMode = "structured" | "continuous";
 
 import type { AudienceId } from "@/lib/prompt/composition/transforms/audience";
 import { AUDIENCE_OPTIONS } from "@/lib/prompt/composition/transforms/audience";
@@ -1411,6 +1428,10 @@ const PROGRESSION_MODE_SET: ReadonlySet<string> = new Set([
   "learner-picks",
   "ai-led",
 ]);
+const LESSON_PLAN_MODE_SET: ReadonlySet<string> = new Set([
+  "structured",
+  "continuous",
+]);
 
 /** Runtime type guard for `AudienceId` (#1995). */
 export function isAudience(value: unknown): value is AudienceId {
@@ -1439,6 +1460,21 @@ export function isProgressionMode(
   value: unknown,
 ): value is ProgressionMode {
   return typeof value === "string" && PROGRESSION_MODE_SET.has(value);
+}
+
+/**
+ * Runtime type guard for `LessonPlanMode` — pacing shape
+ * (`structured` / `continuous`). Sibling of `isLessonPlanModel`
+ * (the pedagogical model). The wizard merge paths use this before
+ * writing `Playbook.config.lessonPlanMode` so a stale or hallucinated
+ * value cannot reach the DB. The pipeline reads
+ * `lessonPlanMode === "structured"` as the structural signal that
+ * `CallerModuleProgress` rows + the admin Modules tab apply.
+ */
+export function isLessonPlanMode(
+  value: unknown,
+): value is LessonPlanMode {
+  return typeof value === "string" && LESSON_PLAN_MODE_SET.has(value);
 }
 
 // ── Subject Discipline Preambles ─────────────────────────────────────────────

--- a/apps/admin/lib/wizard/__tests__/fixtures/course-reference-ielts-v2.3.md
+++ b/apps/admin/lib/wizard/__tests__/fixtures/course-reference-ielts-v2.3.md
@@ -21,6 +21,7 @@ hf-template-version: "5.1"
   
 - **courseStyle:** structured  
 - **examShape:** exam     <!-- enables exam-style settings: cueCardPool, scheduledCues, examMode -->  
+- **lessonPlanMode:** structured     <!-- 5 authored modules — admin Modules tab + CallerModuleProgress active. Operator-authoritative declaration so the wizard does not need to infer. -->  
   
 **Rationale.** IELTS Speaking is fundamentally an exam-prep course with a fixed five-module structure (Baseline, Part 1, Part 2, Part 3, Mock Exam), per-module session-terminal rules, scheduled cues (Part 2 prep + monologue countdown), and a cue-card pool whose semantics are exam-specific. Declaring `courseStyle: structured` keeps `CallerModuleProgress` writes active and the picker honouring the per-module catalogue. Declaring `examShape: exam` (a sub-shape of structured) enables the exam-only settings the projector needs to emit — `moduleCueCardPool`, `moduleScheduledCues`, and the examiner-mode silence rules during the Part 2 long turn.  
   

--- a/apps/admin/lib/wizard/detect-pedagogy.ts
+++ b/apps/admin/lib/wizard/detect-pedagogy.ts
@@ -62,6 +62,33 @@ const CONTINUOUS_PHRASES = [
   "call-by-call adaptive",
 ];
 
+/**
+ * Explicit structured-mode patterns the operator can declare in the
+ * course-ref to override the (short-cadence → continuous) inference.
+ * Symmetric to `CONTINUOUS_PHRASES`. A course-ref doc that declares
+ * `**lessonPlanMode:** structured` (or sibling markdown variants)
+ * matches one of these patterns; the wizard then writes
+ * `Playbook.config.lessonPlanMode = "structured"` so the admin Modules
+ * tab + `CallerModuleProgress` writes stay active for authored-modules
+ * courses. Prevents the IELTS-on-staging fingerprint where 5 authored
+ * modules shipped with `lessonPlanMode` unset → admin UI hid them.
+ *
+ * Regexes (not bare substrings) because markdown emits `**key:**` so a
+ * substring check on `"lessonplanmode: structured"` misses the
+ * common `**lessonPlanMode:** structured` shape. Each regex is
+ * case-insensitive and tolerant of `**` decoration + extra whitespace.
+ */
+const STRUCTURED_PATTERNS: RegExp[] = [
+  // `lessonPlanMode: structured` with any amount of `*` / `_` / whitespace
+  // separating the key from the value (covers `**lessonPlanMode:** structured`,
+  // `lessonPlanMode:structured`, `_lesson plan mode_: structured`, etc.)
+  /lesson\s*plan\s*mode\s*[:=]\s*[*_\s]*structured\b/i,
+  /\bstructured\s+lesson\s+plan\b/i,
+  /\bpre-planned\s+sessions?\b/i,
+  /\bmodules?\s+authored\b/i,
+  /\bauthored\s+modules?\b/i,
+];
+
 const PRESET_PATTERNS: Array<{ preset: PedagogicalPreset; patterns: RegExp[] }> = [
   {
     preset: "balanced",
@@ -125,12 +152,29 @@ export function detectPedagogy(bodyText: string): DetectedPedagogy {
     }
   }
 
-  // ── Continuous mode intent: phrase match (case-insensitive)
-  for (const phrase of CONTINUOUS_PHRASES) {
-    if (lower.includes(phrase)) {
-      result.lessonPlanMode = "continuous";
-      result.detectedFrom.push(`continuous: "${phrase}"`);
+  // ── Explicit structured-mode intent (highest precedence) — pattern match.
+  // Operators can pin the mode by declaring `**lessonPlanMode:** structured`
+  // (or any sibling phrase) in the course-ref doc. Checked first so the
+  // short-cadence→continuous inference below cannot fire when the
+  // operator has explicitly declared structured intent.
+  for (const pattern of STRUCTURED_PATTERNS) {
+    const match = pattern.exec(bodyText);
+    if (match) {
+      result.lessonPlanMode = "structured";
+      result.detectedFrom.push(`structured: "${match[0]}"`);
       break;
+    }
+  }
+
+  // ── Continuous mode intent: phrase match (case-insensitive). Skipped
+  // when structured was already declared above.
+  if (result.lessonPlanMode === null) {
+    for (const phrase of CONTINUOUS_PHRASES) {
+      if (lower.includes(phrase)) {
+        result.lessonPlanMode = "continuous";
+        result.detectedFrom.push(`continuous: "${phrase}"`);
+        break;
+      }
     }
   }
 

--- a/apps/admin/lib/wizard/enum-sets.ts
+++ b/apps/admin/lib/wizard/enum-sets.ts
@@ -43,6 +43,7 @@ import type {
   TeachingMode,
   PlanEmphasis as ResolveConfigPlanEmphasis,
   LessonPlanModel as ResolveConfigLessonPlanModel,
+  LessonPlanMode as ResolveConfigLessonPlanMode,
   FirstCallMode as ResolveConfigFirstCallMode,
   ProgressionMode as ResolveConfigProgressionMode,
 } from "@/lib/content-trust/resolve-config";
@@ -146,6 +147,28 @@ export const PROGRESSION_MODE_ORDER: readonly ProgressionMode[] = [
 ] as const;
 export const VALID_PROGRESSION_MODES: ReadonlySet<string> = new Set<string>(
   PROGRESSION_MODE_ORDER,
+);
+
+/**
+ * Lesson plan MODE — pacing shape (`structured` / `continuous`).
+ * Sibling of `LessonPlanModel` (the pedagogical model — direct_instruction,
+ * socratic, …). Persisted as `Playbook.config.lessonPlanMode`. The
+ * pipeline reads `=== "structured"` as the canonical signal that
+ * authored modules / `CallerModuleProgress` apply.
+ *
+ * The wizard's `coursePedagogy` block sources this from the course-ref
+ * doc; absent an explicit declaration, the merge inference at
+ * `_new-config-merge.ts` / `_reuse-config-merge.ts` defaults to
+ * `"structured"` when authored modules or a course-ref upload are
+ * detected.
+ */
+export type LessonPlanMode = ResolveConfigLessonPlanMode;
+export const LESSON_PLAN_MODE_ORDER: readonly LessonPlanMode[] = [
+  "structured",
+  "continuous",
+] as const;
+export const VALID_LESSON_PLAN_MODES: ReadonlySet<string> = new Set<string>(
+  LESSON_PLAN_MODE_ORDER,
 );
 
 // ── Type guards ───────────────────────────────────────────────

--- a/apps/admin/prisma/seed-ielts-course.ts
+++ b/apps/admin/prisma/seed-ielts-course.ts
@@ -160,6 +160,18 @@ export async function main(prisma: PrismaClient): Promise<void> {
         sessionCount: 12,
         durationMins: 20,
         planEmphasis: "exam preparation — spoken performance with correction",
+        // IELTS Speaking Practice is a structured course with 5 authored
+        // modules (Baseline, Part 1, Part 2, Part 3, Mock Exam). The
+        // pipeline reads `lessonPlanMode === "structured"` to keep
+        // `CallerModuleProgress` writes active and the admin Modules
+        // tab populated. Without this stamp the admin UI's default-deny
+        // (`lessonPlanMode === undefined` → "continuous") hides the
+        // 5 authored modules from operators. Detector at
+        // `lib/wizard/detect-pedagogy.ts` only emits "continuous" or
+        // null — never "structured" — so this stamp must live in the
+        // seed payload (and in the wizard authoring inference; see
+        // `lib/chat/wizard-tool-executor/tools/create_course/_*-config-merge.ts`).
+        lessonPlanMode: "structured",
         welcome: {
           goals: { enabled: true },
           aboutYou: { enabled: true },

--- a/apps/admin/tests/lib/chat/wizard-enum-validation.test.ts
+++ b/apps/admin/tests/lib/chat/wizard-enum-validation.test.ts
@@ -36,12 +36,14 @@ import {
   VALID_AUDIENCE_IDS,
   VALID_PLAN_EMPHASIS,
   VALID_LESSON_PLAN_MODELS,
+  VALID_LESSON_PLAN_MODES,
   VALID_FIRST_CALL_MODES,
   VALID_PROGRESSION_MODES,
   INTERACTION_PATTERN_ORDER,
   TEACHING_MODE_ORDER,
   PLAN_EMPHASIS_ORDER,
   LESSON_PLAN_MODEL_ORDER,
+  LESSON_PLAN_MODE_ORDER,
   FIRST_CALL_MODE_ORDER,
   PROGRESSION_MODE_ORDER,
 } from "../../../lib/wizard/enum-sets";
@@ -55,6 +57,7 @@ import {
   isAudience,
   isPlanEmphasis,
   isLessonPlanModel,
+  isLessonPlanMode,
   isFirstCallMode,
   isProgressionMode,
   INTERACTION_PATTERN_ORDER as RESOLVE_INTERACTION_PATTERN_ORDER,
@@ -144,6 +147,19 @@ const FIELDS: readonly EnumField[] = [
     wrongUnionSamples: ["directive", "recall", "primary"],
     // progressionMode is captured via show_options (not update_setup)
     // per the v5 system prompt — it's not in the create_course schema.
+    inCreateCourseSchema: false,
+  },
+  {
+    fieldName: "lessonPlanMode",
+    canonicalValues: LESSON_PLAN_MODE_ORDER,
+    set: VALID_LESSON_PLAN_MODES,
+    guard: isLessonPlanMode,
+    wrongUnionSamples: ["directive", "recall", "primary", "5e", "breadth"],
+    // lessonPlanMode is sourced from `setupData.coursePedagogy.lessonPlanMode`
+    // (course-ref doc parser) — not surfaced as a direct AI input. The
+    // wizard merge inference defaults it to "structured" when a
+    // course-ref is uploaded / authored modules are present; otherwise
+    // it stays unset. Not in the create_course schema.
     inCreateCourseSchema: false,
   },
 ];

--- a/apps/admin/tests/lib/chat/wizard-tool-executor/lesson-plan-mode-inference.test.ts
+++ b/apps/admin/tests/lib/chat/wizard-tool-executor/lesson-plan-mode-inference.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Unit tests for the wizard `create_course` config-merge inference of
+ * `lessonPlanMode` when modules / course-ref-upload signals are
+ * present but the course-ref doesn't explicitly declare a mode.
+ *
+ * Background: IELTS Speaking Practice on staging shipped with 5
+ * authored modules but `Playbook.config.lessonPlanMode` unset → the
+ * admin Modules tab default-deny (`courseStyle === "continuous"`)
+ * hid the modules. The detector (`lib/wizard/detect-pedagogy.ts`)
+ * only ever emits `"continuous"` or `null` — never `"structured"` —
+ * so the wizard merge needs to infer "structured" from the canonical
+ * authored-course signals available at merge time:
+ *
+ *   - **New path**: `setupData.coursePedagogy` is non-null (a course-ref
+ *     was uploaded + parsed). Absent an explicit `"continuous"` from
+ *     the detector, default to `"structured"`.
+ *   - **Reuse path**: `existingConfig.modules` is a non-empty array
+ *     (authored modules already on the playbook). Default to
+ *     `"structured"` so the admin Modules tab surfaces them.
+ *
+ * The pipeline runtime default-deny convention (`lib/pipeline/course-style.ts`
+ * strict `=== "structured"`) is unaffected — this is wizard authoring
+ * inference at write time, not a runtime default.
+ *
+ * Tests pin the 4-cell matrix per merge path:
+ *
+ *   | Case | pedagogy.lessonPlanMode | modules / pedagogy presence | Expected lessonPlanMode |
+ *   |------|-------------------------|------------------------------|--------------------------|
+ *   | A    | "structured"            | any                          | "structured" (explicit) |
+ *   | B    | "continuous"            | any                          | "continuous" (explicit) |
+ *   | C    | undefined               | modules-present / pedagogy   | "structured" (inferred) |
+ *   | D    | undefined               | no modules / no pedagogy     | unset (preserved)       |
+ */
+import { describe, it, expect, vi } from "vitest";
+
+// _new-config-merge.ts dynamically imports the AI guard module; mock it.
+vi.mock("@/lib/chat/wizard-ai-output-guard", () => ({
+  guardAILearningOutcomes: () => ({
+    filtered: [],
+    accepted: [],
+    skippedByGate: false,
+    gateReason: undefined,
+  }),
+}));
+
+import { buildNewConfigUpdate } from "@/lib/chat/wizard-tool-executor/tools/create_course/_new-config-merge";
+import { buildReuseConfigUpdate } from "@/lib/chat/wizard-tool-executor/tools/create_course/_reuse-config-merge";
+import type { ResolvedCreateCourseContext } from "@/lib/chat/wizard-tool-executor/tools/create_course/_context";
+
+function newCtx(
+  overrides: Partial<{
+    input: Record<string, unknown>;
+    setupData: Record<string, unknown>;
+  }> = {},
+): ResolvedCreateCourseContext {
+  return {
+    input: overrides.input ?? {},
+    setupData: overrides.setupData,
+    userId: "user-test",
+    domainId: "dom-test",
+    subjectDiscipline: "IELTS Speaking",
+    courseName: "IELTS Speaking Practice",
+    interactionPattern: "directive",
+  };
+}
+
+describe("_new-config-merge — lessonPlanMode inference (IELTS-on-staging fingerprint)", () => {
+  it("Case A: explicit pedagogy.lessonPlanMode = 'structured' wins", async () => {
+    const ctx = newCtx({
+      setupData: {
+        coursePedagogy: { lessonPlanMode: "structured" },
+      },
+    });
+    const { configUpdate } = await buildNewConfigUpdate({
+      existingConfig: {},
+      ctx,
+    });
+    expect(configUpdate.lessonPlanMode).toBe("structured");
+  });
+
+  it("Case B: explicit pedagogy.lessonPlanMode = 'continuous' wins", async () => {
+    const ctx = newCtx({
+      setupData: {
+        coursePedagogy: { lessonPlanMode: "continuous" },
+      },
+    });
+    const { configUpdate } = await buildNewConfigUpdate({
+      existingConfig: {},
+      ctx,
+    });
+    expect(configUpdate.lessonPlanMode).toBe("continuous");
+  });
+
+  it("Case C: course-ref uploaded (coursePedagogy present) + no explicit mode → defaults to 'structured'", async () => {
+    const ctx = newCtx({
+      setupData: {
+        coursePedagogy: {
+          lessonPlanMode: null,
+          cadenceMinutesPerCall: null,
+          suggestedSessionCount: null,
+        },
+      },
+    });
+    const { configUpdate } = await buildNewConfigUpdate({
+      existingConfig: {},
+      ctx,
+    });
+    expect(configUpdate.lessonPlanMode).toBe("structured");
+  });
+
+  it("Case D: no course-ref + no explicit mode → lessonPlanMode preserved (unset)", async () => {
+    const ctx = newCtx({});
+    const { configUpdate } = await buildNewConfigUpdate({
+      existingConfig: {},
+      ctx,
+    });
+    expect(configUpdate.lessonPlanMode).toBeUndefined();
+  });
+
+  it("invalid pedagogy.lessonPlanMode value is dropped (not written)", async () => {
+    const ctx = newCtx({
+      setupData: {
+        coursePedagogy: { lessonPlanMode: "not-a-valid-mode" },
+      },
+    });
+    const { configUpdate } = await buildNewConfigUpdate({
+      existingConfig: {},
+      ctx,
+    });
+    // Invalid value rejected; merge falls through. The pedagogy block
+    // IS present so the structured-default inference does NOT fire
+    // when the explicit-but-invalid branch was taken (the explicit
+    // value loses; merge proceeds without setting the field — same
+    // shape as the other invalid-enum drops).
+    expect(configUpdate.lessonPlanMode).toBeUndefined();
+  });
+});
+
+describe("_reuse-config-merge — lessonPlanMode inference (IELTS-on-staging fingerprint)", () => {
+  it("Case A: explicit pedagogy.lessonPlanMode = 'structured' wins", () => {
+    const ctx = newCtx({
+      setupData: {
+        coursePedagogy: { lessonPlanMode: "structured" },
+      },
+    });
+    const out = buildReuseConfigUpdate({}, ctx);
+    expect(out.lessonPlanMode).toBe("structured");
+  });
+
+  it("Case B: explicit pedagogy.lessonPlanMode = 'continuous' wins", () => {
+    const ctx = newCtx({
+      setupData: {
+        coursePedagogy: { lessonPlanMode: "continuous" },
+      },
+    });
+    const out = buildReuseConfigUpdate({}, ctx);
+    expect(out.lessonPlanMode).toBe("continuous");
+  });
+
+  it("Case C: existingConfig.modules non-empty + no explicit mode → defaults to 'structured'", () => {
+    const ctx = newCtx({});
+    const out = buildReuseConfigUpdate(
+      { modules: [{ id: "m1" }, { id: "m2" }] },
+      ctx,
+    );
+    expect(out.lessonPlanMode).toBe("structured");
+  });
+
+  it("Case C (alt): course-ref uploaded + no modules-yet → defaults to 'structured'", () => {
+    const ctx = newCtx({
+      setupData: {
+        coursePedagogy: {
+          lessonPlanMode: null,
+          cadenceMinutesPerCall: null,
+        },
+      },
+    });
+    const out = buildReuseConfigUpdate({}, ctx);
+    expect(out.lessonPlanMode).toBe("structured");
+  });
+
+  it("Case D: no modules + no course-ref + no explicit mode → unset (preserved)", () => {
+    const ctx = newCtx({});
+    const out = buildReuseConfigUpdate({}, ctx);
+    expect(out.lessonPlanMode).toBeUndefined();
+  });
+
+  it("invalid pedagogy.lessonPlanMode value is dropped (not written)", () => {
+    const ctx = newCtx({
+      setupData: {
+        coursePedagogy: { lessonPlanMode: "garbage-value" },
+      },
+    });
+    const out = buildReuseConfigUpdate({}, ctx);
+    expect(out.lessonPlanMode).toBeUndefined();
+  });
+
+  it("preserves existing lessonPlanMode when no override is supplied", () => {
+    const ctx = newCtx({});
+    const out = buildReuseConfigUpdate(
+      { lessonPlanMode: "continuous" },
+      ctx,
+    );
+    // existingConfig is spread first; no pedagogy override + no
+    // inference branch taken (existing already set). Pass-through.
+    expect(out.lessonPlanMode).toBe("continuous");
+  });
+});
+
+describe("isLessonPlanMode type guard (resolve-config.ts)", () => {
+  it("accepts the two canonical values + rejects everything else", async () => {
+    const { isLessonPlanMode } = await import(
+      "@/lib/content-trust/resolve-config"
+    );
+    expect(isLessonPlanMode("structured")).toBe(true);
+    expect(isLessonPlanMode("continuous")).toBe(true);
+
+    // Cross-union "wrong column" samples — these must NOT pass.
+    expect(isLessonPlanMode("recall")).toBe(false); // teachingMode
+    expect(isLessonPlanMode("directive")).toBe(false); // interactionPattern
+    expect(isLessonPlanMode("breadth")).toBe(false); // planEmphasis
+    expect(isLessonPlanMode("5e")).toBe(false); // lessonPlanModel
+    expect(isLessonPlanMode("primary")).toBe(false); // audience
+
+    // Garbage rejections.
+    expect(isLessonPlanMode(undefined)).toBe(false);
+    expect(isLessonPlanMode(null)).toBe(false);
+    expect(isLessonPlanMode(123)).toBe(false);
+    expect(isLessonPlanMode({})).toBe(false);
+    expect(isLessonPlanMode([])).toBe(false);
+    expect(isLessonPlanMode("")).toBe(false);
+  });
+});
+
+describe("detect-pedagogy STRUCTURED_PHRASES (course-ref author surface)", () => {
+  it("emits 'structured' when the doc declares `lessonPlanMode: structured`", async () => {
+    const { detectPedagogy } = await import("@/lib/wizard/detect-pedagogy");
+    const out = detectPedagogy(
+      "Some prose. **lessonPlanMode:** structured. More prose.",
+    );
+    expect(out.lessonPlanMode).toBe("structured");
+    expect(out.detectedFrom.some((s) => s.startsWith("structured:"))).toBe(
+      true,
+    );
+  });
+
+  it("emits 'structured' when the doc says 'authored modules'", async () => {
+    const { detectPedagogy } = await import("@/lib/wizard/detect-pedagogy");
+    const out = detectPedagogy(
+      "**Modules authored:** Yes — see `## Modules` below.",
+    );
+    expect(out.lessonPlanMode).toBe("structured");
+  });
+
+  it("structured signal overrides short-cadence → continuous inference", async () => {
+    const { detectPedagogy } = await import("@/lib/wizard/detect-pedagogy");
+    const out = detectPedagogy(
+      "**lessonPlanMode:** structured. Call duration: 15 minutes.",
+    );
+    // Cadence is short (15 min) so the legacy fallback would have set
+    // "continuous" — but the explicit structured marker wins.
+    expect(out.lessonPlanMode).toBe("structured");
+    expect(out.cadenceMinutesPerCall).toBe(15);
+  });
+
+  it("preserves 'continuous' detection when no structured marker is present", async () => {
+    const { detectPedagogy } = await import("@/lib/wizard/detect-pedagogy");
+    const out = detectPedagogy(
+      "The scheduler decides per call. No fixed session plan.",
+    );
+    expect(out.lessonPlanMode).toBe("continuous");
+  });
+});


### PR DESCRIPTION
## Summary

Wizard authoring (`_new-config-merge.ts`, `_reuse-config-merge.ts`) now defaults `Playbook.config.lessonPlanMode: "structured"` when a course-ref was uploaded OR existing authored modules are present, and the operator did not explicitly declare `pedagogy.lessonPlanMode`. Closes the IELTS-on-staging fingerprint: 5 authored modules + `lessonPlanMode` unset → admin Modules tab default-deny hid them. Companion to the in-flight UI defence PR (`fix/modules-tab-show-authored-modules-regardless-of-lesson-plan-mode`).

- Pipeline runtime contract (`lib/pipeline/course-style.ts` + 5 sibling read sites) — strict `=== "structured"` default-deny **unchanged**.
- Course-agnostic — applies to every wizard-created Playbook, not IELTS-specific.
- New `LessonPlanMode` type union + `isLessonPlanMode` runtime guard + `LESSON_PLAN_MODE_*` enum SET, all wired through the canonical chat-tool merge surface per `.claude/rules/wizard-enum-coverage.md`.
- `seed-ielts-course.ts` writes `lessonPlanMode: "structured"` explicitly so re-seeds set the field regardless of detector output.
- IELTS course-ref v2.3 fixture declares `**lessonPlanMode:** structured` in its Course shape block; new `STRUCTURED_PATTERNS` in `detect-pedagogy.ts` matches it.

## Verified by

**Lattice survey** (`.claude/rules/lattice-survey.md`):

- **Identified surface**: wizard `_*-config-merge.ts` + `seed-ielts-course.ts` + IELTS course-ref fixture + `detect-pedagogy.ts`. DB column: `Playbook.config.lessonPlanMode` (`"structured" | "continuous"` per `lib/types/json-fields.ts:464`).
- **Sibling writers mapped**: pipeline default-deny at `lib/pipeline/course-style.ts:42` (`config?.lessonPlanMode === "structured"`) + sibling read sites in `lib/pipeline/scheduler-presets.ts:255`, `lib/pipeline/adaptive-loop-invariants.ts:227`, `lib/enrollment/instantiate-module-progress.ts:7`, `components/modules-tab/CourseModulesTab.tsx:69`, `components/modules-tab/ModuleInspectorPanel.tsx:130`. ALL preserved unchanged — strict `=== "structured"` runtime contract intact.
- **Default-deny convention**: pipeline keeps strict equality (untouched). Wizard sets explicitly per-PR — no implicit runtime default. Convergence verified: pipeline + wizard agree that authored-module playbooks are "structured".
- **Rules read**:
  - `wizard-enum-coverage.md` — guard added per checklist §1–§7 in the same PR (canonical SET in `enum-sets.ts`, runtime guard in `resolve-config.ts`, merge paths wired, `PlaybookConfig.lessonPlanMode` already typed to the union pre-PR, FIELDS ratchet extended).
  - `spec-readonly-boundary.md` — `lessonPlanMode` is operator-tunable (NOT spec-readonly — not in `PARAMETER_SPEC_READONLY_FIELDS`).
  - `lattice-survey.md` Producer↔consumer pairing — wizard merge IS the producer of `Playbook.config.lessonPlanMode`; the 6 read sites listed above are the consumers — pairing intact.

**4-cell matrix outcome per merge path** (pinned by `tests/lib/chat/wizard-tool-executor/lesson-plan-mode-inference.test.ts`):

| Case | `pedagogy.lessonPlanMode` | modules / pedagogy presence | Expected `lessonPlanMode` | Result |
|---|---|---|---|---|
| A | `"structured"` | any | `"structured"` (explicit) | green |
| B | `"continuous"` | any | `"continuous"` (explicit) | green |
| C | `undefined` | modules-present or pedagogy-detected | `"structured"` (inferred) | green |
| D | `undefined` | no modules and no pedagogy | unset (preserved) | green |

**Tests** (all passing in worktree):

- `tests/lib/chat/wizard-tool-executor/lesson-plan-mode-inference.test.ts` — 17 vitests (4-cell matrix per merge path + isLessonPlanMode guard + detect-pedagogy STRUCTURED_PATTERNS regression), all green.
- `tests/lib/chat/wizard-enum-validation.test.ts` — 96 vitests (incl. new `lessonPlanMode` FIELDS row), all green.
- `tests/lib/wizard/fixture-type-coverage.test.ts` — 12 vitests, all green (fixture YAML still parses).
- `tests/lib/courses/courses-template-version-coverage.test.ts` — 6 vitests, all green.
- `tests/lib/wizard/source-ref-coverage.test.ts` — 10 vitests, all green (source-ref Coverage gate intact).
- `npx tsc --noEmit`: 42 errors (== baseline 42) — pre-push gate green. Zero new tsc errors on touched files.
- `npx eslint --quiet` on every touched file: clean.

**Pipeline regression check**: `lib/pipeline/course-style.ts`, `lib/pipeline/scheduler-presets.ts`, `lib/pipeline/adaptive-loop-invariants.ts`, `lib/enrollment/instantiate-module-progress.ts` — all unchanged in this PR. Confirmed via `git diff --stat HEAD~1` listing only the 8 wizard / seed / fixture / detector / test files.

**`tests/lib/wizard/detect-module-settings.test.ts` 1-failure**: pre-existing on `main` baseline (verified via `git stash` + retest); unrelated to this PR's surface (`silentMode` / `generateLessonPlan` / `pinFocusArea` warnings on baseline + part3 modules in the v2.3 fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)