### PR TITLE
UX-B: learner affordances pass — module-switch banner + post-call CTA

### DIFF
--- a/apps/admin/components/sim/ModuleSwitchLockBanner.tsx
+++ b/apps/admin/components/sim/ModuleSwitchLockBanner.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+/**
+ * ModuleSwitchLockBanner — UX-B B1 (learner affordances pass).
+ *
+ * Surfaces a learner-readable explanation when the active shell's
+ * capability map declares `allowModuleSwitch: false`. Pre-UX-B the
+ * picker was silently hidden — operators observed learners losing the
+ * affordance with no signal explaining WHY.
+ *
+ * Capability-driven by design (per `.claude/rules/learner-shell-selection.md`
+ * and `.claude/rules/learner-ui-leak-coverage.md`):
+ *
+ *  - Reads `allowModuleSwitch` + `modePillKey` from the typed frame.
+ *  - NO `.mode === "X"` branching. Every per-mode copy difference is
+ *    keyed off `modePillKey` (which is itself sourced from the
+ *    `SHELL_DEFAULTS` / `SHELL_CAPABILITY_OVERRIDES` tables).
+ *  - Copy is learner-safe — uses "assessment" / "mock exam" / "round"
+ *    / "session", never criterion names or internal slugs.
+ *
+ * Dismissable per-mount (local state). Persistence across navigation
+ * is a P2 polish — first ship gets local dismiss only.
+ *
+ * Surface lives ABOVE the dispatched shell in `SimChat.tsx::content`
+ * — it's a learner-facing affordance, not a per-shell variant.
+ */
+
+import { useState } from "react";
+import type { LearnerShellCapabilities } from "@/lib/types/json-fields";
+
+export interface ModuleSwitchLockBannerProps {
+  /** Frozen capability map from `resolveLearnerShell(...)`. */
+  capabilities: LearnerShellCapabilities;
+  /**
+   * Resolved shell kind. Used to pick learner-safe copy for shells
+   * whose `modePillKey` is null (e.g. results-readout) but still lock
+   * module switch — those fall through to the generic copy.
+   */
+  shellKind: string;
+}
+
+interface BannerCopy {
+  message: string;
+  /** Stable test/diagnostic id — never user-facing. */
+  variantId: string;
+}
+
+/**
+ * Pick learner-safe copy keyed on the typed capability frame. NO
+ * `.mode === "X"` branching — we read `modePillKey` + `shellKind`,
+ * both of which are HF-canonical capability-side identifiers, not
+ * mode-shape literals.
+ *
+ * Pure for test-ability — exported so the paired vitest can assert
+ * the matrix per cell without spinning up render harness.
+ */
+export function pickBannerCopy(
+  capabilities: LearnerShellCapabilities,
+  shellKind: string,
+): BannerCopy | null {
+  if (capabilities.allowModuleSwitch) return null;
+
+  // Per-shell + per-mode-pill copy. The pill key is the canonical
+  // capability-side identifier for the visual variant of the shell;
+  // SHELL_CAPABILITY_OVERRIDES drives it (exam-shell carries
+  // "examiner" for board-chair frame, "mock-exam" for full-mock).
+  if (shellKind === "exam" && capabilities.modePillKey === "examiner") {
+    return {
+      message: "Finish this assessment before switching modules.",
+      variantId: "exam-examiner",
+    };
+  }
+  if (shellKind === "exam" && capabilities.modePillKey === "mock-exam") {
+    return {
+      message: "Complete the mock exam to switch modules.",
+      variantId: "exam-mock-exam",
+    };
+  }
+  if (shellKind === "mcq-rounds") {
+    return {
+      message: "Complete this round before switching modules.",
+      variantId: "mcq-rounds",
+    };
+  }
+  // Generic fallback — any other shell whose capabilities lock the
+  // switch (today: results-readout sits in this bucket, plus any
+  // future shell variant).
+  return {
+    message: "This session must be completed before switching modules.",
+    variantId: "generic",
+  };
+}
+
+export function ModuleSwitchLockBanner({
+  capabilities,
+  shellKind,
+}: ModuleSwitchLockBannerProps) {
+  const [dismissed, setDismissed] = useState(false);
+  const copy = pickBannerCopy(capabilities, shellKind);
+
+  if (!copy || dismissed) return null;
+
+  return (
+    <div
+      className="hf-banner hf-banner-info"
+      role="status"
+      data-testid="module-switch-lock-banner"
+      data-variant={copy.variantId}
+    >
+      <span>{copy.message}</span>
+      <button
+        type="button"
+        className="hf-btn hf-btn-secondary"
+        onClick={() => setDismissed(true)}
+        aria-label="Dismiss"
+        data-testid="module-switch-lock-banner-dismiss"
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}

--- a/apps/admin/components/sim/PostCallCTA.tsx
+++ b/apps/admin/components/sim/PostCallCTA.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+/**
+ * PostCallCTA — UX-B B2 (learner affordances pass).
+ *
+ * Renders a single primary CTA after a call has ended. Choice of
+ * button text + navigation is driven by `capabilities.dismissOnEnd`
+ * from the typed `LearnerShellCapabilities` frame.
+ *
+ * Capability-driven by design — NO `.mode === "X"` branching. Every
+ * per-shell affordance difference reads from the typed cap map.
+ *
+ * Surface contract:
+ *  - `dismissOnEnd === "home"`         → "Back to home" → learner home
+ *  - `dismissOnEnd === "next-module"`  → "Next module"  → picker page
+ *  - `dismissOnEnd === "results-screen"` → no CTA rendered (the
+ *      ResultsReadoutShell overlay owns the post-call CTA for that
+ *      case; this component returns null to avoid double-CTA stacking).
+ *
+ * Secondary "Back to home" affordance is gated on
+ * `capabilities.allowBackToHome` AND only appears when the primary
+ * CTA is "Next module" (when primary already navigates home, no
+ * secondary needed).
+ *
+ * Pure for test-ability — `pickPrimaryCTA` is exported so the paired
+ * vitest can pin the matrix per cell.
+ */
+
+import { useRouter } from "next/navigation";
+import type { LearnerShellCapabilities } from "@/lib/types/json-fields";
+
+export interface PostCallCTAProps {
+  /** Frozen capability map from `resolveLearnerShell(...)`. */
+  capabilities: LearnerShellCapabilities;
+  /** Learner identity — used to compose the home route. */
+  callerId: string;
+  /** Optional course id — when present, "Next module" navigates to
+   *  the per-course picker; otherwise falls back to learner home. */
+  courseId?: string;
+}
+
+export type PrimaryCTAVariant =
+  | { kind: "back-to-home"; label: string }
+  | { kind: "next-module"; label: string }
+  | { kind: "results-owned"; label: null };
+
+/**
+ * Pure capability → CTA-variant resolver. Exported for tests.
+ */
+export function pickPrimaryCTA(
+  capabilities: LearnerShellCapabilities,
+): PrimaryCTAVariant {
+  switch (capabilities.dismissOnEnd) {
+    case "home":
+      return { kind: "back-to-home", label: "Back to home" };
+    case "next-module":
+      return { kind: "next-module", label: "Next module" };
+    case "results-screen":
+      return { kind: "results-owned", label: null };
+    default: {
+      // Exhaustiveness — TypeScript will fire if `dismissOnEnd`
+      // gains a new value without updating this switch.
+      const exhaustive: never = capabilities.dismissOnEnd;
+      throw new Error(`Unhandled dismissOnEnd: ${String(exhaustive)}`);
+    }
+  }
+}
+
+export function PostCallCTA({
+  capabilities,
+  callerId,
+  courseId,
+}: PostCallCTAProps) {
+  const router = useRouter();
+  const primary = pickPrimaryCTA(capabilities);
+
+  if (primary.kind === "results-owned") return null;
+
+  const homeRoute = `/x/student/${encodeURIComponent(callerId)}`;
+  const pickerRoute = courseId
+    ? `/x/student/${encodeURIComponent(courseId)}/modules`
+    : homeRoute;
+
+  const onPrimaryClick = () => {
+    if (primary.kind === "back-to-home") {
+      router.push(homeRoute);
+      return;
+    }
+    router.push(pickerRoute);
+  };
+
+  // Secondary "Back to home" only when primary is "Next module" and
+  // capabilities allow it.
+  const showSecondary =
+    primary.kind === "next-module" && capabilities.allowBackToHome;
+
+  return (
+    <div
+      className="hf-card"
+      data-testid="post-call-cta"
+      data-variant={primary.kind}
+    >
+      <button
+        type="button"
+        className="hf-btn hf-btn-primary"
+        onClick={onPrimaryClick}
+        data-testid="post-call-cta-primary"
+      >
+        {primary.label}
+      </button>
+      {showSecondary ? (
+        <button
+          type="button"
+          className="hf-btn hf-btn-secondary"
+          onClick={() => router.push(homeRoute)}
+          data-testid="post-call-cta-secondary"
+        >
+          Back to home
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/admin/components/sim/SimChat.tsx
+++ b/apps/admin/components/sim/SimChat.tsx
@@ -21,6 +21,8 @@ import {
   ResultsReadoutShell,
   type ResultsReadoutPayload,
 } from './ResultsReadoutShell';
+import { ModuleSwitchLockBanner } from './ModuleSwitchLockBanner';
+import { PostCallCTA } from './PostCallCTA';
 import { resolveLearnerShell } from '@/lib/voice/resolve-learner-shell';
 import type { AuthoredModuleMode } from '@/lib/types/json-fields';
 import { useProviderCall } from './useProviderCall';
@@ -1484,6 +1486,16 @@ export function SimChat({
         liveBubblesMode={liveBubblesMode}
       />
 
+      {/* UX-B B1 — module-switch lock banner. Capability-driven: reads
+          `allowModuleSwitch` + `modePillKey` from the resolved frame.
+          NO `.mode === "X"` branching here — every per-variant copy
+          difference is keyed off the typed capability map. Silent when
+          `allowModuleSwitch: true`. */}
+      <ModuleSwitchLockBanner
+        capabilities={resolvedCapabilities}
+        shellKind={resolvedShellKind}
+      />
+
       {/* Messages */}
       <div
         ref={scrollContainerRef}
@@ -2082,6 +2094,20 @@ export function SimChat({
               </button>
             )}
           </div>
+        )}
+
+        {/* UX-B B2 — exit/navigate CTA. Capability-driven: button text +
+            destination come from `capabilities.dismissOnEnd`. NULL when
+            `dismissOnEnd === "results-screen"` (ResultsReadoutShell owns
+            the post-call CTA in that case). Sits below "Up next" so the
+            iteration loop (same-module restart) stays the lead action;
+            this surfaces the exit / next-module path. */}
+        {callPhase === 'ended' && (
+          <PostCallCTA
+            capabilities={resolvedCapabilities}
+            callerId={callerId}
+            courseId={playbookId}
+          />
         )}
 
         {/* #1098 Slice C — Qualification readiness recap after the call settles.

--- a/apps/admin/tests/components/sim/ModuleSwitchLockBanner.test.tsx
+++ b/apps/admin/tests/components/sim/ModuleSwitchLockBanner.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * Tests for ModuleSwitchLockBanner (UX-B B1 of learner affordances pass).
+ *
+ * Pinned acceptance:
+ *  1. Silent when `allowModuleSwitch: true`.
+ *  2. Per (shellKind, modePillKey) cells render the learner-safe copy
+ *     declared in the pickBannerCopy matrix.
+ *  3. Generic fallback when `allowModuleSwitch: false` but no specific
+ *     cell matches.
+ *  4. Dismiss removes the banner from the DOM.
+ *  5. Copy never includes internal criterion labels.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+
+import {
+  ModuleSwitchLockBanner,
+  pickBannerCopy,
+} from "@/components/sim/ModuleSwitchLockBanner";
+import {
+  SHELL_DEFAULTS,
+  type LearnerShellCapabilities,
+} from "@/lib/types/json-fields";
+
+afterEach(() => {
+  cleanup();
+});
+
+const chatFeedCaps = SHELL_DEFAULTS["chat-feed"];
+const examMockExamCaps = SHELL_DEFAULTS["exam"]; // modePillKey = "mock-exam"
+const examExaminerCaps: LearnerShellCapabilities = {
+  ...SHELL_DEFAULTS["exam"],
+  modePillKey: "examiner",
+};
+const mcqRoundsCaps = SHELL_DEFAULTS["mcq-rounds"];
+const resultsReadoutCaps = SHELL_DEFAULTS["results-readout"];
+
+describe("pickBannerCopy", () => {
+  it("returns null when allowModuleSwitch is true", () => {
+    expect(pickBannerCopy(chatFeedCaps, "chat-feed")).toBeNull();
+  });
+
+  it("returns examiner copy for exam shell + modePillKey=examiner", () => {
+    const copy = pickBannerCopy(examExaminerCaps, "exam");
+    expect(copy).not.toBeNull();
+    expect(copy?.variantId).toBe("exam-examiner");
+    expect(copy?.message).toMatch(/assessment/i);
+  });
+
+  it("returns mock-exam copy for exam shell + modePillKey=mock-exam", () => {
+    const copy = pickBannerCopy(examMockExamCaps, "exam");
+    expect(copy).not.toBeNull();
+    expect(copy?.variantId).toBe("exam-mock-exam");
+    expect(copy?.message).toMatch(/mock exam/i);
+  });
+
+  it("returns mcq-rounds copy for mcq-rounds shell", () => {
+    const copy = pickBannerCopy(mcqRoundsCaps, "mcq-rounds");
+    expect(copy).not.toBeNull();
+    expect(copy?.variantId).toBe("mcq-rounds");
+    expect(copy?.message).toMatch(/round/i);
+  });
+
+  it("returns generic copy for other locked shells (results-readout)", () => {
+    const copy = pickBannerCopy(resultsReadoutCaps, "results-readout");
+    expect(copy).not.toBeNull();
+    expect(copy?.variantId).toBe("generic");
+    expect(copy?.message).toMatch(/session/i);
+  });
+
+  it("learner-safe copy never carries criterion labels", () => {
+    const internalLabels = [
+      "Fluency and Coherence",
+      "Lexical Resource",
+      "Grammatical Range and Accuracy",
+      "Pronunciation",
+    ];
+    const messages = [
+      pickBannerCopy(examExaminerCaps, "exam")?.message,
+      pickBannerCopy(examMockExamCaps, "exam")?.message,
+      pickBannerCopy(mcqRoundsCaps, "mcq-rounds")?.message,
+      pickBannerCopy(resultsReadoutCaps, "results-readout")?.message,
+    ];
+    for (const m of messages) {
+      expect(m).toBeDefined();
+      for (const label of internalLabels) {
+        expect(m).not.toContain(label);
+      }
+    }
+  });
+});
+
+describe("ModuleSwitchLockBanner — render", () => {
+  it("renders nothing when allowModuleSwitch is true", () => {
+    const { container } = render(
+      <ModuleSwitchLockBanner
+        capabilities={chatFeedCaps}
+        shellKind="chat-feed"
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders examiner copy", () => {
+    render(
+      <ModuleSwitchLockBanner
+        capabilities={examExaminerCaps}
+        shellKind="exam"
+      />,
+    );
+    const banner = screen.getByTestId("module-switch-lock-banner");
+    expect(banner.getAttribute("data-variant")).toBe("exam-examiner");
+    expect(banner.textContent).toMatch(/Finish this assessment/);
+  });
+
+  it("renders mock-exam copy", () => {
+    render(
+      <ModuleSwitchLockBanner
+        capabilities={examMockExamCaps}
+        shellKind="exam"
+      />,
+    );
+    const banner = screen.getByTestId("module-switch-lock-banner");
+    expect(banner.getAttribute("data-variant")).toBe("exam-mock-exam");
+    expect(banner.textContent).toMatch(/mock exam/i);
+  });
+
+  it("renders mcq-rounds copy", () => {
+    render(
+      <ModuleSwitchLockBanner
+        capabilities={mcqRoundsCaps}
+        shellKind="mcq-rounds"
+      />,
+    );
+    const banner = screen.getByTestId("module-switch-lock-banner");
+    expect(banner.getAttribute("data-variant")).toBe("mcq-rounds");
+    expect(banner.textContent).toMatch(/round/i);
+  });
+
+  it("renders generic copy fallback", () => {
+    render(
+      <ModuleSwitchLockBanner
+        capabilities={resultsReadoutCaps}
+        shellKind="results-readout"
+      />,
+    );
+    const banner = screen.getByTestId("module-switch-lock-banner");
+    expect(banner.getAttribute("data-variant")).toBe("generic");
+  });
+
+  it("dismiss button removes the banner from the DOM", () => {
+    render(
+      <ModuleSwitchLockBanner
+        capabilities={examExaminerCaps}
+        shellKind="exam"
+      />,
+    );
+    expect(screen.queryByTestId("module-switch-lock-banner")).not.toBeNull();
+    fireEvent.click(screen.getByTestId("module-switch-lock-banner-dismiss"));
+    expect(screen.queryByTestId("module-switch-lock-banner")).toBeNull();
+  });
+
+  it("uses hf-banner classes (UI design system compliance)", () => {
+    render(
+      <ModuleSwitchLockBanner
+        capabilities={examExaminerCaps}
+        shellKind="exam"
+      />,
+    );
+    const banner = screen.getByTestId("module-switch-lock-banner");
+    expect(banner.className).toContain("hf-banner");
+    expect(banner.className).toContain("hf-banner-info");
+  });
+});

--- a/apps/admin/tests/components/sim/PostCallCTA.test.tsx
+++ b/apps/admin/tests/components/sim/PostCallCTA.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * Tests for PostCallCTA (UX-B B2 of learner affordances pass).
+ *
+ * Pinned acceptance:
+ *  1. `dismissOnEnd === "home"` → primary "Back to home" button.
+ *  2. `dismissOnEnd === "next-module"` → primary "Next module" button.
+ *  3. `dismissOnEnd === "results-screen"` → no CTA (ResultsReadoutShell
+ *     owns the post-call CTA in that case).
+ *  4. Secondary "Back to home" appears only when primary is "Next module"
+ *     AND `allowBackToHome: true`.
+ *  5. Primary click navigates to the matching route.
+ *  6. The `pickPrimaryCTA` pure resolver matches the matrix.
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+
+import {
+  PostCallCTA,
+  pickPrimaryCTA,
+} from "@/components/sim/PostCallCTA";
+import {
+  SHELL_DEFAULTS,
+  type LearnerShellCapabilities,
+} from "@/lib/types/json-fields";
+
+// Override the global useRouter mock so we can assert pushes per test.
+const pushMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: pushMock,
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useParams: () => ({}),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+afterEach(() => {
+  cleanup();
+  pushMock.mockClear();
+});
+
+// Reference capability frames from canonical SHELL_DEFAULTS.
+const chatFeedCaps = SHELL_DEFAULTS["chat-feed"]; // dismissOnEnd: "home"
+const examCaps = SHELL_DEFAULTS["exam"]; // dismissOnEnd: "results-screen"
+const mcqRoundsCaps = SHELL_DEFAULTS["mcq-rounds"]; // dismissOnEnd: "home"
+const resultsReadoutCaps = SHELL_DEFAULTS["results-readout"]; // dismissOnEnd: "next-module"
+
+// Synthetic frames for testing the secondary "Back to home" gate.
+// SHELL_DEFAULTS["results-readout"] has allowBackToHome=false; we
+// synthesise a true variant to pin the positive path, and a false
+// variant to pin suppression.
+const nextModuleWithHomeCaps: LearnerShellCapabilities = {
+  ...resultsReadoutCaps,
+  allowBackToHome: true,
+};
+const nextModuleNoHomeCaps: LearnerShellCapabilities = {
+  ...resultsReadoutCaps,
+  allowBackToHome: false,
+};
+
+describe("pickPrimaryCTA", () => {
+  it("returns back-to-home for dismissOnEnd=home", () => {
+    expect(pickPrimaryCTA(chatFeedCaps)).toEqual({
+      kind: "back-to-home",
+      label: "Back to home",
+    });
+  });
+
+  it("returns next-module for dismissOnEnd=next-module", () => {
+    expect(pickPrimaryCTA(resultsReadoutCaps)).toEqual({
+      kind: "next-module",
+      label: "Next module",
+    });
+  });
+
+  it("returns results-owned (null CTA) for dismissOnEnd=results-screen", () => {
+    expect(pickPrimaryCTA(examCaps)).toEqual({
+      kind: "results-owned",
+      label: null,
+    });
+  });
+});
+
+describe("PostCallCTA — render", () => {
+  it("renders Back to home for chat-feed default", () => {
+    render(
+      <PostCallCTA
+        capabilities={chatFeedCaps}
+        callerId="cl_test_1"
+        courseId="course-1"
+      />,
+    );
+    const cta = screen.getByTestId("post-call-cta");
+    expect(cta.getAttribute("data-variant")).toBe("back-to-home");
+    expect(screen.getByTestId("post-call-cta-primary").textContent).toBe(
+      "Back to home",
+    );
+    // Primary is the lead — no secondary when primary IS back-to-home.
+    expect(screen.queryByTestId("post-call-cta-secondary")).toBeNull();
+  });
+
+  it("renders Next module for results-readout default", () => {
+    render(
+      <PostCallCTA
+        capabilities={resultsReadoutCaps}
+        callerId="cl_test_2"
+        courseId="course-2"
+      />,
+    );
+    const cta = screen.getByTestId("post-call-cta");
+    expect(cta.getAttribute("data-variant")).toBe("next-module");
+    expect(screen.getByTestId("post-call-cta-primary").textContent).toBe(
+      "Next module",
+    );
+  });
+
+  it("renders nothing for dismissOnEnd=results-screen (exam shell)", () => {
+    const { container } = render(
+      <PostCallCTA
+        capabilities={examCaps}
+        callerId="cl_test_3"
+        courseId="course-3"
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders Back to home for mcq-rounds default", () => {
+    render(
+      <PostCallCTA
+        capabilities={mcqRoundsCaps}
+        callerId="cl_test_4"
+        courseId="course-4"
+      />,
+    );
+    expect(screen.getByTestId("post-call-cta-primary").textContent).toBe(
+      "Back to home",
+    );
+  });
+
+  it("renders secondary Back to home for next-module + allowBackToHome", () => {
+    // SHELL_DEFAULTS["results-readout"] sets allowBackToHome=false,
+    // so a synthetic true-variant pins the positive secondary path.
+    render(
+      <PostCallCTA
+        capabilities={nextModuleWithHomeCaps}
+        callerId="cl_test_5"
+        courseId="course-5"
+      />,
+    );
+    const secondary = screen.getByTestId("post-call-cta-secondary");
+    expect(secondary.textContent).toBe("Back to home");
+  });
+
+  it("suppresses secondary when allowBackToHome=false", () => {
+    render(
+      <PostCallCTA
+        capabilities={nextModuleNoHomeCaps}
+        callerId="cl_test_6"
+        courseId="course-6"
+      />,
+    );
+    expect(screen.queryByTestId("post-call-cta-secondary")).toBeNull();
+  });
+
+  it("primary click pushes the home route for dismissOnEnd=home", () => {
+    render(
+      <PostCallCTA capabilities={chatFeedCaps} callerId="cl_z_home" />,
+    );
+    fireEvent.click(screen.getByTestId("post-call-cta-primary"));
+    expect(pushMock).toHaveBeenCalledWith("/x/student/cl_z_home");
+  });
+
+  it("primary click pushes the modules route for dismissOnEnd=next-module", () => {
+    render(
+      <PostCallCTA
+        capabilities={resultsReadoutCaps}
+        callerId="cl_z_next"
+        courseId="course-z"
+      />,
+    );
+    fireEvent.click(screen.getByTestId("post-call-cta-primary"));
+    expect(pushMock).toHaveBeenCalledWith("/x/student/course-z/modules");
+  });
+
+  it("falls back to home route when courseId missing on next-module", () => {
+    render(
+      <PostCallCTA
+        capabilities={resultsReadoutCaps}
+        callerId="cl_z_fallback"
+      />,
+    );
+    fireEvent.click(screen.getByTestId("post-call-cta-primary"));
+    expect(pushMock).toHaveBeenCalledWith("/x/student/cl_z_fallback");
+  });
+});


### PR DESCRIPTION
## Summary

Closes findings 4 + 5 from today's Learner UX audit. Capability-driven affordances surface inside SimChat for the two pre-UX-B silent UX gaps.

- **B1 (Finding 4) — Module-switch denial banner.** When `capabilities.allowModuleSwitch === false`, the picker stays hidden (B3 unchanged) and a learner-readable banner explains WHY. Copy keyed off `(shellKind, modePillKey)` per the typed capability frame — never the raw mode literal. Dismissable per-mount.
- **B2 (Finding 5) — Post-call CTA.** Primary button text + navigation come from `capabilities.dismissOnEnd`:

  | dismissOnEnd | Primary CTA | Destination |
  |---|---|---|
  | `home` | "Back to home" | `/x/student/<callerId>` |
  | `next-module` | "Next module" | `/x/student/<courseId>/modules` |
  | `results-screen` | (null — ResultsReadoutShell owns it) | — |

  Secondary "Back to home" appears only when primary is "Next module" AND `allowBackToHome: true`.
- **B3 — Picker visibility.** Unchanged. The new banner is the explanation surface.

The existing "Up next" same-module restart card stays — it's a different verb (continue here) from the new CTA (exit / navigate away).

## Capability-driven affordance matrix

| Shell | dismissOnEnd | allowModuleSwitch | Banner variant | Primary CTA | Secondary |
|---|---|---|---|---|---|
| `chat-feed` (tutor / mixed) | `home` | `true` | none | "Back to home" | none |
| `exam` + `modePillKey=examiner` | `results-screen` | `false` | exam-examiner | (null — Results owns) | n/a |
| `exam` + `modePillKey=mock-exam` | `results-screen` | `false` | exam-mock-exam | (null — Results owns) | n/a |
| `mcq-rounds` (quiz) | `home` | `false` | mcq-rounds | "Back to home" | none |
| `results-readout` | `next-module` | `false` | generic | "Next module" | (gated on allowBackToHome) |

## Verified by

- **Lattice survey** (per `.claude/rules/lattice-survey.md`): capability-driven; reads `LearnerShellCapabilities` from `resolveLearnerShell(...)`; no `.mode === "X"` JSX branching; no internal-label leak. Banner copy is learner-safe ("assessment" / "mock exam" / "round" / "session").
- **Tests**: 25 cells across 2 new test files (13 banner + 12 CTA), all green.
  - `apps/admin/tests/components/sim/ModuleSwitchLockBanner.test.tsx` — 5 banner variants × pickBannerCopy resolver + render + dismiss + leak-clean assertion + design-system classes.
  - `apps/admin/tests/components/sim/PostCallCTA.test.tsx` — 3 dismissOnEnd cells × pickPrimaryCTA + render variants + secondary gate + router push assertions.
- **Coverage ratchets**: all green, no movement.
  - `mode-ui-coverage.test.ts` — 8/8 pass, gap-count stays at 0.
  - `learner-ui-leak-coverage.test.ts` — 11/11 pass, no new leaks.
  - `shell-coverage.test.ts` — 9/9 pass, no shell additions.
  - Full sim sweep: 104/104 pass (`tests/components/sim/`).
- **tsc / lint**: tsc baseline unchanged at 42 errors (zero new). ESLint clean on changed files (5 lint warnings on SimChat.tsx are pre-existing, none from this PR).
- **Survey cross-check**: PR #2227 (pinned-card collapse) — separate surface, no conflict. `dismissOnEnd` is a typed union with no nullable — default-deny path is safe.

## Don't violations check

- [x] **NO HARDCODINGS** — banner copy keyed off capability flags + `modePillKey`; CTA keyed off `dismissOnEnd`. No course names.
- [x] **NO INTERNAL LEAKS** — banner copy is learner-safe; test explicitly asserts no criterion labels.
- [x] **NO MODE-LITERAL JSX BRANCHING** — only `capabilities.*` reads + `shellKind` from resolver.
- [x] **CAPABILITY-DRIVEN** — all per-shell variation reads from the typed `LearnerShellCapabilities` frame.

## Test plan

- [ ] Spin up a tutor session — confirm no banner; post-call "Back to home" appears.
- [ ] Spin up an IELTS examiner / mock-exam terminal session — confirm banner shows "Finish this assessment…" / "Complete the mock exam…", picker stays hidden.
- [ ] Confirm post-call on a Mock session: ResultsReadoutShell owns the CTA, PostCallCTA returns null (no double-CTA stacking).
- [ ] Spin up a CIO/CTO Pop Quiz session — confirm banner shows "Complete this round…".

🤖 Generated with [Claude Code](https://claude.com/claude-code)