### PR TITLE
fix(sim): PostCallProgressCard crash on module-mastery learners

### DIFF
--- a/apps/admin/components/sim/PostCallProgressCard.tsx
+++ b/apps/admin/components/sim/PostCallProgressCard.tsx
@@ -9,13 +9,28 @@ interface LearningParam {
   latest: number;
 }
 
-interface LearningData {
-  profile: string;
-  profileLabel: string;
-  competencyLevel: string | null;
-  parameters: LearningParam[];
-  checkpoints: { key: string; status: string; score: number | null }[];
-}
+// Discriminated union mirroring `/api/callers/[id]/learning-trajectory`
+// (`kind: "skills"` | `kind: "module-mastery"`). This card consumes only
+// the `skills` shape; the `module-mastery` shape is rendered by
+// `LearningTrajectoryCard` on the caller-detail page. Without the
+// discriminator, accessing `data.parameters.length` on a module-mastery
+// response crashed with "undefined is not an object" after END CALL on
+// an IELTS-class course.
+type LearningData =
+  | {
+      kind: 'skills';
+      profile: string;
+      profileLabel: string;
+      competencyLevel: string | null;
+      parameters: LearningParam[];
+      checkpoints: { key: string; status: string; score: number | null }[];
+    }
+  | {
+      kind: 'module-mastery';
+      playbookId: string;
+      playbookName: string;
+      modules: unknown[];
+    };
 
 const BAND_LABELS: Record<string, string> = {
   mastery: 'Mastery',
@@ -58,7 +73,7 @@ export function PostCallProgressCard({ callerId }: { callerId: string }): JSX.El
     return () => { cancelled = true; };
   }, [callerId]);
 
-  if (loading || !data || data.parameters.length === 0) return null;
+  if (loading || !data || data.kind !== 'skills' || data.parameters.length === 0) return null;
 
   const avgScore = data.parameters.reduce((s, p) => s + p.latest, 0) / data.parameters.length;
 


### PR DESCRIPTION
## Summary

Crash on END CALL for module-mastery (IELTS-class) callers — `PostCallProgressCard.tsx:61` unconditionally read `data.parameters.length` against a response that, for module-mastery courses, has shape `{ kind: "module-mastery", modules: [...] }` (no `parameters` field). Sibling consumer `LearningTrajectoryCard.tsx:114` already branched on `data.kind`; this PR brings the post-call card to the same discipline.

## Fix
- Type `LearningData` as a discriminated union mirroring the route's two response shapes (`kind: "skills" | "module-mastery"`).
- Add `data.kind !== 'skills'` to the early-return guard — module-mastery payloads render `null` here; the caller-detail page owns that surface.

## Verified by

### Lattice survey (per `.claude/rules/lattice-survey.md`)
Every consumer of `/api/callers/[id]/learning-trajectory`:
- `components/sim/PostCallProgressCard.tsx` — this file, fixed here.
- `components/callers/caller-detail/cards/LearningTrajectoryCard.tsx` — already branches on `data.kind` (line 114). No drift.

Producer-side route returns exactly two shapes (`route.ts:164/271`). Discriminated union matches.

### tsc
- `npx tsc --noEmit` → 43 errors (matches `.ratchet.json` baseline; no new errors on the edited file).

### Pre-push (auto-ran)
- tsc 43 == baseline 43.
- eslint: no errors in changed files.

### Repro path
1. End a chat session on an IELTS-class learner (Dana Yamamoto on dev).
2. Pre-fix: `Something went wrong / undefined is not an object …` at `PostCallProgressCard.tsx:61:42`.
3. Post-fix: card renders `null` (module-mastery has its own surface on the caller-detail page).

## Lattice gap noted (not fixed in this PR)
Producer↔consumer discipline at the **API-response discriminated-union** layer is not structurally pinned today. Existing Coverage gates pin TYPE-UNION consumers (e.g. `mode-ui-coverage`, `sessionkind-reader-coverage`, `bdd-typed-unions-coverage`) — they don't enumerate API JSON responses. A new Coverage test could walk the two `route.ts` `return NextResponse.json({...kind: …})` branches and assert every fetch site of the route branches on `data.kind`. Filing as a follow-on if you want it.

## Test plan
- [ ] End a chat session on `dev.humanfirstfoundation.com` as Dana Yamamoto (IELTS) — no crash on the caller-detail page.
- [ ] End a chat session on a skills-shape caller (any non-IELTS course) — `PostCallProgressCard` still renders the WhatsApp-style progress summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)