### PR TITLE
feat(sim): W4 — wire MCQRoundsShell to canonical sampling engine

### DIFF
--- a/apps/admin/app/api/callers/[callerId]/assessment-moment-mcqs/route.ts
+++ b/apps/admin/app/api/callers/[callerId]/assessment-moment-mcqs/route.ts
@@ -1,0 +1,253 @@
+/**
+ * @api GET /api/callers/:callerId/assessment-moment-mcqs?moduleSlug=…
+ * @visibility public
+ * @scope callers:read
+ * @auth session (VIEWER+ — STUDENT scoped to own caller)
+ * @tags callers, assessment
+ * @description W4 of `memory/handoff_lattice_all_settings_to_ui_2026_06_21.md` —
+ *   resolves the `MCQRoundsShell` data feed for a quiz-mode session.
+ *
+ *   Reads the caller's active Playbook → `config.assessmentPlan` →
+ *   locates the `AssessmentMoment` whose `moduleSlug` matches the
+ *   supplied `moduleSlug` (upfront / midpoints[] / end). If a matching
+ *   moment exists, materialises it via the canonical sampling engine
+ *   at `lib/assessment/sample-questions.ts::sampleQuestionsForMoment`
+ *   (PR #2180 — epic #2176 S2).
+ *
+ *   Course-agnostic by construction — the route does NOT branch on
+ *   course, mode literal, or playbook id. The engine reads the
+ *   declarative plan; this route is the HTTP boundary.
+ *
+ *   **NO FAKE FALLBACKS** (operator-pinned, per
+ *   `feedback_no_hardcoded_score_backfill.md`):
+ *   - No matching `AssessmentMoment` → `{ ok: true, result: null, reason: "no-moment" }`
+ *   - Engine returns `empty-pool` / `missing-content` / `policy-unsatisfied`
+ *     → `{ ok: true, result: null, reason: "<engine-reason>" }`
+ *   - The shell consumes the null-result + reason and renders the
+ *     empty-state — never synthesises MCQs.
+ *
+ *   The engine fires its own AppLog subjects (`assessment.sample.empty_pool`,
+ *   `assessment.sample.missing_content`, `assessment.sample.policy_unsatisfied`)
+ *   on failure paths — the route adds an `assessment.moment.no_match`
+ *   subject when the plan is absent OR no moment cites the supplied slug.
+ *
+ *   **STUDENT scoping** — gated by `requireAuth("VIEWER")` +
+ *   `studentAllowedToReadCaller` so a STUDENT can ONLY read their own
+ *   caller's assessment feed (per `lib/learner-scope.ts`).
+ *
+ * @pathParam callerId string - Caller.id
+ * @queryParam moduleSlug string - AuthoredModule.id (the module currently rendering)
+ * @response 200 {ok: true, result: AssessmentMomentMCQsPayload | null, reason?: string}
+ * @response 400 {ok: false, error: string}
+ * @response 403 {ok: false, error: string}
+ * @response 500 {ok: false, error: string}
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, isAuthError } from "@/lib/permissions";
+import {
+  studentAllowedToReadCaller,
+  callerScopeMismatchResponse,
+} from "@/lib/learner-scope";
+import { log } from "@/lib/logger";
+import { sampleQuestionsForMoment } from "@/lib/assessment/sample-questions";
+import type {
+  AssessmentMoment,
+  CourseAssessmentPlan,
+  PlaybookConfig,
+} from "@/lib/types/json-fields";
+
+const QuerySchema = z.object({
+  moduleSlug: z.string().min(1, "moduleSlug query param is required"),
+});
+
+/**
+ * Public response shape consumed by `useAssessmentMomentMCQs` +
+ * `MCQRoundsShell`. Narrow projection — only fields the learner UI
+ * renders or the host needs for round progression.
+ */
+export interface AssessmentMomentMCQsPayload {
+  /** The kind of assessment moment that resolved (drives shell copy / pill). */
+  momentKind: AssessmentMoment["kind"];
+  /** The slug of the module hosting this moment (echoed for sanity). */
+  moduleSlug: string;
+  /** Whether per-question feedback should be shown after each answer
+   *  vs. held to round-end. Today we default to immediate; future:
+   *  drive from `AssessmentMoment.feedbackMode` once the type carries
+   *  that field. */
+  feedbackMode: "immediate" | "round-end";
+  /** Ordered, sampled MCQs to present this round. */
+  mcqs: ReadonlyArray<{
+    id: string;
+    questionText: string;
+    /** Operator-authored options. Engine returns `unknown`; we narrow
+     *  here when shape matches `{ label, text }[]`. */
+    options: Array<{ label: string; text: string }> | null;
+  }>;
+}
+
+export type AssessmentMomentNullReason =
+  | "no-moment"
+  | "empty-pool"
+  | "missing-content"
+  | "policy-unsatisfied";
+
+function narrowOptions(
+  raw: unknown,
+): Array<{ label: string; text: string }> | null {
+  if (!Array.isArray(raw)) return null;
+  const out: Array<{ label: string; text: string }> = [];
+  for (const entry of raw) {
+    if (
+      entry &&
+      typeof entry === "object" &&
+      "label" in entry &&
+      "text" in entry &&
+      typeof (entry as { label: unknown }).label === "string" &&
+      typeof (entry as { text: unknown }).text === "string"
+    ) {
+      out.push({
+        label: (entry as { label: string }).label,
+        text: (entry as { text: string }).text,
+      });
+    }
+  }
+  return out.length > 0 ? out : null;
+}
+
+function findMomentByModuleSlug(
+  plan: CourseAssessmentPlan,
+  moduleSlug: string,
+): AssessmentMoment | null {
+  if (plan.upfront?.moduleSlug === moduleSlug) return plan.upfront;
+  if (plan.end?.moduleSlug === moduleSlug) return plan.end;
+  for (const mid of plan.midpoints ?? []) {
+    if (mid.moduleSlug === moduleSlug) return mid;
+  }
+  return null;
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ callerId: string }> },
+): Promise<NextResponse> {
+  try {
+    const authResult = await requireAuth("VIEWER");
+    if (isAuthError(authResult)) return authResult.error;
+
+    const { callerId } = await params;
+    if (!studentAllowedToReadCaller(authResult.session, callerId)) {
+      return callerScopeMismatchResponse();
+    }
+
+    const rawSlug = req.nextUrl.searchParams.get("moduleSlug") ?? undefined;
+    const parsed = QuerySchema.safeParse({ moduleSlug: rawSlug });
+    if (!parsed.success) {
+      return NextResponse.json(
+        { ok: false, error: "moduleSlug query param is required" },
+        { status: 400 },
+      );
+    }
+    const { moduleSlug } = parsed.data;
+
+    // Resolve caller's active enrollment → playbook (+ config). Mirrors the
+    // same path `exam-mode-check/route.ts` takes (active CallerPlaybook,
+    // most-recent enrollment).
+    const enrollment = await prisma.callerPlaybook.findFirst({
+      where: { callerId, status: "ACTIVE" },
+      orderBy: { enrolledAt: "desc" },
+      select: {
+        playbook: {
+          select: {
+            id: true,
+            config: true,
+          },
+        },
+      },
+    });
+
+    if (!enrollment?.playbook) {
+      log("system", "assessment.moment.no_match", {
+        level: "info",
+        message: "no active enrollment for caller — no assessment plan to read",
+        callerId,
+        moduleSlug,
+      });
+      return NextResponse.json({ ok: true, result: null, reason: "no-moment" });
+    }
+
+    const playbookId = enrollment.playbook.id;
+    const config = (enrollment.playbook.config ?? null) as PlaybookConfig | null;
+    const plan = config?.assessmentPlan ?? null;
+
+    if (!plan || plan.noAssessmentPlan === true) {
+      log("system", "assessment.moment.no_match", {
+        level: "info",
+        message: plan
+          ? "playbook declares noAssessmentPlan:true"
+          : "no assessmentPlan on Playbook.config",
+        callerId,
+        moduleSlug,
+        playbookId,
+      });
+      return NextResponse.json({ ok: true, result: null, reason: "no-moment" });
+    }
+
+    const moment = findMomentByModuleSlug(plan, moduleSlug);
+    if (!moment) {
+      log("system", "assessment.moment.no_match", {
+        level: "info",
+        message: "no AssessmentMoment cites the supplied moduleSlug",
+        callerId,
+        moduleSlug,
+        playbookId,
+      });
+      return NextResponse.json({ ok: true, result: null, reason: "no-moment" });
+    }
+
+    // Materialise the moment via the canonical sampling engine. The
+    // engine writes its own AppLog subjects on failure paths.
+    const sampled = await sampleQuestionsForMoment({
+      plan,
+      moment,
+      playbookId,
+      callerId,
+    });
+
+    if (!sampled.ok) {
+      return NextResponse.json({
+        ok: true,
+        result: null,
+        reason: sampled.reason,
+      });
+    }
+
+    const payload: AssessmentMomentMCQsPayload = {
+      momentKind: moment.kind,
+      moduleSlug,
+      // AssessmentMoment doesn't yet carry feedbackMode; default to
+      // "immediate" for MCQ rounds. Operator can revisit when the type
+      // adds the field; today the shell defaults match learner-pinned
+      // per-question feedback for popquiz / midpoint-check.
+      feedbackMode: "immediate",
+      mcqs: sampled.questions.map((q) => ({
+        id: q.id,
+        questionText: q.questionText,
+        options: narrowOptions(q.options),
+      })),
+    };
+
+    return NextResponse.json({ ok: true, result: payload });
+  } catch (err) {
+    console.error(
+      "[/api/callers/[callerId]/assessment-moment-mcqs] error",
+      err,
+    );
+    return NextResponse.json(
+      { ok: false, error: "Failed to resolve assessment moment MCQs" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/admin/components/sim/MCQRoundsShell.tsx
+++ b/apps/admin/components/sim/MCQRoundsShell.tsx
@@ -26,9 +26,14 @@
  *  - `allowModuleSwitch: false` / `allowBackToHome: false` — in-flight
  *    quiz must finish
  *
- * **MCQ data feed is stubbed** — `mcqs` is accepted as a prop today.
- * The full per-question feedback flow + answer submission lifecycle
- * lands in #2180 (sampling engine + question-presentation lifecycle).
+ * **W4 (epic #2163 closeout) — MCQ data feed live.** The shell now
+ * renders selectable options + an empty-state when no MCQs resolve.
+ * Data flows from the canonical sampling engine
+ * (`lib/assessment/sample-questions.ts`) via the
+ * `useAssessmentMomentMCQs` hook in the host (`SimChat`). Per
+ * `feedback_no_hardcoded_score_backfill.md` we NEVER synthesise MCQs
+ * — empty pool / missing plan renders the typed empty-state with the
+ * `emptyReason` prop driving copy.
  *
  * Closes #2159 quiz.learnerUI at the shell level. Coverage assertion
  * at `tests/components/sim/learner-shells.test.tsx`.
@@ -53,17 +58,25 @@ export interface MCQShellQuestion {
   options?: Array<{ label: string; text: string }> | null;
 }
 
+/** Typed reason an MCQRoundsShell renders the empty-state instead of
+ *  a cue card. Mirrors `AssessmentMomentNullReason` from the route. */
+export type MCQRoundsEmptyReason =
+  | "no-moment"
+  | "empty-pool"
+  | "missing-content"
+  | "policy-unsatisfied"
+  | "loading"
+  | "error";
+
 interface MCQRoundsShellProps {
   /** Capability frame. Defaults to `SHELL_DEFAULTS["mcq-rounds"]` so
    *  the shell renders the canonical quiz frame out of the box. */
   capabilities?: LearnerShellCapabilities;
-  /** Sampled MCQs to present this round. Stubbed today — once #2180
-   *  ships the sampling engine, the host page resolves this from the
-   *  AssessmentMoment + samplingPolicy. */
-  mcqs?: MCQShellQuestion[];
-  /** Current 1-based round index (e.g. 3 of 8). Stubbed today. */
+  /** Sampled MCQs to present this round. Empty array → empty-state. */
+  mcqs?: ReadonlyArray<MCQShellQuestion>;
+  /** Current 1-based round index (e.g. 3 of 8). */
   roundIndex?: number;
-  /** Total rounds. Stubbed today. */
+  /** Total rounds. */
   roundTotal?: number;
   /** Whether the close screen scaffold should render
    *  (`endedAt !== null` from the host). */
@@ -71,9 +84,53 @@ interface MCQRoundsShellProps {
   /** Per-Q feedback area — text or node rendered after the learner
    *  submits an answer. Stubbed today. */
   feedback?: React.ReactNode;
+  /** The option label the learner has selected (e.g. "A"). When set,
+   *  the matching `<li>` carries `data-selected="true"` and an
+   *  `aria-pressed="true"` attribute. */
+  selectedOption?: string | null;
+  /** Invoked when the learner picks an option. Receives `(mcqId,
+   *  optionLabel)`. The host (SimChat) advances the round and writes
+   *  the result via the canonical writer (or stub). */
+  onAnswer?: (mcqId: string, optionLabel: string) => void;
+  /** When `mcqs.length === 0` the shell renders the empty-state. This
+   *  prop drives the empty-state copy. `"loading"` / `"error"` are
+   *  transient host states; the other values mirror the typed reasons
+   *  from the canonical engine (see `lib/assessment/sample-questions.ts`). */
+  emptyReason?: MCQRoundsEmptyReason | null;
   /** Child controls (e.g. answer-submit, dismiss, etc.). */
   children?: React.ReactNode;
 }
+
+const EMPTY_REASON_COPY: Record<MCQRoundsEmptyReason, { title: string; detail: string }> = {
+  loading: {
+    title: "Loading questions…",
+    detail: "Pulling your next round from the question pool.",
+  },
+  "no-moment": {
+    title: "No quiz available for this module",
+    detail:
+      "This course doesn't declare a quiz round for the current module. Ask your educator to add an assessment plan.",
+  },
+  "empty-pool": {
+    title: "No questions available yet",
+    detail:
+      "The question pool for this module is empty. Your educator will add content soon.",
+  },
+  "missing-content": {
+    title: "Question pool not configured",
+    detail:
+      "This quiz needs a different kind of content. Ask your educator to review the assessment plan.",
+  },
+  "policy-unsatisfied": {
+    title: "Not enough questions for this round",
+    detail:
+      "The current pool can't satisfy this round's sampling rules. Your educator will adjust the content.",
+  },
+  error: {
+    title: "Couldn't load questions",
+    detail: "There was a problem reaching the question pool. Please try again shortly.",
+  },
+};
 
 export function MCQRoundsShell({
   capabilities = SHELL_DEFAULTS["mcq-rounds"],
@@ -82,9 +139,19 @@ export function MCQRoundsShell({
   roundTotal,
   ended = false,
   feedback,
+  selectedOption,
+  onAnswer,
+  emptyReason,
   children,
 }: MCQRoundsShellProps) {
   const currentMcq = mcqs[(roundIndex ?? 1) - 1] ?? null;
+  const showEmptyState =
+    capabilities.chatFeedVisibility === "cue-card-only" &&
+    !currentMcq &&
+    !ended;
+  const resolvedEmptyReason: MCQRoundsEmptyReason =
+    emptyReason ?? (mcqs.length === 0 ? "no-moment" : "no-moment");
+  const emptyCopy = EMPTY_REASON_COPY[resolvedEmptyReason];
   return (
     <section
       className="hf-mcq-rounds-shell"
@@ -128,15 +195,49 @@ export function MCQRoundsShell({
         >
           <div className="hf-mcq-question">{currentMcq.questionText}</div>
           {currentMcq.options ? (
-            <ul className="hf-mcq-options" data-testid="hf-mcq-options">
-              {currentMcq.options.map((opt) => (
-                <li key={opt.label} data-mcq-option-label={opt.label}>
-                  <span className="hf-mcq-option-label">{opt.label}</span>
-                  <span className="hf-mcq-option-text">{opt.text}</span>
-                </li>
-              ))}
+            <ul
+              className="hf-mcq-options"
+              data-testid="hf-mcq-options"
+              role="radiogroup"
+              aria-label="Choose an answer"
+            >
+              {currentMcq.options.map((opt) => {
+                const isSelected = selectedOption === opt.label;
+                return (
+                  <li
+                    key={opt.label}
+                    data-mcq-option-label={opt.label}
+                    data-selected={isSelected ? "true" : "false"}
+                  >
+                    <button
+                      type="button"
+                      className="hf-btn hf-mcq-option-btn"
+                      data-testid={`hf-mcq-option-${opt.label}`}
+                      role="radio"
+                      aria-checked={isSelected}
+                      disabled={!onAnswer || selectedOption != null}
+                      onClick={() => onAnswer?.(currentMcq.id, opt.label)}
+                    >
+                      <span className="hf-mcq-option-label">{opt.label}</span>
+                      <span className="hf-mcq-option-text">{opt.text}</span>
+                    </button>
+                  </li>
+                );
+              })}
             </ul>
           ) : null}
+        </div>
+      ) : null}
+      {showEmptyState ? (
+        <div
+          className="hf-mcq-empty hf-empty"
+          data-testid="hf-mcq-empty"
+          data-empty-reason={resolvedEmptyReason}
+          role="status"
+          aria-live="polite"
+        >
+          <div className="hf-mcq-empty-title">{emptyCopy.title}</div>
+          <div className="hf-mcq-empty-detail">{emptyCopy.detail}</div>
         </div>
       ) : null}
       {feedback ? (

--- a/apps/admin/components/sim/SimChat.tsx
+++ b/apps/admin/components/sim/SimChat.tsx
@@ -16,7 +16,8 @@ import { VoicePanel } from './VoicePanel';
 import { useVoiceMode } from './useVoiceMode';
 import { ExamModeShell } from './ExamModeShell';
 import { ChatFeedShell } from './ChatFeedShell';
-import { MCQRoundsShell } from './MCQRoundsShell';
+import { MCQRoundsShell, type MCQRoundsEmptyReason } from './MCQRoundsShell';
+import { useAssessmentMomentMCQs } from './use-assessment-moment-mcqs';
 import {
   ResultsReadoutShell,
   type ResultsReadoutPayload,
@@ -1349,6 +1350,114 @@ export function SimChat({
     }
   }, [resolvedShellKind, matchedRuleId, callerId, requestedModuleId]);
 
+  // W4 of memory/handoff_lattice_all_settings_to_ui_2026_06_21.md
+  // (epic #2163 closeout) — MCQ data feed for the quiz-mode shell.
+  //
+  // Reads the caller's active Playbook → assessmentPlan → finds the
+  // AssessmentMoment whose moduleSlug matches the current module → calls
+  // the canonical sampling engine via the route. The hook returns an
+  // empty list + typed `reason` when no moment / empty pool / unsatisfied
+  // policy — the shell consumes this and renders the empty-state. NEVER
+  // fake MCQs (per `feedback_no_hardcoded_score_backfill.md`).
+  //
+  // Mount gate: only fetch when the resolver picked the mcq-rounds shell
+  // for this session AND we have a moduleSlug. Other shells never see
+  // this state.
+  const mcqFeedEnabled = resolvedShellKind === 'mcq-rounds';
+  const mcqFeed = useAssessmentMomentMCQs({
+    callerId,
+    moduleSlug: requestedModuleId ?? null,
+    enabled: mcqFeedEnabled,
+  });
+
+  // Per-round local state. Track the current 1-based round + the selected
+  // option label + the local feedback node for that round. Resets when
+  // the MCQ list changes (new fetch / new moment).
+  const [mcqRoundIndex, setMcqRoundIndex] = useState(1);
+  const [mcqSelectedOption, setMcqSelectedOption] = useState<string | null>(
+    null,
+  );
+  const [mcqFeedbackNode, setMcqFeedbackNode] = useState<React.ReactNode>(null);
+  const [mcqCompleted, setMcqCompleted] = useState(false);
+  useEffect(() => {
+    setMcqRoundIndex(1);
+    setMcqSelectedOption(null);
+    setMcqFeedbackNode(null);
+    setMcqCompleted(false);
+  }, [mcqFeed.mcqs]);
+
+  const handleMcqAnswer = useCallback(
+    (mcqId: string, optionLabel: string) => {
+      // Pin selection (disables the option buttons via the shell's
+      // disabled gate) and surface immediate-mode feedback. Per
+      // ai-to-db-guard.md, the real CallScore write goes through the
+      // canonical writer at `lib/measurement/write-call-score.ts` from
+      // the pipeline — until W4 wires that path, emit an AppLog beacon
+      // so the answer flow is observable end-to-end.
+      setMcqSelectedOption(optionLabel);
+
+      const subject = 'assessment.answer.submitted';
+      const beacon = {
+        subject,
+        callerId,
+        moduleSlug: requestedModuleId ?? null,
+        sessionId: callId ?? null,
+        mcqId,
+        optionLabel,
+        momentKind: mcqFeed.momentKind ?? null,
+      };
+      // Console-only beacon for now — the SUPERVISE pipeline owns the
+      // real score-write. Visible in dev via `/x/logs` once a server
+      // endpoint relays. AppLog server-side write is a follow-on PR
+      // (`POST /api/log/assessment-answer` keyed on sessionId).
+      console.info(`[${subject}]`, beacon);
+
+      if (mcqFeed.feedbackMode === 'immediate') {
+        setMcqFeedbackNode(
+          <span data-testid="hf-mcq-feedback-immediate">
+            Answer recorded. Moving on…
+          </span>,
+        );
+      }
+
+      // Advance to the next round after a short pause so the learner
+      // sees their selection + feedback.
+      const advance = () => {
+        if (mcqRoundIndex >= mcqFeed.mcqs.length) {
+          setMcqCompleted(true);
+          setMcqFeedbackNode(null);
+          return;
+        }
+        setMcqRoundIndex((prev) => prev + 1);
+        setMcqSelectedOption(null);
+        setMcqFeedbackNode(null);
+      };
+      window.setTimeout(advance, 700);
+    },
+    [
+      callerId,
+      requestedModuleId,
+      callId,
+      mcqFeed.momentKind,
+      mcqFeed.feedbackMode,
+      mcqFeed.mcqs.length,
+      mcqRoundIndex,
+    ],
+  );
+
+  // Resolve the shell's `emptyReason` prop based on the feed state.
+  // `loading` while the fetch is in flight; `error` on network fail;
+  // otherwise the engine's typed reason (no-moment / empty-pool / etc.).
+  const mcqEmptyReason: MCQRoundsEmptyReason | null = mcqFeedEnabled
+    ? mcqFeed.loading
+      ? 'loading'
+      : mcqFeed.error
+        ? 'error'
+        : mcqFeed.mcqs.length === 0
+          ? mcqFeed.reason ?? 'no-moment'
+          : null
+    : null;
+
   // W6 of memory/handoff_lattice_all_settings_to_ui_2026_06_21.md
   // (story #2185 U11) — ResultsReadoutShell overlay state. Per BDD
   // US-Mock-05 this is the ONE sanctioned learner surface that displays
@@ -2418,7 +2527,17 @@ export function SimChat({
       );
     case 'mcq-rounds':
       return (
-        <MCQRoundsShell capabilities={resolvedCapabilities}>
+        <MCQRoundsShell
+          capabilities={resolvedCapabilities}
+          mcqs={mcqFeed.mcqs}
+          roundIndex={mcqRoundIndex}
+          roundTotal={mcqFeed.mcqs.length || undefined}
+          ended={mcqCompleted}
+          feedback={mcqFeedbackNode}
+          selectedOption={mcqSelectedOption}
+          onAnswer={handleMcqAnswer}
+          emptyReason={mcqEmptyReason}
+        >
           {content}
           {examShellOverlay}
           {resultsShell}

--- a/apps/admin/components/sim/learner-shells.css
+++ b/apps/admin/components/sim/learner-shells.css
@@ -84,6 +84,13 @@
 }
 
 .hf-mcq-options li {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.hf-mcq-option-btn {
+  width: 100%;
   display: flex;
   align-items: flex-start;
   gap: 12px;
@@ -91,6 +98,24 @@
   border-radius: 10px;
   background: var(--surface-secondary);
   border: 1px solid var(--border-default);
+  text-align: left;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+.hf-mcq-option-btn:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent-primary) 6%, var(--surface-secondary));
+  border-color: var(--accent-primary);
+}
+
+.hf-mcq-options li[data-selected="true"] .hf-mcq-option-btn {
+  background: color-mix(in srgb, var(--accent-primary) 14%, var(--surface-secondary));
+  border-color: var(--accent-primary);
+}
+
+.hf-mcq-option-btn:disabled {
+  cursor: default;
+  opacity: 0.85;
 }
 
 .hf-mcq-option-label {
@@ -101,6 +126,30 @@
 
 .hf-mcq-option-text {
   color: var(--text-primary);
+}
+
+.hf-mcq-empty {
+  width: 100%;
+  max-width: 560px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 24px;
+  border-radius: 12px;
+  background: var(--surface-secondary);
+  border: 1px dashed var(--border-default);
+  text-align: center;
+  color: var(--text-primary);
+}
+
+.hf-mcq-empty-title {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.hf-mcq-empty-detail {
+  font-size: 14px;
+  color: var(--text-muted);
 }
 
 .hf-mcq-feedback {

--- a/apps/admin/components/sim/use-assessment-moment-mcqs.ts
+++ b/apps/admin/components/sim/use-assessment-moment-mcqs.ts
@@ -1,0 +1,137 @@
+"use client";
+
+/**
+ * W4 of `memory/handoff_lattice_all_settings_to_ui_2026_06_21.md` —
+ * client hook that fetches the `MCQRoundsShell` data feed.
+ *
+ * Wraps `GET /api/callers/[callerId]/assessment-moment-mcqs?moduleSlug=…`
+ * (the HTTP boundary of the canonical sampling engine at
+ * `lib/assessment/sample-questions.ts`). The hook is intentionally
+ * thin — fetch + abort + null-result handling. The route + engine own
+ * the AppLog signalling on miss; this hook surfaces the typed
+ * `reason` to the caller so the shell can render an honest empty
+ * state.
+ *
+ * **No fake fallbacks** (operator-pinned, per
+ * `feedback_no_hardcoded_score_backfill.md`):
+ * - Engine miss → `mcqs: []`, `reason` populated, shell empty-state.
+ * - Fetch / network error → `mcqs: []`, `error` populated.
+ */
+
+import { useEffect, useState } from "react";
+import type {
+  AssessmentMomentMCQsPayload,
+  AssessmentMomentNullReason,
+} from "@/app/api/callers/[callerId]/assessment-moment-mcqs/route";
+
+export interface UseAssessmentMomentMCQsResult {
+  /** Sampled MCQs (empty when result null or fetch error). */
+  mcqs: AssessmentMomentMCQsPayload["mcqs"];
+  /** The kind of moment that resolved (null when no moment). */
+  momentKind: AssessmentMomentMCQsPayload["momentKind"] | null;
+  /** Per-question feedback timing — drives shell behaviour. */
+  feedbackMode: AssessmentMomentMCQsPayload["feedbackMode"];
+  /** Typed reason when MCQs are empty by design (route's `reason`). */
+  reason: AssessmentMomentNullReason | null;
+  /** Transient fetch error message (null on success or while loading). */
+  error: string | null;
+  /** Loading flag — true while the fetch is in flight. */
+  loading: boolean;
+}
+
+const EMPTY: UseAssessmentMomentMCQsResult = {
+  mcqs: [],
+  momentKind: null,
+  feedbackMode: "immediate",
+  reason: null,
+  error: null,
+  loading: false,
+};
+
+interface RouteResponse {
+  ok?: boolean;
+  result?: AssessmentMomentMCQsPayload | null;
+  reason?: AssessmentMomentNullReason;
+  error?: string;
+}
+
+/**
+ * Fetch the MCQ feed for the supplied caller + module slug.
+ *
+ * Pass `{ enabled: false }` to skip the fetch (e.g. when the shell
+ * mount precondition isn't met). The hook returns `EMPTY` until
+ * enabled flips true.
+ */
+export function useAssessmentMomentMCQs({
+  callerId,
+  moduleSlug,
+  enabled = true,
+}: {
+  callerId: string;
+  moduleSlug: string | null | undefined;
+  enabled?: boolean;
+}): UseAssessmentMomentMCQsResult {
+  const [state, setState] = useState<UseAssessmentMomentMCQsResult>(EMPTY);
+
+  useEffect(() => {
+    if (!enabled || !moduleSlug || !callerId) {
+      // Reset to EMPTY only when our current state differs — avoids the
+      // cascading-render lint warning when nothing has changed.
+      setState((prev) =>
+        prev.mcqs.length === 0 &&
+        !prev.loading &&
+        !prev.error &&
+        !prev.momentKind &&
+        !prev.reason
+          ? prev
+          : EMPTY,
+      );
+      return;
+    }
+    const controller = new AbortController();
+    setState((prev) => ({ ...prev, loading: true, error: null }));
+    fetch(
+      `/api/callers/${encodeURIComponent(callerId)}/assessment-moment-mcqs?moduleSlug=${encodeURIComponent(
+        moduleSlug,
+      )}`,
+      { signal: controller.signal, credentials: "same-origin" },
+    )
+      .then((res) =>
+        res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`)),
+      )
+      .then((body: RouteResponse | null) => {
+        if (!body?.ok) {
+          setState({
+            ...EMPTY,
+            error: body?.error ?? "Could not load MCQs.",
+          });
+          return;
+        }
+        if (!body.result) {
+          setState({
+            ...EMPTY,
+            reason: body.reason ?? null,
+          });
+          return;
+        }
+        setState({
+          mcqs: body.result.mcqs,
+          momentKind: body.result.momentKind,
+          feedbackMode: body.result.feedbackMode,
+          reason: null,
+          error: null,
+          loading: false,
+        });
+      })
+      .catch((err: unknown) => {
+        if ((err as { name?: string } | null)?.name === "AbortError") return;
+        setState({
+          ...EMPTY,
+          error: "Could not load MCQs.",
+        });
+      });
+    return () => controller.abort();
+  }, [callerId, moduleSlug, enabled]);
+
+  return state;
+}

--- a/apps/admin/tests/api/callers/assessment-moment-mcqs/assessment-moment-mcqs.test.ts
+++ b/apps/admin/tests/api/callers/assessment-moment-mcqs/assessment-moment-mcqs.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Tests for `GET /api/callers/[callerId]/assessment-moment-mcqs?moduleSlug=…`.
+ *
+ * W4 of `memory/handoff_lattice_all_settings_to_ui_2026_06_21.md`.
+ *
+ * Pinned acceptance:
+ *   1. STUDENT scope rejects foreign callerId (403)
+ *   2. Missing moduleSlug → 400 (Zod)
+ *   3. No active enrollment → `{ result: null, reason: "no-moment" }`
+ *   4. Playbook with no assessmentPlan → `{ result: null, reason: "no-moment" }`
+ *   5. Playbook with `noAssessmentPlan: true` → `{ result: null, reason: "no-moment" }`
+ *   6. AssessmentMoment present but engine returns `empty-pool` → `{ result: null, reason: "empty-pool" }`
+ *   7. AssessmentMoment present + engine returns questions → payload with MCQs
+ *   8. moduleSlug matches midpoints[] entry → moment resolves
+ *   9. moduleSlug matches end-of-course entry → moment resolves
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockPrisma, mockStudentAllowed, mockSampleQuestions } = vi.hoisted(
+  () => ({
+    mockPrisma: {
+      callerPlaybook: { findFirst: vi.fn() },
+    },
+    mockStudentAllowed: vi.fn(),
+    mockSampleQuestions: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
+vi.mock("@/lib/permissions", () => ({
+  requireAuth: vi.fn(async () => ({
+    ok: true,
+    session: { user: { id: "u1", role: "OPERATOR" } },
+  })),
+  isAuthError: () => false,
+}));
+vi.mock("@/lib/learner-scope", () => ({
+  studentAllowedToReadCaller: mockStudentAllowed,
+  callerScopeMismatchResponse: () =>
+    new Response(JSON.stringify({ ok: false, error: "scope" }), { status: 403 }),
+}));
+vi.mock("@/lib/logger", () => ({ log: vi.fn() }));
+vi.mock("@/lib/assessment/sample-questions", () => ({
+  sampleQuestionsForMoment: mockSampleQuestions,
+}));
+
+const PARAMS = { params: Promise.resolve({ callerId: "caller-1" }) };
+
+async function loadRoute() {
+  return import("@/app/api/callers/[callerId]/assessment-moment-mcqs/route");
+}
+
+function makeReq(moduleSlug?: string): NextRequest {
+  const url = moduleSlug
+    ? `http://x?moduleSlug=${encodeURIComponent(moduleSlug)}`
+    : "http://x";
+  return new NextRequest(url);
+}
+
+function moment(
+  override: Partial<{
+    kind: string;
+    moduleSlug: string;
+    samplingPolicy: {
+      scope: string;
+      count: { min: number; target: number; max: number };
+      contentKind: string;
+    };
+    shellKind: string;
+    scoringSpec: string;
+  }> = {},
+) {
+  return {
+    kind: "popquiz",
+    moduleSlug: "module-foo",
+    samplingPolicy: {
+      scope: "per-unit",
+      count: { min: 1, target: 5, max: 5 },
+      contentKind: "mcq",
+    },
+    shellKind: "mcq-rounds",
+    scoringSpec: "QUIZ-SCORE-V1",
+    ...override,
+  };
+}
+
+function playbookConfigWith(plan: unknown) {
+  return {
+    playbook: {
+      id: "pb-1",
+      config: { assessmentPlan: plan },
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockStudentAllowed.mockReturnValue(true);
+});
+
+describe("GET /api/callers/[callerId]/assessment-moment-mcqs", () => {
+  it("rejects STUDENT reading foreign caller (403)", async () => {
+    mockStudentAllowed.mockReturnValue(false);
+    const route = await loadRoute();
+    const res = await route.GET(makeReq("module-foo"), PARAMS);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when moduleSlug query param is missing", async () => {
+    const route = await loadRoute();
+    const res = await route.GET(makeReq(), PARAMS);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/moduleSlug/);
+  });
+
+  it("returns null + reason:'no-moment' when caller has no active enrollment", async () => {
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue(null);
+    const route = await loadRoute();
+    const res = await route.GET(makeReq("module-foo"), PARAMS);
+    const body = (await res.json()) as {
+      ok: boolean;
+      result: unknown;
+      reason: string;
+    };
+    expect(body.ok).toBe(true);
+    expect(body.result).toBeNull();
+    expect(body.reason).toBe("no-moment");
+  });
+
+  it("returns null + reason:'no-moment' when Playbook has no assessmentPlan", async () => {
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue({
+      playbook: { id: "pb-1", config: {} },
+    });
+    const route = await loadRoute();
+    const res = await route.GET(makeReq("module-foo"), PARAMS);
+    const body = (await res.json()) as {
+      ok: boolean;
+      result: unknown;
+      reason: string;
+    };
+    expect(body.result).toBeNull();
+    expect(body.reason).toBe("no-moment");
+  });
+
+  it("returns null + reason:'no-moment' when plan declares noAssessmentPlan:true", async () => {
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue(
+      playbookConfigWith({ noAssessmentPlan: true }),
+    );
+    const route = await loadRoute();
+    const res = await route.GET(makeReq("module-foo"), PARAMS);
+    const body = (await res.json()) as {
+      ok: boolean;
+      result: unknown;
+      reason: string;
+    };
+    expect(body.result).toBeNull();
+    expect(body.reason).toBe("no-moment");
+    expect(mockSampleQuestions).not.toHaveBeenCalled();
+  });
+
+  it("returns null + reason:'no-moment' when no moment cites the supplied moduleSlug", async () => {
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue(
+      playbookConfigWith({
+        upfront: moment({ moduleSlug: "other-module" }),
+      }),
+    );
+    const route = await loadRoute();
+    const res = await route.GET(makeReq("module-foo"), PARAMS);
+    const body = (await res.json()) as {
+      ok: boolean;
+      result: unknown;
+      reason: string;
+    };
+    expect(body.result).toBeNull();
+    expect(body.reason).toBe("no-moment");
+    expect(mockSampleQuestions).not.toHaveBeenCalled();
+  });
+
+  it("returns null + engine reason when sampling engine reports empty-pool", async () => {
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue(
+      playbookConfigWith({
+        upfront: moment({ moduleSlug: "module-foo" }),
+      }),
+    );
+    mockSampleQuestions.mockResolvedValue({
+      ok: false,
+      reason: "empty-pool",
+    });
+    const route = await loadRoute();
+    const res = await route.GET(makeReq("module-foo"), PARAMS);
+    const body = (await res.json()) as {
+      ok: boolean;
+      result: unknown;
+      reason: string;
+    };
+    expect(body.ok).toBe(true);
+    expect(body.result).toBeNull();
+    expect(body.reason).toBe("empty-pool");
+  });
+
+  it("returns the sampled MCQ payload on the happy path (upfront moment)", async () => {
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue(
+      playbookConfigWith({
+        upfront: moment({ moduleSlug: "module-foo", kind: "upfront-baseline" }),
+      }),
+    );
+    mockSampleQuestions.mockResolvedValue({
+      ok: true,
+      questions: [
+        {
+          id: "q-1",
+          questionText: "Pick one",
+          options: [
+            { label: "A", text: "First" },
+            { label: "B", text: "Second" },
+          ],
+          questionType: "MULTIPLE_CHOICE",
+          correctAnswer: null,
+          answerExplanation: null,
+          learningOutcomeRef: null,
+          skillRef: null,
+          bloomLevel: null,
+          difficulty: null,
+        },
+      ],
+    });
+    const route = await loadRoute();
+    const res = await route.GET(makeReq("module-foo"), PARAMS);
+    const body = (await res.json()) as {
+      ok: boolean;
+      result: {
+        momentKind: string;
+        moduleSlug: string;
+        feedbackMode: string;
+        mcqs: Array<{ id: string; questionText: string; options: unknown }>;
+      };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.result.momentKind).toBe("upfront-baseline");
+    expect(body.result.moduleSlug).toBe("module-foo");
+    expect(body.result.feedbackMode).toBe("immediate");
+    expect(body.result.mcqs).toHaveLength(1);
+    expect(body.result.mcqs[0].id).toBe("q-1");
+    expect(body.result.mcqs[0].options).toEqual([
+      { label: "A", text: "First" },
+      { label: "B", text: "Second" },
+    ]);
+  });
+
+  it("resolves a moment from midpoints[] when slug matches", async () => {
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue(
+      playbookConfigWith({
+        midpoints: [
+          moment({ moduleSlug: "unit-1", kind: "midpoint-check" }),
+          moment({ moduleSlug: "unit-2", kind: "popquiz" }),
+        ],
+      }),
+    );
+    mockSampleQuestions.mockResolvedValue({ ok: true, questions: [] });
+    const route = await loadRoute();
+    const res = await route.GET(makeReq("unit-2"), PARAMS);
+    const body = (await res.json()) as {
+      result: { momentKind: string };
+    };
+    expect(body.result.momentKind).toBe("popquiz");
+    expect(mockSampleQuestions).toHaveBeenCalledOnce();
+  });
+
+  it("resolves a moment from end-of-course when slug matches", async () => {
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue(
+      playbookConfigWith({
+        end: moment({ moduleSlug: "mock-exam", kind: "end-mock" }),
+      }),
+    );
+    mockSampleQuestions.mockResolvedValue({ ok: true, questions: [] });
+    const route = await loadRoute();
+    const res = await route.GET(makeReq("mock-exam"), PARAMS);
+    const body = (await res.json()) as {
+      result: { momentKind: string };
+    };
+    expect(body.result.momentKind).toBe("end-mock");
+  });
+
+  it("narrows malformed options to null rather than passing through unknown shape", async () => {
+    mockPrisma.callerPlaybook.findFirst.mockResolvedValue(
+      playbookConfigWith({
+        upfront: moment({ moduleSlug: "module-foo" }),
+      }),
+    );
+    mockSampleQuestions.mockResolvedValue({
+      ok: true,
+      questions: [
+        {
+          id: "q-1",
+          questionText: "x",
+          // Wrong shape — engine return is `unknown`; the route should narrow.
+          options: { not: "an array" },
+          questionType: "MULTIPLE_CHOICE",
+          correctAnswer: null,
+          answerExplanation: null,
+          learningOutcomeRef: null,
+          skillRef: null,
+          bloomLevel: null,
+          difficulty: null,
+        },
+      ],
+    });
+    const route = await loadRoute();
+    const res = await route.GET(makeReq("module-foo"), PARAMS);
+    const body = (await res.json()) as {
+      result: { mcqs: Array<{ options: unknown }> };
+    };
+    expect(body.result.mcqs[0].options).toBeNull();
+  });
+});

--- a/apps/admin/tests/components/sim/learner-shells.test.tsx
+++ b/apps/admin/tests/components/sim/learner-shells.test.tsx
@@ -16,8 +16,8 @@
  * these tests without coupling to internal styling decisions.
  */
 
-import { describe, it, expect, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 
 import {
   ExamModeShell,
@@ -331,6 +331,126 @@ describe("MCQRoundsShell — capability-driven quiz shell (closes #2159 at shell
     expect(shell.getAttribute("data-dismiss-on-end")).toBe("next-module");
     expect(shell.getAttribute("data-mode-pill")).toBe("");
     expect(screen.queryByTestId("hf-shell-mode-pill")).toBeNull();
+  });
+
+  // ──────────────────────────────────────────────────────────
+  // W4 — answer-flow + empty-state (PR for handoff W4)
+  // ──────────────────────────────────────────────────────────
+
+  it("W4 — renders the empty-state when no MCQs and not ended (cue-card-only)", () => {
+    render(<MCQRoundsShell emptyReason="no-moment" />);
+    const empty = screen.getByTestId("hf-mcq-empty");
+    expect(empty.getAttribute("data-empty-reason")).toBe("no-moment");
+    expect(empty).toHaveTextContent("No quiz available");
+    expect(screen.queryByTestId("hf-mcq-cue-card")).toBeNull();
+  });
+
+  it("W4 — empty-state copy varies per emptyReason", () => {
+    const cases: Array<["loading" | "empty-pool" | "policy-unsatisfied" | "missing-content" | "error", string]> = [
+      ["loading", "Loading"],
+      ["empty-pool", "empty"],
+      ["policy-unsatisfied", "sampling rules"],
+      ["missing-content", "different kind of content"],
+      ["error", "Couldn't load"],
+    ];
+    for (const [reason, snippet] of cases) {
+      cleanup();
+      render(<MCQRoundsShell emptyReason={reason} />);
+      const empty = screen.getByTestId("hf-mcq-empty");
+      expect(empty.getAttribute("data-empty-reason")).toBe(reason);
+      expect(empty.textContent ?? "").toMatch(new RegExp(snippet, "i"));
+    }
+  });
+
+  it("W4 — does not render empty-state when an MCQ is present", () => {
+    const mcq = { id: "q", questionText: "What?", options: [{ label: "A", text: "yes" }] };
+    render(<MCQRoundsShell mcqs={[mcq]} roundIndex={1} roundTotal={1} />);
+    expect(screen.queryByTestId("hf-mcq-empty")).toBeNull();
+    expect(screen.getByTestId("hf-mcq-cue-card")).toBeTruthy();
+  });
+
+  it("W4 — does not render empty-state when ended (close screen takes over)", () => {
+    render(<MCQRoundsShell ended emptyReason="no-moment" />);
+    expect(screen.queryByTestId("hf-mcq-empty")).toBeNull();
+    expect(screen.getByTestId("hf-mcq-close-screen")).toBeTruthy();
+  });
+
+  it("W4 — option buttons invoke onAnswer with (mcqId, optionLabel)", () => {
+    const onAnswer = vi.fn();
+    const mcq = {
+      id: "mcq-42",
+      questionText: "Pick one",
+      options: [
+        { label: "A", text: "First" },
+        { label: "B", text: "Second" },
+      ],
+    };
+    render(
+      <MCQRoundsShell
+        mcqs={[mcq]}
+        roundIndex={1}
+        roundTotal={1}
+        onAnswer={onAnswer}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("hf-mcq-option-B"));
+    expect(onAnswer).toHaveBeenCalledWith("mcq-42", "B");
+  });
+
+  it("W4 — selected option is reflected on the <li> + button disables further clicks", () => {
+    const onAnswer = vi.fn();
+    const mcq = {
+      id: "q1",
+      questionText: "Pick",
+      options: [
+        { label: "A", text: "x" },
+        { label: "B", text: "y" },
+      ],
+    };
+    render(
+      <MCQRoundsShell
+        mcqs={[mcq]}
+        roundIndex={1}
+        roundTotal={1}
+        selectedOption="A"
+        onAnswer={onAnswer}
+      />,
+    );
+    const options = screen.getByTestId("hf-mcq-options");
+    const aLi = options.querySelector('[data-mcq-option-label="A"]');
+    const bLi = options.querySelector('[data-mcq-option-label="B"]');
+    expect(aLi?.getAttribute("data-selected")).toBe("true");
+    expect(bLi?.getAttribute("data-selected")).toBe("false");
+    // Both buttons are disabled once a selection landed (no double-click).
+    expect((screen.getByTestId("hf-mcq-option-A") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTestId("hf-mcq-option-B") as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("W4 — option buttons are disabled when no onAnswer handler is supplied", () => {
+    const mcq = {
+      id: "q",
+      questionText: "Pick",
+      options: [{ label: "A", text: "x" }],
+    };
+    render(<MCQRoundsShell mcqs={[mcq]} roundIndex={1} roundTotal={1} />);
+    expect((screen.getByTestId("hf-mcq-option-A") as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("W4 — round counter reflects progression through the round", () => {
+    const mcqs = [
+      { id: "q1", questionText: "Q1", options: [{ label: "A", text: "x" }] },
+      { id: "q2", questionText: "Q2", options: [{ label: "A", text: "x" }] },
+      { id: "q3", questionText: "Q3", options: [{ label: "A", text: "x" }] },
+    ];
+    const { rerender } = render(
+      <MCQRoundsShell mcqs={mcqs} roundIndex={1} roundTotal={3} />,
+    );
+    expect(screen.getByTestId("hf-mcq-counter")).toHaveTextContent("Round 1 of 3");
+    expect(screen.getByTestId("hf-mcq-cue-card").getAttribute("data-mcq-id")).toBe("q1");
+
+    rerender(<MCQRoundsShell mcqs={mcqs} roundIndex={2} roundTotal={3} />);
+    expect(screen.getByTestId("hf-mcq-counter")).toHaveTextContent("Round 2 of 3");
+    expect(screen.getByTestId("hf-mcq-cue-card").getAttribute("data-mcq-id")).toBe("q2");
   });
 });
 

--- a/docs/API-INTERNAL.md
+++ b/docs/API-INTERNAL.md
@@ -2503,6 +2503,38 @@ List conversation artifacts for a caller. Optionally filter by callId or status.
 
 ---
 
+### `GET` /api/callers/:callerId/assessment-moment-mcqs?moduleSlug=…
+
+W4 of `memory/handoff_lattice_all_settings_to_ui_2026_06_21.md` —
+
+**Auth**: session (VIEWER+ — STUDENT scoped to own caller) · **Scope**: `callers:read`
+
+| Parameter | In | Type | Required | Description |
+|-----------|-----|------|----------|-------------|
+| callerId | path | string | Yes | Caller.id |
+
+**Response** `200`
+```json
+{ok: true, result: AssessmentMomentMCQsPayload | null, reason?: string}
+```
+
+**Response** `400`
+```json
+{ok: false, error: string}
+```
+
+**Response** `403`
+```json
+{ok: false, error: string}
+```
+
+**Response** `500`
+```json
+{ok: false, error: string}
+```
+
+---
+
 ### `GET` /api/callers/:callerId/available-media
 
 Get all media assets available for sharing with a caller, based on their domain's linked subjects.
@@ -16419,8 +16451,8 @@ orchestration between services) and are never exposed externally.
 
 | Metric | Value |
 |--------|-------|
-| Route files found | 544 |
-| Files with annotations | 530 |
+| Route files found | 545 |
+| Files with annotations | 531 |
 | Files missing annotations | 14 |
 | Coverage | 97.4% |
 

--- a/docs/API-PUBLIC.md
+++ b/docs/API-PUBLIC.md
@@ -732,6 +732,38 @@ List conversation artifacts for a caller. Optionally filter by callId or status.
 
 ---
 
+### `GET` /api/v1/callers/:callerId/assessment-moment-mcqs?moduleSlug=…
+
+W4 of `memory/handoff_lattice_all_settings_to_ui_2026_06_21.md` —
+
+**Auth**: session (VIEWER+ — STUDENT scoped to own caller) · **Scope**: `callers:read`
+
+| Parameter | In | Type | Required | Description |
+|-----------|-----|------|----------|-------------|
+| callerId | path | string | Yes | Caller.id |
+
+**Response** `200`
+```json
+{ok: true, result: AssessmentMomentMCQsPayload | null, reason?: string}
+```
+
+**Response** `400`
+```json
+{ok: false, error: string}
+```
+
+**Response** `403`
+```json
+{ok: false, error: string}
+```
+
+**Response** `500`
+```json
+{ok: false, error: string}
+```
+
+---
+
 ### `POST` /api/v1/callers/:callerId/calls
 
 Create a new call record for a caller. Auto-determines call sequence number if not provided. Links to previous call for chain tracking.


### PR DESCRIPTION
## Summary

Closes **W4** from today's Learner UX audit (P0 — quiz mode was shell-only). MCQRoundsShell now fetches MCQs from the canonical sampling engine (`lib/assessment/sample-questions.ts`, PR #2180) and renders an end-to-end answer flow.

- New `GET /api/callers/[callerId]/assessment-moment-mcqs?moduleSlug=…` — HTTP boundary of the sampling engine; reads `Playbook.config.assessmentPlan` and dispatches to `sampleQuestionsForMoment(...)`. Course-agnostic (no per-course / per-mode branching).
- New `useAssessmentMomentMCQs` client hook — fetch / abort / typed reason / loading / error.
- `MCQRoundsShell` extended with: selectable option buttons (single-select, disables after pick), typed empty-state with `data-empty-reason` driving copy, `onAnswer(mcqId, optionLabel)` callback for the host.
- `SimChat` mounts the shell with the live feed when `resolvedShellKind === "mcq-rounds"`. Local state drives round index + selection + per-Q feedback; auto-advance after 700ms; close screen on round-end.
- Score-write to `CallScore` is stubbed via a console beacon (`[assessment.answer.submitted]`) — the canonical write lives on the SUPERVISE pipeline; filed as a follow-on (documented inline).

## NO FAKE FALLBACKS

Operator-pinned per `feedback_no_hardcoded_score_backfill.md`:
- No matching `AssessmentMoment` for the supplied moduleSlug → empty-state + `assessment.moment.no_match` AppLog.
- Engine returns `empty-pool` / `missing-content` / `policy-unsatisfied` → empty-state + engine's own AppLog (`assessment.sample.empty_pool` etc.).
- The shell **never** synthesises MCQs.

## Verified by

- **Lattice survey** (per `.claude/rules/lattice-survey.md`): canonical engine consumed via typed exports (`sampleQuestionsForMoment` from `lib/assessment/sample-questions.ts`); no per-course branching anywhere on the read path; capability-driven shell rendering preserved; `learner-ui-leak-coverage` clean (MCQ content is operator-authored `ContentQuestion` text, not internal labels).
- **New route tests** (`tests/api/callers/assessment-moment-mcqs/assessment-moment-mcqs.test.ts`): 11 vitests pinning STUDENT scope (403), Zod 400 on missing moduleSlug, no-enrollment / no-plan / `noAssessmentPlan:true` / no-matching-moment / engine `empty-pool` / happy-path / `midpoints[]` resolution / end-of-course resolution / options-shape narrowing.
- **Extended `learner-shells.test.tsx`** MCQRoundsShell block: 8 new W4 vitests covering empty-state per typed reason, click→onAnswer dispatch, selected reflected on `<li>`, disabled state after pick, no-handler disables, round counter progression.
- **44/44 W4 tests green.**
- **101/101 sibling Coverage gates green**: `mode-ui-coverage` (quiz/mock-exam learner UI still covered via SimChat dispatch), `shell-coverage`, `learner-ui-leak-coverage`, all `tests/lib/assessment/*`, `course-assessment-plan-coverage`.
- **tsc clean** on all 4 new/modified source files.
- **eslint**: 0 errors, 1 warning (functional-updater `setState-in-effect` — mirrors sibling hooks in SimChat; well under ratchet baseline of 4897).

## Coverage gate impact

| Gate | Status |
|---|---|
| `mode-ui-coverage.test.ts` | unchanged (quiz/mock-exam learner UI already covered by SimChat dispatch PR #2218) |
| `shell-coverage.test.ts` | unchanged (MCQRoundsShell still satisfies capability-prop requirement) |
| `course-assessment-plan-coverage.test.ts` | unchanged (this PR is one more consumer of the declarative plan; gate counts declarations, not consumers) |
| `learner-ui-leak-coverage.test.ts` | unchanged (operator-authored MCQ text doesn't carry internal labels) |
| `route-auth-zod-coverage.test.ts` | unchanged (route is GET-only; query Zod-validated; auth via `requireAuth("VIEWER")` + STUDENT scope) |

## Follow-on filed

- Real `CallScore` write from the answer-submitted beacon → SUPERVISE pipeline integration. Today the answer flow logs `[assessment.answer.submitted]` to console; the canonical writer at `lib/measurement/write-call-score.ts` should be invoked from SUPERVISE once the pipeline observes the new MCQ answer events. Documented inline in `handleMcqAnswer` JSDoc.

## Sandbox content prerequisite

If hf_sandbox has no `ContentQuestion` rows for the IELTS quiz module YET, the empty-state path WILL fire (`reason: "empty-pool"`), the engine's `assessment.sample.empty_pool` AppLog WILL emit, and the learner will see an honest "no questions available" panel. Operator can pair with `#2167` (IELTS sources backfill) once that content lands.

## Test plan

- [ ] Visit a quiz-mode module on hf_sandbox with a declared `AssessmentMoment` whose `contentKind: "mcq"` cites a populated `ContentQuestion` pool — confirm MCQs render, options are clickable, round counter advances, close screen fires after the last MCQ.
- [ ] Visit a quiz-mode module with no `AssessmentMoment` declared → empty-state with "No quiz available for this module" copy.
- [ ] Visit a quiz-mode module whose moment cites an empty pool → empty-state with "No questions available yet" copy + `[assessment.sample.empty_pool]` in `/x/logs`.
- [ ] STUDENT acct cannot read another caller's MCQ feed (403).