### PR TITLE
fix(#2271): forward parameters[].isAdjustable through JSON spec parser

### DIFF
--- a/apps/admin/lib/bdd/ai-parser.ts
+++ b/apps/admin/lib/bdd/ai-parser.ts
@@ -236,6 +236,7 @@ export interface ParsedParameter {
   workedExample?: WorkedExample;
   scoringAnchors?: ScoringAnchor[];
   promptGuidance?: PromptGuidanceItem[];
+  isAdjustable?: boolean;
 }
 
 export interface Submetric {
@@ -839,6 +840,7 @@ export function convertJsonSpecToHybrid(spec: JsonFeatureSpec): ParsedHybridResu
       interpretationScale: p.interpretationScale,
       scoringAnchors: p.scoringAnchors,
       promptGuidance,
+      isAdjustable: p.isAdjustable,
       // Preserve config for IDENTITY and CONTENT specs
       config: p.config,
     };

--- a/apps/admin/tests/lib/bdd/ai-parser.test.ts
+++ b/apps/admin/tests/lib/bdd/ai-parser.test.ts
@@ -472,6 +472,32 @@ describe("convertJsonSpecToHybrid", () => {
     expect(result.storyData!.failureConditions).toEqual([]);
     expect(result.parameterData!.parameters[0].submetrics).toEqual([]);
   });
+
+  it("forwards parameters[].isAdjustable from JSON to ParsedParameter (#2271 follow-on)", () => {
+    // Regression pin: convertJsonSpecToHybrid used to silently drop
+    // `isAdjustable` because the explicit-field return shape did not
+    // include it. Result: seed-from-specs.ts:375 read `param.isAdjustable`
+    // as undefined → wrote `isAdjustable: false` on every Parameter row
+    // regardless of what the spec JSON declared. The IELTS-MEASURE-001
+    // gate was the live fingerprint (PR #2273).
+    const spec: JsonFeatureSpec = {
+      id: "ADJ-FORWARD-001",
+      title: "Adjustability forwarding",
+      version: "1.0",
+      story: { asA: "a", iWant: "b", soThat: "c" },
+      parameters: [
+        { id: "P-ADJ", name: "p_adj", description: "d", isAdjustable: true },
+        { id: "P-NO", name: "p_no", description: "d", isAdjustable: false },
+        { id: "P-OMIT", name: "p_omit", description: "d" },
+      ],
+    };
+
+    const result = convertJsonSpecToHybrid(spec);
+    const params = result.parameterData!.parameters;
+    expect(params[0].isAdjustable).toBe(true);
+    expect(params[1].isAdjustable).toBe(false);
+    expect(params[2].isAdjustable).toBeUndefined();
+  });
 });
 
 // =====================================================


### PR DESCRIPTION
## Summary

- `convertJsonSpecToHybrid` in `lib/bdd/ai-parser.ts` silently dropped `parameters[].isAdjustable` from the JSON → `ParsedParameter` conversion (explicit-field return shape didn't list it).
- Downstream `seed-from-specs.ts:375` reads `param.isAdjustable || false` from this converted shape → every Parameter row got `isAdjustable=false` regardless of what the spec JSON declared.
- Live fingerprint: PR #2273's spec-JSON edit was a no-op because of this bug. The Sand + DEV unblock had to be applied via direct DB writes.

## What changed

| File | Change |
|---|---|
| `apps/admin/lib/bdd/ai-parser.ts` | Add `isAdjustable?: boolean` to `ParsedParameter` interface + forward `p.isAdjustable` in the map return |
| `apps/admin/tests/lib/bdd/ai-parser.test.ts` | Regression vitest pinning the forwarding (3-row test: true, false, omitted) |

## Verified by

- `npx vitest run tests/lib/bdd/ai-parser.test.ts` — all 70 tests pass including the new regression case
- `npx tsc --noEmit | grep ai-parser` — no errors in changed files (pre-existing tsc errors in unrelated test files are NOT mine)

## Why this matters

Without this fix, the next re-seed on hf_sandbox or hf_staging would WIPE the manually-applied `isAdjustable=true` flag on the 4 IELTS skill parameters (BTs would survive, but `compile-targets` re-runs would silently skip those params again — recreating the original silent-drop class).

## Lattice notes

- Sibling-writer survey: `convertJsonSpecToHybrid` is the only path from JSON spec → seed pipeline. Adding a field to the explicit-shape return is convergent with the existing pattern.
- The structural inverse (gate's reliance on BT presence for STATE-typed scoring specs) remains tracked under #2271 — this PR only closes the parser bug.

## Test plan

- [x] vitest passes including the regression pin
- [ ] On main after merge: re-seed IELTS-MEASURE-001 on Sand → verify `Parameter.isAdjustable=true` survives the re-seed (instead of getting wiped back to false)
- [ ] Same check on hf_staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)