### PR TITLE
feat(seed): add CourseAssessmentPlan declaration to IELTS Speaking Practice seed

### DIFF
--- a/apps/admin/prisma/seed-ielts-course.ts
+++ b/apps/admin/prisma/seed-ielts-course.ts
@@ -192,6 +192,40 @@ export async function main(prisma: PrismaClient): Promise<void> {
         },
         tierPresetId: "ielts-speaking",
         skillScoringEmaHalfLifeDays: 14,
+        // ── CourseAssessmentPlan (epic #2176 / PR #2254 S1) ──
+        // BDD-shaped: upfront baseline + end mock. Speaking is examiner-
+        // mode, conversational — contentKind:"topic-prompt" (not mcq).
+        // Stratification.perCriterion=1 ensures one task per IELTS
+        // criterion (FC / LR / GRA / Pron) per moment.
+        // shellKind:"exam" mounts ExamModeShell (board-chair frame).
+        // Per Part modules (Part 1 / 2 / 3) are practice sessions,
+        // not formal moments — no midpoints declared.
+        assessmentPlan: {
+          upfront: {
+            kind: "upfront-baseline",
+            moduleSlug: "baseline",
+            samplingPolicy: {
+              scope: "cross-curriculum",
+              count: { min: 4, target: 4, max: 4 },
+              contentKind: "topic-prompt",
+              stratification: { perCriterion: 1 },
+            },
+            shellKind: "exam",
+            scoringSpec: "spec-ielts-measure-001",
+          },
+          end: {
+            kind: "end-mock",
+            moduleSlug: "mock",
+            samplingPolicy: {
+              scope: "cross-curriculum",
+              count: { min: 4, target: 4, max: 4 },
+              contentKind: "topic-prompt",
+              stratification: { perCriterion: 1 },
+            },
+            shellKind: "exam",
+            scoringSpec: "spec-ielts-measure-001",
+          },
+        },
       },
     },
   });


### PR DESCRIPTION
## Summary

Adds the canonical CourseAssessmentPlan declaration to IELTS Speaking Practice seed. Companion to PR #2254 (S1 — CourseAssessmentPlan editor lens) merged to main today.

**Plan shape** (BDD-aligned):
- `upfront`: kind=upfront-baseline, moduleSlug=baseline, scope=cross-curriculum, count=4, contentKind=topic-prompt, stratification.perCriterion=1, shellKind=exam, scoringSpec=spec-ielts-measure-001
- `end`: kind=end-mock, moduleSlug=mock, same sampling shape
- No midpoints (per Part modules are practice sessions, not formal moments)

**Pedagogy notes**
- IELTS Speaking is conversational examiner-mode, NOT MCQ-driven → `contentKind: "topic-prompt"` (MCQs are for CIO/CTO per #2009).
- `shellKind: "exam"` mounts ExamModeShell (board-chair frame for IELTS).
- `stratification.perCriterion: 1` ensures one task per IELTS criterion (FC / LR / GRA / Pron).

Live PATCHes already applied to sandbox via `PATCH /api/courses/:id/journey-setting`; staging receives the PATCH after #2254 reaches Cloud Run. This PR is the durable re-seed companion.

## Verified by
- **Lattice survey** — contract for `assessmentPlan` exists in `lib/journey/setting-contracts.entries.ts` (PR #2254); types `CourseAssessmentPlan` in `lib/types/json-fields.ts`; Coverage gate `tests/lib/assessment/course-assessment-plan-coverage.test.ts` walks the (hand-maintained) manifest — all already on main. Seed addition is data-only; no manifest change required.
- **tsc** — 38 errors total on this branch vs baseline 43 in `.ratchet.json` (pre-push: -5, all incumbent on main). Zero tsc errors touch `prisma/seed-ielts-course.ts`. Diff introduces zero new errors.
- **eslint** — `npx eslint prisma/seed-ielts-course.ts` → 0 errors. The 2 pre-existing warnings on lines 440/442 are outside the 34-line insertion.

## Test plan
- [ ] Lattice survey result cited above
- [ ] Re-seed IELTS course on a fresh DB; verify `Playbook.config.assessmentPlan` is present with shape above
- [ ] Course Pane → IELTS Speaking → CourseAssessmentPlan lens renders the plan (post #2254 deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)