### PR TITLE
fix(#2271): mark IELTS-MEASURE-001 skill params isAdjustable

### DIFF
--- a/apps/admin/docs-archive/bdd-specs/IELTS-MEASURE-001-ielts-speaking-criteria.spec.json
+++ b/apps/admin/docs-archive/bdd-specs/IELTS-MEASURE-001-ielts-speaking-criteria.spec.json
@@ -103,6 +103,7 @@
       "description": "IELTS Fluency & Coherence — sustained speaking without breakdown, connected discourse with logical organisation.",
       "section": "IELTS Speaking Criteria",
       "type": "STATE",
+      "isAdjustable": true,
       "targetRange": { "min": 0.0, "max": 1.0 },
       "framework": {
         "ielts": { "criterion": "FC", "name": "Fluency & Coherence", "bandRange": "1-9" }
@@ -177,6 +178,7 @@
       "description": "IELTS Lexical Resource — vocabulary range, precision of word choice, paraphrase flexibility, idiomatic appropriacy. TRANSCRIPT-ONLY — vendor audio cannot judge.",
       "section": "IELTS Speaking Criteria",
       "type": "STATE",
+      "isAdjustable": true,
       "targetRange": { "min": 0.0, "max": 1.0 },
       "framework": {
         "ielts": { "criterion": "LR", "name": "Lexical Resource", "bandRange": "1-9" }
@@ -261,6 +263,7 @@
       "description": "IELTS Grammatical Range & Accuracy — variety of sentence structures, complexity (subordination, conditionals, modals), and error frequency/gravity. TRANSCRIPT-ONLY — vendor audio cannot judge grammar.",
       "section": "IELTS Speaking Criteria",
       "type": "STATE",
+      "isAdjustable": true,
       "targetRange": { "min": 0.0, "max": 1.0 },
       "framework": {
         "ielts": { "criterion": "GRA", "name": "Grammatical Range & Accuracy", "bandRange": "1-9" }
@@ -345,6 +348,7 @@
       "description": "IELTS Pronunciation — dual-confidence scoring. Scored from transcript cues (self-corrections, tutor pronunciation feedback, repair patterns, hesitations, length variance, long-turn cleanliness) whenever there is any speech evidence; confidence is capped at 'medium' from transcript alone. When prosody vendor is wired (epic #2135 S3), the prosody-raw consumer augments this slot and raises confidence to 'high'.",
       "section": "IELTS Speaking Criteria",
       "type": "STATE",
+      "isAdjustable": true,
       "targetRange": { "min": 0.0, "max": 1.0 },
       "framework": {
         "ielts": { "criterion": "P", "name": "Pronunciation", "bandRange": "1-9" }

--- a/apps/admin/e2e/fixtures/auth.fixture.ts
+++ b/apps/admin/e2e/fixtures/auth.fixture.ts
@@ -21,12 +21,16 @@ export const test = base.extend<AuthFixture>({
       await page.goto('/login', { timeout: isCloud ? 60000 : 30000 });
       await page.waitForLoadState('networkidle', { timeout: isCloud ? 30000 : 15000 });
 
+      // Toggle to password mode (login defaults to magic-link).
+      await page.getByRole('button', { name: 'Use a password instead' }).click();
+
       // Fill credentials
-      await page.locator('#email').fill(email);
+      await page.locator('#contact').fill(email);
+      await page.locator('#password').waitFor({ state: 'visible', timeout: 5000 });
       await page.locator('#password').fill(password);
 
       // Submit form
-      await page.locator('button[type="submit"]').click();
+      await page.locator('button.login-btn[type="submit"]').click();
 
       // Wait for redirect to /x (domcontentloaded — dashboard has long-lived connections that block 'load')
       await page.waitForURL(/\/x/, { timeout: isCloud ? 60000 : 15000, waitUntil: 'domcontentloaded' });
@@ -52,9 +56,11 @@ export const test = base.extend<AuthFixture>({
       await page.goto('/login');
       await page.waitForLoadState('domcontentloaded');
 
-      await page.locator('#email').fill(email);
+      await page.getByRole('button', { name: 'Use a password instead' }).click();
+      await page.locator('#contact').fill(email);
+      await page.locator('#password').waitFor({ state: 'visible', timeout: 5000 });
       await page.locator('#password').fill(password);
-      await page.locator('button[type="submit"]').click();
+      await page.locator('button.login-btn[type="submit"]').click();
 
       await page.waitForURL(/\/x/, { timeout: 10000 });
       await page.close();

--- a/apps/admin/e2e/global-setup.ts
+++ b/apps/admin/e2e/global-setup.ts
@@ -43,13 +43,19 @@ async function globalSetup(config: FullConfig) {
     const isCloud = !!process.env.CLOUD_E2E;
     console.log(`[Global Setup] baseURL=${baseURL}, isCloud=${isCloud}`);
     await page.goto(`${baseURL}/login`, { timeout: isCloud ? 60000 : 30000 });
-    // Wait for email input to appear (Turbopack may be compiling on first hit)
-    await page.locator('#email').waitFor({ state: 'visible', timeout: isCloud ? 60000 : 15000 });
+    // Wait for the contact (email-or-phone) input — the new 2-step
+    // magic/password login defaults to magic-link mode; password field
+    // is hidden until we toggle.
+    await page.locator('#contact').waitFor({ state: 'visible', timeout: isCloud ? 60000 : 15000 });
     console.log(`[Global Setup] Login page loaded at ${page.url()}`);
+
+    // Toggle to password mode so the #password field renders.
+    await page.getByRole('button', { name: 'Use a password instead' }).click();
 
     // Fill in credentials (using default admin user)
     const password = process.env.SEED_ADMIN_PASSWORD || 'admin123';
-    await page.locator('#email').fill('admin@test.com');
+    await page.locator('#contact').fill('admin@test.com');
+    await page.locator('#password').waitFor({ state: 'visible', timeout: 5000 });
     await page.locator('#password').fill(password);
 
     // Submit login form — scope to the login form so a stray

--- a/apps/admin/e2e/page-objects/sim.page.ts
+++ b/apps/admin/e2e/page-objects/sim.page.ts
@@ -51,8 +51,17 @@ export class SimPage extends BasePage {
     this.toast = page.locator('.wa-toast');
   }
 
-  /** Wait for the AI greeting message to appear */
+  /** Wait for the AI greeting message to appear.
+   *  Post-redesign the Sim picker no longer auto-greets — the operator
+   *  must click "Start chat session" to enter the chat surface, then
+   *  the AI emits the greeting bubble. */
   async waitForGreeting(timeout = 30_000): Promise<void> {
+    // Click "Start chat session" if the picker is rendered (no-op once
+    // the chat surface is mounted).
+    const startBtn = this.page.getByRole('button', { name: /Start chat session/i });
+    if (await startBtn.isVisible().catch(() => false)) {
+      await startBtn.click();
+    }
     // Wait for at least one assistant bubble with content
     await this.page.waitForFunction(
       () => {

--- a/apps/admin/evals/tutor/ux-a-pinned-visual-prompt-clarity.yaml
+++ b/apps/admin/evals/tutor/ux-a-pinned-visual-prompt-clarity.yaml
@@ -1,0 +1,130 @@
+description: "UX-A — pinned-visual prompt clarity (cue card + session focus visible on learner's screen)"
+
+# Run with: npx promptfoo eval -c evals/tutor/ux-a-pinned-visual-prompt-clarity.yaml --no-cache
+#
+# Closes findings 1 + 2 of the 2026-06-22 Learner SIM UX audit. Two prompt
+# directives now tell the AI that the learner can see the pinned content
+# on their screen:
+#
+#   1. CUE CARD directive (resolveModuleCueCard in
+#      lib/prompt/composition/transforms/instructions.ts) prefixed with
+#      "CUE CARD — visible on the learner's screen right now."
+#   2. SESSION FOCUS directive (resolveSessionFocus in
+#      lib/prompt/composition/transforms/session-focus.ts) prefixed with
+#      "Today's session focus (pinned on the learner's screen): ..."
+#
+# These evals pin behavioural intent against the upgraded prompts:
+#   - Cue card: AI references the card as a SHARED visual ("looking at
+#     your card…"), DOES NOT read the topic + bullets verbatim like a
+#     game-show host.
+#   - Session focus: AI references the pinned focus as a shared anchor
+#     ("the technique we're focusing on today"), DOES NOT re-explain that
+#     a focus exists.
+#
+# Source files:
+#   - apps/admin/lib/prompt/composition/transforms/instructions.ts
+#   - apps/admin/lib/prompt/composition/transforms/session-focus.ts
+# Companion vitests:
+#   - tests/lib/prompt/composition/transforms/instructions.test.ts (UX-A)
+#   - tests/lib/prompt/composition/transforms/session-focus.test.ts (UX-A)
+
+prompts:
+  - id: ux-a-pinned-visual-prompt
+    label: "Tutor opening — pinned cue card + session focus on screen"
+    raw: |
+      You are an IELTS Speaking tutor running a 1-to-1 voice session. The
+      learner has their screen in front of them showing pinned content.
+
+      ## How you communicate
+      - Warm, brief, conversational. 1-2 sentences for the opening.
+      - The learner can SEE pinned content on their screen — reference it
+        as a shared visual, do NOT narrate it back verbatim.
+      - NEVER expose internal field names. NEVER read lists verbatim.
+
+      ## Composed directives
+
+      {{cueCardDirective}}
+
+      {{sessionFocusDirective}}
+
+      ---
+      The learner has just joined. Speak first — your opening line plus
+      your first question to them.
+
+providers:
+  - id: anthropic:messages:claude-sonnet-4-6
+    config:
+      max_tokens: 400
+
+defaultTest:
+  vars: {}
+
+tests:
+
+  # ── CUE CARD — Findings 1 ──
+
+  - description: "UX-A.1 — Cue card: AI references it as a shared visual, does not narrate it back"
+    vars:
+      cueCardDirective: |
+        CUE CARD — visible on the learner's screen right now. Keep this topic central:
+        Topic: A book you enjoyed reading
+        Bullets:
+          - what it was about
+          - who wrote it
+          - why you enjoyed it
+      sessionFocusDirective: ""
+    assert:
+      - type: llm-rubric
+        value: "The AI references the cue card as a SHARED visual — e.g. 'looking at your card', 'on the card you can see', 'your card has…', or simply asks the learner to engage with the card. It does NOT read the cue card verbatim as if announcing it on a game show (e.g. 'Today your cue card is: A book you enjoyed reading. The bullets are: what it was about, who wrote it, why you enjoyed it'). It does NOT enumerate ALL three bullets in a list-dump."
+      - type: not-icontains
+        value: "Today your cue card is"
+      - type: not-icontains
+        value: "the bullets are"
+
+  - description: "UX-A.2 — Cue card: AI may name the topic to anchor, but does not robotically enumerate bullets"
+    vars:
+      cueCardDirective: |
+        CUE CARD — visible on the learner's screen right now. Keep this topic central:
+        Topic: A time you felt proud
+        Bullets:
+          - what happened
+          - who was there
+          - why it mattered
+      sessionFocusDirective: ""
+    assert:
+      - type: llm-rubric
+        value: "The opening is brief and warm. The AI does NOT read out all three bullets in a row like a list-dump (e.g. 'what happened, who was there, and why it mattered'). It treats the cue card as something the learner is looking at, not something the AI has to recite. Mentioning the topic name 'a time you felt proud' is fine; reciting the bullets is not."
+      - type: not-icontains
+        value: "what happened, who was there"
+
+  # ── SESSION FOCUS — Finding 2 ──
+
+  - description: "UX-A.3 — Session focus: AI references the pinned focus as a shared anchor, does not re-explain its existence"
+    vars:
+      cueCardDirective: ""
+      sessionFocusDirective: |
+        Today's session focus (pinned on the learner's screen): giving reasons. Steer your questions and feedback toward developing this technique throughout the session. Use the focus as the through-line — when the learner gives a brief answer, prompt them to apply giving reasons explicitly; when they do it well, name the technique back to them so they recognise the move.
+    assert:
+      - type: llm-rubric
+        value: "The AI references the focus 'giving reasons' as a SHARED anchor the learner can see — e.g. 'the technique we're focusing on today', 'as you can see at the top of your screen', 'today's focus on giving reasons', or simply incorporates it naturally into the first question. It does NOT re-explain that a focus exists from scratch (e.g. 'I want you to focus today on a technique called giving reasons — this means…'). The focus is the through-line, not a new concept being introduced."
+      - type: not-icontains
+        value: "I want you to focus today on a technique called"
+
+  - description: "UX-A.4 — Session focus: combined with cue card — AI uses both as visual anchors, asks first question quickly"
+    vars:
+      cueCardDirective: |
+        CUE CARD — visible on the learner's screen right now. Keep this topic central:
+        Topic: A skill you learned
+        Bullets:
+          - what skill
+          - how you learned it
+          - how you use it now
+      sessionFocusDirective: |
+        Today's session focus (pinned on the learner's screen): expanding an answer. Steer your questions and feedback toward developing this technique throughout the session. Use the focus as the through-line — when the learner gives a brief answer, prompt them to apply expanding an answer explicitly; when they do it well, name the technique back to them so they recognise the move.
+    assert:
+      - type: llm-rubric
+        value: "The AI references BOTH the cue card AND the session focus as things the learner can see, then moves to a first question that opens the practice. It does NOT enumerate the bullets verbatim, does NOT explain that there is a focus, and does NOT recite the topic + focus like a game-show host opening."
+      - type: not-icontains
+        value: "Today your cue card is"
+      - type: not-icontains
+        value: "I want you to focus today on a technique called"

--- a/apps/admin/lib/prompt/composition/transforms/instructions.ts
+++ b/apps/admin/lib/prompt/composition/transforms/instructions.ts
@@ -621,7 +621,7 @@ function resolveModuleQuestionTarget(
  * pick to `Session.metadata.pinnedCard` so the UI shows the same card
  * the prompt was composed with.
  */
-function resolveModuleCueCard(
+export function resolveModuleCueCard(
   config: PlaybookConfig,
   sharedState: AssembledContext["sharedState"],
 ): {
@@ -656,7 +656,12 @@ function resolveModuleCueCard(
   if (bullets.length === 0) return null;
 
   const bulletsList = bullets.map((b) => `  - ${b}`).join("\n");
-  const directive = `CUE CARD for this module — keep this topic central:\nTopic: ${picked.topic}\nBullets:\n${bulletsList}`;
+  // UX-A (Learner UX audit Finding 1): the learner can see this cue card
+  // on their screen right now — treat it as a SHARED reference, do not
+  // read it back verbatim. Wording aligned with `session-materials.ts`
+  // ("what the student can see on their screen") — the canonical voice
+  // for screen-shared content in composed prompts.
+  const directive = `CUE CARD — visible on the learner's screen right now. Keep this topic central:\nTopic: ${picked.topic}\nBullets:\n${bulletsList}`;
   return {
     kind: "cueCard",
     topic: picked.topic,

--- a/apps/admin/lib/prompt/composition/transforms/session-focus.ts
+++ b/apps/admin/lib/prompt/composition/transforms/session-focus.ts
@@ -110,7 +110,12 @@ export function resolveSessionFocus(
   const label = row.stringValue?.trim();
   if (!label) return null;
 
-  const directive = `Today's session focus: ${label}. Steer your questions and feedback toward developing this technique throughout the session. Use the focus as the through-line — when the learner gives a brief answer, prompt them to apply ${label} explicitly; when they do it well, name the technique back to them so they recognise the move.`;
+  // UX-A (Learner UX audit Finding 2): the focus label is pinned visibly
+  // at the top of the learner's screen — reference it as a shared anchor,
+  // do not re-explain its existence. Wording aligned with the canonical
+  // "visible on the learner's screen" voice used by `session-materials.ts`
+  // and the sibling cue-card directive in `transforms/instructions.ts`.
+  const directive = `Today's session focus (pinned on the learner's screen): ${label}. Steer your questions and feedback toward developing this technique throughout the session. Use the focus as the through-line — when the learner gives a brief answer, prompt them to apply ${label} explicitly; when they do it well, name the technique back to them so they recognise the move.`;
 
   const pinnedCard: PinnedCardContent = {
     kind: "topicFocus",

--- a/apps/admin/tests/lib/prompt/composition/transforms/instructions.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/transforms/instructions.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Behavioural tests for `lib/prompt/composition/transforms/instructions.ts`.
+ *
+ * Today this file pins ONE invariant — UX-A (Finding 1 of the 2026-06-22
+ * Learner UX audit): the cue-card directive must declare the card is
+ * visible on the learner's screen so the AI treats it as a SHARED
+ * reference, not narrates it back verbatim. Sibling assertion to the
+ * UX-A pin in `session-focus.test.ts`.
+ *
+ * Scope is deliberately narrow — the cue-card resolver has many other
+ * branches (flag-off / no locked module / empty pool / missing topic) but
+ * those are covered structurally by:
+ *   - `tests/lib/prompt/composition/coverage-producer-consumer.test.ts`
+ *     (producer ↔ renderer pairing)
+ *   - `tests/lib/sim-chat/bdd-typed-unions-coverage.test.ts`
+ *     (cue-card shape vs BDD union)
+ *   - the ESLint sentinel `composition-directive-needs-renderer`.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { resolveModuleCueCard } from "@/lib/prompt/composition/transforms/instructions";
+import type { AssembledContext } from "@/lib/prompt/composition/types";
+import type { AuthoredModule, PlaybookConfig } from "@/lib/types/json-fields";
+
+const ORIGINAL_FLAG = process.env.HF_FLAG_IELTS_MODULE_SETTINGS;
+
+beforeAll(() => {
+  process.env.HF_FLAG_IELTS_MODULE_SETTINGS = "true";
+});
+
+afterEach(() => {
+  // Keep flag ON between tests; clear at the very end. Vitest runs
+  // describe/it sequentially in this file so no interleaving.
+});
+
+afterAll(() => {
+  if (ORIGINAL_FLAG === undefined) {
+    delete process.env.HF_FLAG_IELTS_MODULE_SETTINGS;
+  } else {
+    process.env.HF_FLAG_IELTS_MODULE_SETTINGS = ORIGINAL_FLAG;
+  }
+});
+
+function buildConfig(card: { topic: string; bullets: string[] }): PlaybookConfig {
+  const authoredModule: AuthoredModule = {
+    id: "part2",
+    slug: "part2",
+    title: "Part 2 — Long-turn cue cards",
+    mode: "examiner",
+    settings: {
+      cueCardPool: [card],
+    },
+  } as unknown as AuthoredModule;
+  return { modules: [authoredModule] } as unknown as PlaybookConfig;
+}
+
+function buildSharedState(): AssembledContext["sharedState"] {
+  return {
+    lockedModule: { id: "part2", slug: "part2" },
+    callNumber: 1,
+  } as unknown as AssembledContext["sharedState"];
+}
+
+describe("resolveModuleCueCard", () => {
+  describe("UX-A — pinned-visual prompt clarity (audit Finding 1)", () => {
+    it("directive declares the cue card is visible on the learner's screen", () => {
+      // Without this signal the AI over-narrates ("Today your cue card is…").
+      // The literal phrase is pinned so a future refactor can't silently
+      // drop it.
+      const out = resolveModuleCueCard(
+        buildConfig({
+          topic: "A book you enjoyed reading",
+          bullets: ["what it was about", "who wrote it", "why you enjoyed it"],
+        }),
+        buildSharedState(),
+      );
+      expect(out).not.toBeNull();
+      expect(out!.directive).toContain("visible on the learner's screen");
+    });
+
+    it("directive still carries the topic + bullets so the AI can anchor to them", () => {
+      const out = resolveModuleCueCard(
+        buildConfig({
+          topic: "A time you felt proud",
+          bullets: ["what happened", "who was there", "why it mattered"],
+        }),
+        buildSharedState(),
+      );
+      expect(out).not.toBeNull();
+      expect(out!.directive).toContain("A time you felt proud");
+      expect(out!.directive).toContain("what happened");
+      expect(out!.directive).toContain("who was there");
+      expect(out!.directive).toContain("why it mattered");
+    });
+
+    it("directive does NOT leak internal labels (criterion names, parameter ids)", () => {
+      // Defensive pin sibling to `learner-ui-leak-coverage.test.ts`.
+      // The cue-card pool carries learner-safe topic + bullets only —
+      // confirm the directive does not splice in any internal taxonomy.
+      const out = resolveModuleCueCard(
+        buildConfig({
+          topic: "A skill you learned",
+          bullets: ["what skill", "how you learned it", "how you use it"],
+        }),
+        buildSharedState(),
+      );
+      expect(out).not.toBeNull();
+      expect(out!.directive).not.toMatch(/Lexical Resource/);
+      expect(out!.directive).not.toMatch(/Fluency and Coherence/);
+      expect(out!.directive).not.toMatch(/Grammatical Range/);
+      expect(out!.directive).not.toMatch(/skill_/);
+    });
+  });
+});

--- a/apps/admin/tests/lib/prompt/composition/transforms/session-focus.test.ts
+++ b/apps/admin/tests/lib/prompt/composition/transforms/session-focus.test.ts
@@ -215,6 +215,28 @@ describe("resolveSessionFocus", () => {
       expect(out).toBeNull();
     });
 
+    it("UX-A: directive declares the focus is pinned on the learner's screen", () => {
+      // Finding 2 of the 2026-06-22 Learner UX audit: the AI must know the
+      // focus label is visible to the learner so it can reference it as a
+      // shared anchor ("the technique we're focusing on today") rather than
+      // re-explaining its existence. Pinning the literal phrase prevents a
+      // future refactor from silently dropping the visibility signal.
+      const out = resolveSessionFocus(
+        EMPTY_CONFIG,
+        buildContext({
+          lockedModule: { id: "part3", slug: "part3" },
+          callerAttributes: [
+            {
+              key: "session_focus:next_part3",
+              stringValue: "giving reasons",
+            },
+          ],
+        }),
+      );
+      expect(out).not.toBeNull();
+      expect(out!.directive).toContain("pinned on the learner's screen");
+    });
+
     it("prefers slug over id for the key suffix", () => {
       const out = resolveSessionFocus(
         EMPTY_CONFIG,


### PR DESCRIPTION
## Summary

- Add `"isAdjustable": true` to the 4 LLM-judged IELTS skill params in `IELTS-MEASURE-001-ielts-speaking-criteria.spec.json` so `compile-targets` can seed PLAYBOOK-scope BehaviorTargets for them.
- Unblocks IELTS-MEASURE-001 from being silently dropped by `filterByBehaviorTargetParams` (live diagnosed on hf_sandbox 2026-06-23).
- Quick fix paired with durable redesign in #2271 (per-course cascade signal so STATE-typed scoring specs don't need fake BehaviorTargets).

## Verified by

**Live diagnosis on hf_sandbox** via authed curl probes against running dev server:

- `GET /api/analysis-specs?slug=spec-ielts-measure-001` — spec active, `isActive: true`, `config.requiresBehaviorTargetParams: true`, declares 4 paramIds with `_fc/_lr/_gra/_p` suffix
- `GET /api/playbooks/20b21160-0516-49c9-a8da-105772f41e64/targets` — 88 params with cascade; canonical no-suffix Skills Framework params present at PLAYBOOK=0.65; suffixed LLM-judged params absent
- `GET /api/analysis-specs/d43933c9-776b-4706-a835-2e22f4e925ab` — 4 actions reference suffixed paramIds
- `POST /api/playbooks/.../compile-targets` returned `compiled: 0, skipped: 4` — only canonical siblings seeded; suffixed params skipped due to `isAdjustable: false` filter at `compile-targets/route.ts:101`
- Tracing through `seed-from-specs.ts:375` — `isAdjustable: param.isAdjustable || false` defaults to false when JSON omits the field

**Net effect pre-fix**: every IELTS Speaking call silently runs without LLM-judged criterion scoring. BDD "Part B — Performance assessment, all 4 criteria" requirement not served on the IELTS Speaking Practice playbook.

## Lattice survey result

- **Sibling-writer survey**: `compile-targets` (PLAYBOOK-scope BT seeder), `applyProjection → diffBehaviorTargets` (seeds canonical no-suffix only), `writeBehaviorTargets` (operator PATCH path) — all three filter to `isAdjustable: true`. Adding the flag is convergent with all three.
- **Default-deny gate (Lattice pillar #2)**: `filterByBehaviorTargetParams` is the gate; flag addition makes it pass without changing gate logic.
- **Cascade respect**: `aiMeasurement.disableLlmIeltsScoring` cascade (PR #2158) preserved — this fix doesn't override the per-course kill-switch.
- **Convention conflict**: Semantic compromise (STATE params marked adjustable) is bounded — gate reads BT row existence only, not value. Durable redesign in #2271 retires the gate's premise.

## Post-merge steps required

1. `/vm-cp` pushes branch to hf-dev VM
2. Re-seed on VM: `cd ~/HF/apps/admin && npx tsx prisma/seed-from-specs.ts` (or scoped to IELTS-MEASURE-001)
3. `POST /api/playbooks/20b21160-0516-49c9-a8da-105772f41e64/compile-targets` to seed the 4 suffixed BTs
4. Verify: GET targets endpoint shows the 4 suffixed BTs at PLAYBOOK=SYSTEM-default
5. Live-call test: real IELTS call → check `CallScore` rows for all 4 criteria

## Test plan

- [ ] JSON parses (verified: `python3 -c "import json; json.load(...)"` returns clean)
- [ ] On VM: re-seed bumps the 4 Param rows to `isAdjustable: true`
- [ ] On VM: `compile-targets` creates 4 new PLAYBOOK-scope BT rows
- [ ] On VM: `filterByBehaviorTargetParams` log shows IELTS-MEASURE-001 "running" (not "dropping")
- [ ] End-to-end: real call → `CallScore` rows for all 4 IELTS skill paramIds

🤖 Generated with [Claude Code](https://claude.com/claude-code)