### PR TITLE
feat(journey): #2266 S1 — lift 8 useJourneyChat strings to cascade

### DIFF
--- a/apps/admin/components/student/WelcomeSurveyFlow.tsx
+++ b/apps/admin/components/student/WelcomeSurveyFlow.tsx
@@ -19,6 +19,14 @@ import {
   type SurveyEndAction,
 } from "@/lib/learner/survey-config";
 import { DEFAULT_PERSONALITY_QUESTIONS } from "@/lib/assessment/personality-defaults";
+// PR #2266 S1 — shared canonical defaults + token applier. Same source
+// of truth used by `hooks/useJourneyChat.ts`; this component's
+// `buildPersonalitySteps` + `buildPreTestSteps` were verbatim duplicates
+// of the hook's pre-cascade literals.
+import {
+  ONBOARDING_COPY_DEFAULTS,
+  applyCopyTokens,
+} from "@/lib/learner/onboarding-copy-defaults";
 import { isSummaryAction } from "@/lib/learner/survey-end-action";
 import { StopSummaryCard } from "@/components/student/StopSummaryCard";
 import "@/app/x/student/welcome/welcome.css";
@@ -58,40 +66,44 @@ function buildPersonalitySteps(
   configs: SurveyStepConfig[],
   subject: string,
   teacherName: string,
+  aboutYouIntroOverride?: string | null,
 ): SurveyStep[] {
   const steps: SurveyStep[] = configs.map((c) => ({
     ...c,
     prompt: c.prompt.replace(/\{subject\}/g, subject),
   }));
 
+  const prompt = applyCopyTokens(
+    aboutYouIntroOverride ?? ONBOARDING_COPY_DEFAULTS.aboutYouIntro,
+    { subject, teacherName },
+  );
   return [
-    {
-      id: "_greeting",
-      type: "message",
-      prompt: `Hey! I'm your AI study partner for ${subject}. ${teacherName ? `${teacherName} set this up for you.` : ""} Before we dive in, I'd love to learn a bit about you.`,
-    },
+    { id: "_greeting", type: "message", prompt },
     ...steps,
   ];
 }
 
-function buildPreTestSteps(configs: SurveyStepConfig[], subject: string): SurveyStep[] {
+function buildPreTestSteps(
+  configs: SurveyStepConfig[],
+  subject: string,
+  preTestIntroOverride?: string | null,
+  preTestClosingOverride?: string | null,
+): SurveyStep[] {
   const steps: SurveyStep[] = configs.map((c) => ({
     ...c,
     prompt: c.prompt.replace(/\{subject\}/g, subject),
   }));
 
+  const introPrompt = applyCopyTokens(
+    preTestIntroOverride ?? ONBOARDING_COPY_DEFAULTS.preTestIntro,
+    { subject, questionCount: configs.length },
+  );
+  const closingPrompt =
+    preTestClosingOverride ?? ONBOARDING_COPY_DEFAULTS.preTestClosing;
   return [
-    {
-      id: "_pretest_intro",
-      type: "message",
-      prompt: `Now let's do a quick knowledge check on ${subject} — just ${configs.length} questions. Don't worry about getting them right, this just helps me understand where you're starting from.`,
-    },
+    { id: "_pretest_intro", type: "message", prompt: introPrompt },
     ...steps,
-    {
-      id: "_pretest_done",
-      type: "message",
-      prompt: "Brilliant! I've got everything I need. Let's start your first practice session — you're going to do great.",
-    },
+    { id: "_pretest_done", type: "message", prompt: closingPrompt },
   ];
 }
 
@@ -118,26 +130,42 @@ export function WelcomeSurveyFlow({ callerId, onComplete, onAlreadyDone }: Welco
   // Persona tone
   const [tone, setTone] = useState("default");
 
+  // PR #2266 S1 — cascade-resolved learner copy from /api/student/progress.
+  // Falls through to canonical defaults in onboarding-copy-defaults.ts.
+  const [aboutYouIntro, setAboutYouIntro] = useState<string | null>(null);
+  const [preTestIntro, setPreTestIntro] = useState<string | null>(null);
+  const [preTestClosing, setPreTestClosing] = useState<string | null>(null);
+
   const url = useCallback((base: string, extra?: Record<string, string>) => buildUrl(base, callerId, extra), [callerId]);
 
   // Init: check completion + load config + assessment questions
   useEffect(() => {
     async function init(): Promise<void> {
       try {
-        const [surveyRes, teacherRes, configRes, personalityRes, preTestRes] = await Promise.all([
+        const [surveyRes, teacherRes, configRes, personalityRes, preTestRes, progressRes] = await Promise.all([
           fetch(url(`/api/student/survey`, { scope: SURVEY_SCOPES.PRE })),
           fetch(url("/api/student/teacher")),
           fetch(url("/api/student/survey-config")),
           fetch(url(`/api/student/survey`, { scope: SURVEY_SCOPES.PERSONALITY })),
           fetch(url("/api/student/assessment-questions", { type: "pre_test" })),
+          // PR #2266 S1 — cascade-resolved aboutYouIntro / preTestIntro /
+          // preTestClosing from /api/student/progress.
+          fetch(url("/api/student/progress")),
         ]);
-        const [surveyData, teacherData, configData, personalityData, preTestData] = await Promise.all([
+        const [surveyData, teacherData, configData, personalityData, preTestData, progressData] = await Promise.all([
           surveyRes.json(),
           teacherRes.json(),
           configRes.json(),
           personalityRes.json(),
           preTestRes.json(),
+          progressRes.json(),
         ]);
+
+        // Stash cascade overrides — read by buildPersonalitySteps +
+        // buildPreTestSteps at render time.
+        if (progressData?.aboutYouIntro) setAboutYouIntro(progressData.aboutYouIntro);
+        if (progressData?.preTestIntro) setPreTestIntro(progressData.preTestIntro);
+        if (progressData?.preTestClosing) setPreTestClosing(progressData.preTestClosing);
 
         if (teacherData.ok) {
           setSubject(teacherData.domain || "this subject");
@@ -350,7 +378,7 @@ export function WelcomeSurveyFlow({ callerId, onComplete, onAlreadyDone }: Welco
           {phaseIndicator}
         </div>
         <ChatSurvey
-          steps={buildPersonalitySteps(personalityConfigs, subject, teacherName)}
+          steps={buildPersonalitySteps(personalityConfigs, subject, teacherName, aboutYouIntro)}
           tutorName="AI Tutor"
           onComplete={handlePersonalityComplete}
           submitting={submitting}
@@ -368,7 +396,7 @@ export function WelcomeSurveyFlow({ callerId, onComplete, onAlreadyDone }: Welco
           {phaseIndicator}
         </div>
         <ChatSurvey
-          steps={buildPreTestSteps(preTestConfigs, subject)}
+          steps={buildPreTestSteps(preTestConfigs, subject, preTestIntro, preTestClosing)}
           tutorName="AI Tutor"
           onComplete={handlePreTestComplete}
           submitting={submitting}

--- a/apps/admin/hooks/useJourneyChat.ts
+++ b/apps/admin/hooks/useJourneyChat.ts
@@ -104,35 +104,79 @@ function dividerItem(label: string): DividerItem {
   return { id: nextId(), kind: 'divider', label, timestamp: new Date() };
 }
 
+// Default literals for the 6 build*Steps helpers. The cascade overrides
+// (`progressData.aboutYouIntro` etc.) fall through to these when null.
+// These are also the canonical defaults shared with `WelcomeSurveyFlow.tsx`
+// (kept in sync via lib/learner/onboarding-copy-defaults.ts).
+import {
+  ONBOARDING_COPY_DEFAULTS,
+  applyCopyTokens,
+} from '@/lib/learner/onboarding-copy-defaults';
+
 // Build personality survey steps with greeting
-function buildPersonalitySteps(configs: SurveyStepConfig[], subject: string, teacherName: string): SurveyStep[] {
+function buildPersonalitySteps(
+  configs: SurveyStepConfig[],
+  subject: string,
+  teacherName: string,
+  aboutYouIntroOverride?: string | null,
+): SurveyStep[] {
+  const prompt = applyCopyTokens(
+    aboutYouIntroOverride ?? ONBOARDING_COPY_DEFAULTS.aboutYouIntro,
+    { subject, teacherName },
+  );
   return [
-    { id: '_greeting', type: 'message', prompt: `Hey! I'm your AI study partner for ${subject}. ${teacherName ? `${teacherName} set this up for you.` : ''} Before we dive in, I'd love to learn a bit about you.` },
+    { id: '_greeting', type: 'message', prompt },
     ...configs.map((c) => ({ ...c, prompt: c.prompt.replace(/\{subject\}/g, subject) })),
   ];
 }
 
-function buildPreTestSteps(configs: SurveyStepConfig[], subject: string): SurveyStep[] {
+function buildPreTestSteps(
+  configs: SurveyStepConfig[],
+  subject: string,
+  preTestIntroOverride?: string | null,
+  preTestClosingOverride?: string | null,
+): SurveyStep[] {
+  const introPrompt = applyCopyTokens(
+    preTestIntroOverride ?? ONBOARDING_COPY_DEFAULTS.preTestIntro,
+    { subject, questionCount: configs.length },
+  );
+  const closingPrompt = preTestClosingOverride ?? ONBOARDING_COPY_DEFAULTS.preTestClosing;
   return [
-    { id: '_pretest_intro', type: 'message' as const, prompt: `Now let's do a quick knowledge check on ${subject} — just ${configs.length} questions. Don't worry about getting them right, this just helps me understand where you're starting from.` },
+    { id: '_pretest_intro', type: 'message' as const, prompt: introPrompt },
     ...configs.map((c) => ({ ...c, prompt: c.prompt.replace(/\{subject\}/g, subject) })),
-    { id: '_pretest_done', type: 'message' as const, prompt: "Brilliant! I've got everything I need. Let's start your first practice session — you're going to do great." },
+    { id: '_pretest_done', type: 'message' as const, prompt: closingPrompt },
   ];
 }
 
-function buildPostTestSteps(configs: SurveyStepConfig[], subject: string): SurveyStep[] {
+function buildPostTestSteps(
+  configs: SurveyStepConfig[],
+  subject: string,
+  postTestIntroOverride?: string | null,
+  postTestClosingOverride?: string | null,
+): SurveyStep[] {
+  const introPrompt = applyCopyTokens(
+    postTestIntroOverride ?? ONBOARDING_COPY_DEFAULTS.postTestIntro,
+    { subject, questionCount: configs.length },
+  );
+  const closingPrompt = postTestClosingOverride ?? ONBOARDING_COPY_DEFAULTS.postTestClosing;
   return [
-    { id: '_posttest_intro', type: 'message' as const, prompt: `One last thing — let's see how much your ${subject} comprehension has grown. ${configs.length} questions, same skills we've been working on.` },
+    { id: '_posttest_intro', type: 'message' as const, prompt: introPrompt },
     ...configs.map((c) => ({ ...c, prompt: c.prompt.replace(/\{subject\}/g, subject) })),
-    { id: '_posttest_done', type: 'message' as const, prompt: "Brilliant! Let's wrap up with some quick feedback." },
+    { id: '_posttest_done', type: 'message' as const, prompt: closingPrompt },
   ];
 }
 
-function buildPostSteps(configs: SurveyStepConfig[]): SurveyStep[] {
+function buildPostSteps(
+  configs: SurveyStepConfig[],
+  journeyExitIntroOverride?: string | null,
+  journeyExitClosingOverride?: string | null,
+): SurveyStep[] {
+  const intro = journeyExitIntroOverride ?? ONBOARDING_COPY_DEFAULTS.journeyExitIntro;
+  const closing = journeyExitClosingOverride ?? ONBOARDING_COPY_DEFAULTS.journeyExitClosing;
   return [
-    { id: '_post_greeting', type: 'message' as const, prompt: "You've finished all your sessions — amazing work! Before you go, I'd love to hear how it went." },
+    { id: '_post_greeting', type: 'message' as const, prompt: intro },
     ...configs,
-    { id: '_post_thanks', type: 'message' as const, prompt: "Thanks so much for your feedback! You've been brilliant. Good luck with everything!" },
+    { id: '_post_thanks', type: 'message' as const, prompt: closing },
   ];
 }
 
@@ -315,13 +359,15 @@ export function useJourneyChat({ callerId, forceFirstCall, callerRole }: UseJour
     try {
       pushItems(dividerItem('Course Feedback'));
 
-      const [surveyRes, configRes, postTestRes] = await Promise.all([
+      const [surveyRes, configRes, postTestRes, progressRes] = await Promise.all([
         fetch(url('/api/student/survey', callerId, { scope: SURVEY_SCOPES.POST })),
         fetch(url('/api/student/survey-config', callerId)),
         fetch(url('/api/student/assessment-questions', callerId, { type: 'post_test' })),
+        // PR #2266 S1 — post-test + journey-exit overrides.
+        fetch(url('/api/student/progress', callerId)),
       ]);
-      const [surveyData, configData, postTestData] = await Promise.all([
-        surveyRes.json(), configRes.json(), postTestRes.json(),
+      const [surveyData, configData, postTestData, progressData] = await Promise.all([
+        surveyRes.json(), configRes.json(), postTestRes.json(), progressRes.json(),
       ]);
 
       // Already done?
@@ -334,7 +380,16 @@ export function useJourneyChat({ callerId, forceFirstCall, callerRole }: UseJour
       const postTestEnabled = configData?.ok && configData.assessment?.postTest?.enabled;
       if (postTestEnabled && postTestData?.ok && !postTestData.skipped && postTestData.questions?.length > 0) {
         const subject = configData.subject || subjectRef.current;
-        startSurveyPhase('post_test', buildPostTestSteps(postTestData.questions, subject), postTestData.questionIds);
+        startSurveyPhase(
+          'post_test',
+          buildPostTestSteps(
+            postTestData.questions,
+            subject,
+            progressData?.postTestIntro ?? null,
+            progressData?.postTestClosing ?? null,
+          ),
+          postTestData.questionIds,
+        );
         return;
       }
 
@@ -344,7 +399,14 @@ export function useJourneyChat({ callerId, forceFirstCall, callerRole }: UseJour
         postConfigs = configData.postSurvey.surveySteps;
       }
 
-      startSurveyPhase('post', buildPostSteps(postConfigs));
+      startSurveyPhase(
+        'post',
+        buildPostSteps(
+          postConfigs,
+          progressData?.journeyExitIntro ?? null,
+          progressData?.journeyExitClosing ?? null,
+        ),
+      );
     } catch (err) {
       console.error('[journey] post-survey load failed:', err);
       setState('teaching');
@@ -384,13 +446,15 @@ export function useJourneyChat({ callerId, forceFirstCall, callerRole }: UseJour
         const overflow = goals.length - visibleGoals.length;
         const goalList = visibleGoals.map((g: { name: string }) => `• ${g.name}`).join('\n');
         const tail = overflow > 0 ? `\n• …and ${overflow} more` : '';
-        pushItems(textItem('assistant', `Here's what we'll work on:\n${goalList}${tail}`));
+        const goalsPreamble =
+          progressData.goalsPreamble ?? ONBOARDING_COPY_DEFAULTS.goalsPreamble;
+        pushItems(textItem('assistant', `${goalsPreamble}\n${goalList}${tail}`));
       }
 
       // Course-scoped closing CTA — Playbook.config.onboardingClosingLine.
-      // Falls back to the original hardcoded literal when null.
+      // Falls back to the canonical default literal when null.
       const closingLine: string =
-        progressData.onboardingClosingLine ?? "We'll adapt as we go. Let's get started!";
+        progressData.onboardingClosingLine ?? ONBOARDING_COPY_DEFAULTS.onboardingClosingLine;
       pushItems(textItem('assistant', closingLine));
 
       const hasMorePhases = welcomeQueueRef.current.length > 0;
@@ -434,14 +498,20 @@ export function useJourneyChat({ callerId, forceFirstCall, callerRole }: UseJour
   // ── Load a single pre-survey phase (aboutYou = personality, knowledgeCheck = pre-test) ──
   const loadPreSurveyPhase = useCallback(async (phase: 'aboutYou' | 'knowledgeCheck') => {
     try {
-      const [teacherRes, configRes, personalityRes, preTestRes] = await Promise.all([
+      const [teacherRes, configRes, personalityRes, preTestRes, progressRes] = await Promise.all([
         fetch(url('/api/student/teacher', callerId)),
         fetch(url('/api/student/survey-config', callerId)),
         fetch(url(`/api/student/survey`, callerId, { scope: SURVEY_SCOPES.PERSONALITY })),
         fetch(url('/api/student/assessment-questions', callerId, { type: 'pre_test' })),
+        // PR #2266 S1 — progress endpoint surfaces the onboarding-copy
+        // cascade bundle (aboutYouIntro / preTestIntro / preTestClosing
+        // resolved server-side). Phase loader passes the overrides into
+        // the build* helpers; they fall through to the canonical
+        // defaults in lib/learner/onboarding-copy-defaults.ts when null.
+        fetch(url('/api/student/progress', callerId)),
       ]);
-      const [teacherData, configData, personalityData, preTestData] = await Promise.all([
-        teacherRes.json(), configRes.json(), personalityRes.json(), preTestRes.json(),
+      const [teacherData, configData, personalityData, preTestData, progressData] = await Promise.all([
+        teacherRes.json(), configRes.json(), personalityRes.json(), preTestRes.json(), progressRes.json(),
       ]);
 
       let subject = 'this subject';
@@ -465,7 +535,15 @@ export function useJourneyChat({ callerId, forceFirstCall, callerRole }: UseJour
         const personalityDone = personalityData.ok && personalityData.answers?.submitted_at;
         if (!personalityDone) {
           pushItems(dividerItem('About You'));
-          startSurveyPhase('personality', buildPersonalitySteps(personalityConfigs, subject, teacherName));
+          startSurveyPhase(
+            'personality',
+            buildPersonalitySteps(
+              personalityConfigs,
+              subject,
+              teacherName,
+              progressData?.aboutYouIntro ?? null,
+            ),
+          );
           return;
         }
         // Already done — advance to next phase
@@ -473,7 +551,16 @@ export function useJourneyChat({ callerId, forceFirstCall, callerRole }: UseJour
       } else if (phase === 'knowledgeCheck') {
         if (preTestData.ok && !preTestData.skipped && preTestData.questions?.length > 0) {
           pushItems(dividerItem('Knowledge Check'));
-          startSurveyPhase('pre_test', buildPreTestSteps(preTestData.questions, subject), preTestData.questionIds);
+          startSurveyPhase(
+            'pre_test',
+            buildPreTestSteps(
+              preTestData.questions,
+              subject,
+              progressData?.preTestIntro ?? null,
+              progressData?.preTestClosing ?? null,
+            ),
+            preTestData.questionIds,
+          );
           return;
         }
         // No pre-test available — advance
@@ -611,13 +698,26 @@ export function useJourneyChat({ callerId, forceFirstCall, callerRole }: UseJour
           // After post-test MCQs → transition to post satisfaction survey
           if (completedPhase === 'post_test') {
             try {
-              const configRes = await fetch(url('/api/student/survey-config', callerId));
-              const configData = await configRes.json();
+              const [configRes, progressRes] = await Promise.all([
+                fetch(url('/api/student/survey-config', callerId)),
+                fetch(url('/api/student/progress', callerId)),
+              ]);
+              const [configData, progressData] = await Promise.all([
+                configRes.json(),
+                progressRes.json(),
+              ]);
               let postConfigs: SurveyStepConfig[] = DEFAULT_OFFBOARDING_SURVEY;
               if (configData?.ok && configData.offboarding?.surveySteps?.length > 0) {
                 postConfigs = configData.offboarding.surveySteps;
               }
-              startSurveyPhase('post', buildPostSteps(postConfigs));
+              startSurveyPhase(
+                'post',
+                buildPostSteps(
+                  postConfigs,
+                  progressData?.journeyExitIntro ?? null,
+                  progressData?.journeyExitClosing ?? null,
+                ),
+              );
               return;
             } catch {}
           }

--- a/apps/admin/lib/journey/setting-contracts.entries.ts
+++ b/apps/admin/lib/journey/setting-contracts.entries.ts
@@ -267,6 +267,78 @@ const G1_ONBOARDING_CLOSING_LINE: JourneySettingContract = {
   previewLocators: [{ section: "onboarding", hint: "closing CTA tail" }],
 };
 
+const G1_GOALS_PREAMBLE: JourneySettingContract = {
+  id: "goalsPreamble",
+  menuGroupKey: "A_intake",
+  group: "G1",
+  educatorLabel: "Goals preamble",
+  helpText:
+    "One-liner shown above the goals bullet list during the FOH onboarding sequence. Default: \"Here's what we'll work on:\".",
+  storagePath: "config.goalsPreamble",
+  control: "text",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["onboarding"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "onboarding", hint: "goals preamble" }],
+};
+
+const G1_ABOUT_YOU_INTRO: JourneySettingContract = {
+  id: "aboutYouIntro",
+  menuGroupKey: "A_intake",
+  group: "G1",
+  educatorLabel: '"About you" intro line',
+  helpText:
+    "Greeting at the start of the personality / About-You survey on Call 1. Supports {subject} + {teacherName} tokens. Default: \"Hey! I'm your AI study partner for {subject}…\".",
+  storagePath: "config.aboutYouIntro",
+  control: "text",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["intake"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "intake", hint: "about-you intro" }],
+};
+
+const G1_PRE_TEST_INTRO: JourneySettingContract = {
+  id: "preTestIntro",
+  menuGroupKey: "A_intake",
+  group: "G1",
+  educatorLabel: "Pre-test intro line",
+  helpText:
+    "Intro shown above the pre-test knowledge check. Supports {subject} + {questionCount} tokens. Default: \"Now let's do a quick knowledge check on {subject}…\".",
+  storagePath: "config.preTestIntro",
+  control: "text",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["intake"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "intake", hint: "pre-test intro" }],
+};
+
+const G1_PRE_TEST_CLOSING: JourneySettingContract = {
+  id: "preTestClosing",
+  menuGroupKey: "A_intake",
+  group: "G1",
+  educatorLabel: "Pre-test closing line",
+  helpText:
+    "Closing line shown after the pre-test knowledge check before the first session. Default: \"Brilliant! I've got everything I need. Let's start your first practice session — you're going to do great.\".",
+  storagePath: "config.preTestClosing",
+  control: "text",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["intake"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "intake", hint: "pre-test closing" }],
+};
+
 // =============================================================
 // G2 — Call 1 — opening & assessment (6)
 // =============================================================
@@ -1460,6 +1532,78 @@ const G5_NPS_STOP: JourneySettingContract = {
 // G6 — End of course / offboarding (4)
 // =============================================================
 
+const G6_POST_TEST_INTRO: JourneySettingContract = {
+  id: "postTestIntro",
+  menuGroupKey: "H_closing",
+  group: "G6",
+  educatorLabel: "Post-test intro line",
+  helpText:
+    "Intro shown above the post-test knowledge check at journey end. Supports {subject} + {questionCount} tokens. Default: \"One last thing — let's see how much your {subject} comprehension has grown…\".",
+  storagePath: "config.postTestIntro",
+  control: "text",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["offboarding"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "offboarding", hint: "post-test intro" }],
+};
+
+const G6_POST_TEST_CLOSING: JourneySettingContract = {
+  id: "postTestClosing",
+  menuGroupKey: "H_closing",
+  group: "G6",
+  educatorLabel: "Post-test closing line",
+  helpText:
+    "Closing line after the post-test, before the journey-exit feedback survey. Default: \"Brilliant! Let's wrap up with some quick feedback.\".",
+  storagePath: "config.postTestClosing",
+  control: "text",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["offboarding"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "offboarding", hint: "post-test closing" }],
+};
+
+const G6_JOURNEY_EXIT_INTRO: JourneySettingContract = {
+  id: "journeyExitIntro",
+  menuGroupKey: "H_closing",
+  group: "G6",
+  educatorLabel: "Journey-exit intro line",
+  helpText:
+    "Intro shown at the very end of the journey, before the final feedback survey. Default: \"You've finished all your sessions — amazing work! Before you go, I'd love to hear how it went.\".",
+  storagePath: "config.journeyExitIntro",
+  control: "text",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["offboarding"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "offboarding", hint: "exit intro" }],
+};
+
+const G6_JOURNEY_EXIT_CLOSING: JourneySettingContract = {
+  id: "journeyExitClosing",
+  menuGroupKey: "H_closing",
+  group: "G6",
+  educatorLabel: "Journey-exit closing line",
+  helpText:
+    "Final thank-you line at the end of the journey. Last learner-facing touchpoint. Default: \"Thanks so much for your feedback! You've been brilliant. Good luck with everything!\".",
+  storagePath: "config.journeyExitClosing",
+  control: "text",
+  cascadeSources: [],
+  composeImpact: {
+    sections: ["offboarding"],
+    kinds: ["section-content"],
+    requiresReprompt: false,
+  },
+  previewLocators: [{ section: "offboarding", hint: "exit closing" }],
+};
+
 const G6_OFFBOARDING_FLOW_PHASES: JourneySettingContract = {
   id: "offboardingFlowPhases",
   menuGroupKey: "H_closing",
@@ -2501,6 +2645,10 @@ export const JOURNEY_SETTINGS: readonly JourneySettingContract[] = [
   G1_INTAKE_KNOWLEDGE_CHECK_MODE,
   G1_INTAKE_SKIP_IF_RETURNING,
   G1_ONBOARDING_CLOSING_LINE,
+  G1_GOALS_PREAMBLE,
+  G1_ABOUT_YOU_INTRO,
+  G1_PRE_TEST_INTRO,
+  G1_PRE_TEST_CLOSING,
   // G2 (6)
   G2_FIRST_CALL_MODE,
   G2_WELCOME_MESSAGE,
@@ -2555,6 +2703,10 @@ export const JOURNEY_SETTINGS: readonly JourneySettingContract[] = [
   G5_NPS_THRESHOLD,
   G5_NPS_STOP,
   // G6 (4)
+  G6_POST_TEST_INTRO,
+  G6_POST_TEST_CLOSING,
+  G6_JOURNEY_EXIT_INTRO,
+  G6_JOURNEY_EXIT_CLOSING,
   G6_OFFBOARDING_FLOW_PHASES,
   G6_OFFBOARDING_SUMMARY_ENABLED,
   G6_OFFBOARDING_SUMMARY_CADENCE,

--- a/apps/admin/lib/learner/onboarding-copy-defaults.ts
+++ b/apps/admin/lib/learner/onboarding-copy-defaults.ts
@@ -1,0 +1,72 @@
+/**
+ * Default learner-facing onboarding copy.
+ *
+ * Single source of truth for the strings that were hardcoded in
+ * `hooks/useJourneyChat.ts` + `components/student/WelcomeSurveyFlow.tsx`
+ * before PR #2266 lifted them to the cascade. Both consumers fall back
+ * to these defaults when `Playbook.config.<field>` is null.
+ *
+ * The shared module also deduplicates the 3 strings that were duplicated
+ * verbatim across the two consumers pre-#2266 (aboutYouIntro,
+ * preTestIntro, preTestClosing).
+ *
+ * Token convention: `{subject}` + `{teacherName}` + `{questionCount}`.
+ * `applyCopyTokens` does the substitution.
+ */
+
+export const ONBOARDING_COPY_DEFAULTS = {
+  /** FOH onboarding welcome bubble — when both Playbook + Domain + Institution layers are null. */
+  welcomeMessage:
+    "Welcome! I'm your AI study partner — ready to help you learn through conversation.",
+  /** Onboarding closing CTA tail. */
+  onboardingClosingLine: "We'll adapt as we go. Let's get started!",
+  /** Goals preamble above the bullet list. */
+  goalsPreamble: "Here's what we'll work on:",
+  /** About-You / personality survey greeting. */
+  aboutYouIntro:
+    "Hey! I'm your AI study partner for {subject}. {teacherName} Before we dive in, I'd love to learn a bit about you.",
+  /** Pre-test intro. */
+  preTestIntro:
+    "Now let's do a quick knowledge check on {subject} — just {questionCount} questions. Don't worry about getting them right, this just helps me understand where you're starting from.",
+  /** Pre-test closing before the first practice session. */
+  preTestClosing:
+    "Brilliant! I've got everything I need. Let's start your first practice session — you're going to do great.",
+  /** Post-test intro at journey end. */
+  postTestIntro:
+    "One last thing — let's see how much your {subject} comprehension has grown. {questionCount} questions, same skills we've been working on.",
+  /** Post-test closing before the exit survey. */
+  postTestClosing: "Brilliant! Let's wrap up with some quick feedback.",
+  /** Journey-exit intro before the final survey. */
+  journeyExitIntro:
+    "You've finished all your sessions — amazing work! Before you go, I'd love to hear how it went.",
+  /** Journey-exit thank-you. Last learner-facing touchpoint. */
+  journeyExitClosing:
+    "Thanks so much for your feedback! You've been brilliant. Good luck with everything!",
+} as const;
+
+export interface CopyTokens {
+  subject?: string;
+  teacherName?: string;
+  questionCount?: number;
+}
+
+/**
+ * Substitute `{subject}` / `{teacherName}` / `{questionCount}` tokens in
+ * a copy string. The `{teacherName}` token additionally swallows the
+ * surrounding "{teacherName} set this up for you. " phrasing when
+ * teacherName is empty — matches the pre-cascade behaviour where the
+ * literal was assembled with a conditional template.
+ */
+export function applyCopyTokens(template: string, tokens: CopyTokens): string {
+  const teacherSegment = tokens.teacherName
+    ? `${tokens.teacherName} set this up for you.`
+    : "";
+  return template
+    .replace(/\{subject\}/g, tokens.subject ?? "")
+    .replace(/\{teacherName\}/g, teacherSegment)
+    .replace(/\{questionCount\}/g, String(tokens.questionCount ?? 0))
+    // Collapse the double-space that `{teacherName}` produces when the
+    // teacher segment is empty (e.g. "for Maths.  Before we dive in" →
+    // "for Maths. Before we dive in").
+    .replace(/  +/g, " ");
+}

--- a/apps/admin/lib/learner/resolve-onboarding-welcome.ts
+++ b/apps/admin/lib/learner/resolve-onboarding-welcome.ts
@@ -1,27 +1,29 @@
 /**
- * Resolves the learner-facing onboarding welcome bundle for the FOH journey.
+ * Resolves the learner-facing onboarding + journey copy bundle for the
+ * FOH journey.
  *
- * Two values, two layers:
+ * Originally introduced by PR #2265 covering 2 fields (welcomeMessage +
+ * onboardingClosingLine). Extended by PR #2266 S1 with 8 more fields
+ * lifted out of `useJourneyChat.ts` + `WelcomeSurveyFlow.tsx` as part
+ * of the "ALL settings → UI" drive.
  *
- *   - `welcomeMessage` — cascade-resolved (`Playbook.config.welcomeMessage`
- *     wins, then `Domain.onboardingWelcome`, then the supplied
- *     `institutionFallback`, then `null`). Reuses the canonical
- *     `resolveWelcomeMessage` resolver to avoid divergence with the
- *     Inspector's cascade chip rendering of the same knob.
- *   - `onboardingClosingLine` — course-only (`Playbook.config.onboardingClosingLine`).
- *     No upstream layer today; cascade-classification-coverage classifies
- *     this contract as `course-only`.
+ * Cascade resolution:
+ *
+ *   - `welcomeMessage` — cascade-resolved via `resolveWelcomeMessage`
+ *     (`Playbook.config.welcomeMessage` → `Domain.onboardingWelcome` →
+ *     `institutionFallback` → `null`).
+ *   - Every other field — course-only (`Playbook.config.<field>`). No
+ *     upstream layer today. Cascade-classification-coverage classifies
+ *     each as `course-only`.
+ *
+ * Failures (Prisma blip, missing playbook) are swallowed and logged —
+ * the onboarding screens MUST render. Consumers fall back to the
+ * hardcoded literal kept in `useJourneyChat` / `WelcomeSurveyFlow`.
  *
  * Producer ↔ consumer pairing (see `.claude/rules/registry-consumer-coverage.md`):
- * this helper is the LIB-level reader for both `welcomeMessage` and
- * `onboardingClosingLine`. The route at `app/api/student/progress/route.ts`
- * imports it and forwards the values into the progress response;
- * `hooks/useJourneyChat.ts::loadOnboardingPhase` reads them from the response
- * and renders the FOH onboarding bubbles.
- *
- * Failures (Prisma blips, missing playbook) are swallowed and logged —
- * the onboarding screen MUST render, falling back to the institution-level
- * welcome and then to the hardcoded literal in `useJourneyChat`.
+ * this helper is the LIB-level reader for ALL course-only learner-copy
+ * knobs that flow through `/api/student/progress`. The hook + the HTML
+ * onboarding wizard both consume the values from the route response.
  */
 
 import { prisma } from "@/lib/prisma";
@@ -32,6 +34,29 @@ import type { PlaybookConfig } from "@/lib/types/json-fields";
 export interface OnboardingWelcomeBundle {
   welcomeMessage: string | null;
   onboardingClosingLine: string | null;
+  goalsPreamble: string | null;
+  aboutYouIntro: string | null;
+  preTestIntro: string | null;
+  preTestClosing: string | null;
+  postTestIntro: string | null;
+  postTestClosing: string | null;
+  journeyExitIntro: string | null;
+  journeyExitClosing: string | null;
+}
+
+function emptyBundle(welcomeMessage: string | null): OnboardingWelcomeBundle {
+  return {
+    welcomeMessage,
+    onboardingClosingLine: null,
+    goalsPreamble: null,
+    aboutYouIntro: null,
+    preTestIntro: null,
+    preTestClosing: null,
+    postTestIntro: null,
+    postTestClosing: null,
+    journeyExitIntro: null,
+    journeyExitClosing: null,
+  };
 }
 
 export async function resolveOnboardingWelcomeForCaller(
@@ -41,7 +66,7 @@ export async function resolveOnboardingWelcomeForCaller(
   try {
     const playbookId = await resolvePlaybookId(callerId);
     if (!playbookId) {
-      return { welcomeMessage: institutionFallback, onboardingClosingLine: null };
+      return emptyBundle(institutionFallback);
     }
 
     const [effective, playbook] = await Promise.all([
@@ -54,14 +79,24 @@ export async function resolveOnboardingWelcomeForCaller(
 
     const cfg = (playbook?.config ?? {}) as PlaybookConfig;
     const welcomeMessage = effective.value ?? institutionFallback;
-    const onboardingClosingLine = cfg.onboardingClosingLine ?? null;
 
-    return { welcomeMessage, onboardingClosingLine };
+    return {
+      welcomeMessage,
+      onboardingClosingLine: cfg.onboardingClosingLine ?? null,
+      goalsPreamble: cfg.goalsPreamble ?? null,
+      aboutYouIntro: cfg.aboutYouIntro ?? null,
+      preTestIntro: cfg.preTestIntro ?? null,
+      preTestClosing: cfg.preTestClosing ?? null,
+      postTestIntro: cfg.postTestIntro ?? null,
+      postTestClosing: cfg.postTestClosing ?? null,
+      journeyExitIntro: cfg.journeyExitIntro ?? null,
+      journeyExitClosing: cfg.journeyExitClosing ?? null,
+    };
   } catch (err) {
     console.warn(
       "[resolve-onboarding-welcome] resolution failed:",
       (err as Error).message,
     );
-    return { welcomeMessage: institutionFallback, onboardingClosingLine: null };
+    return emptyBundle(institutionFallback);
   }
 }

--- a/apps/admin/lib/types/json-fields.ts
+++ b/apps/admin/lib/types/json-fields.ts
@@ -482,6 +482,73 @@ export interface PlaybookConfig {
    */
   onboardingClosingLine?: string;
   /**
+   * Preamble shown above the goals bullet list in the FOH onboarding
+   * sequence — read by `useJourneyChat.ts::loadOnboardingPhase`. Default
+   * literal: "Here's what we'll work on:".
+   *
+   * @bucket Course parameter — Sign-up & pre-call profile (G1 / A_intake).
+   */
+  goalsPreamble?: string;
+  /**
+   * Intro line for the "About you" personality survey — read by both
+   * `useJourneyChat.ts::buildPersonalitySteps` and `WelcomeSurveyFlow.tsx`.
+   * Supports `{subject}` and `{teacherName}` tokens. Default literal:
+   * "Hey! I'm your AI study partner for {subject}. ...".
+   *
+   * @bucket Course parameter — Sign-up & pre-call profile (G1 / A_intake).
+   */
+  aboutYouIntro?: string;
+  /**
+   * Intro line for the pre-test knowledge check — read by both
+   * `useJourneyChat.ts::buildPreTestSteps` and `WelcomeSurveyFlow.tsx`.
+   * Supports `{subject}` and `{questionCount}` tokens.
+   *
+   * @bucket Course parameter — Sign-up & pre-call profile (G1 / A_intake).
+   */
+  preTestIntro?: string;
+  /**
+   * Closing line after the pre-test — read by both `useJourneyChat.ts`
+   * and `WelcomeSurveyFlow.tsx`. Default literal:
+   * "Brilliant! I've got everything I need. Let's start your first
+   * practice session — you're going to do great.".
+   *
+   * @bucket Course parameter — Sign-up & pre-call profile (G1 / A_intake).
+   */
+  preTestClosing?: string;
+  /**
+   * Intro line for the post-test knowledge check — read by
+   * `useJourneyChat.ts::buildPostTestSteps`. Supports `{subject}` and
+   * `{questionCount}` tokens.
+   *
+   * @bucket Course parameter — Wrap-up & offboarding (G6 / F_offboarding).
+   */
+  postTestIntro?: string;
+  /**
+   * Closing line after the post-test — read by `useJourneyChat.ts`.
+   * Default literal: "Brilliant! Let's wrap up with some quick feedback.".
+   *
+   * @bucket Course parameter — Wrap-up & offboarding (G6 / F_offboarding).
+   */
+  postTestClosing?: string;
+  /**
+   * Intro line for the journey-exit feedback survey — read by
+   * `useJourneyChat.ts::buildPostSteps`. Default literal:
+   * "You've finished all your sessions — amazing work! Before you go,
+   * I'd love to hear how it went.".
+   *
+   * @bucket Course parameter — Wrap-up & offboarding (G6 / F_offboarding).
+   */
+  journeyExitIntro?: string;
+  /**
+   * Final thank-you line at the end of the journey — read by
+   * `useJourneyChat.ts::buildPostSteps`. Last learner-facing touchpoint.
+   * Default literal: "Thanks so much for your feedback! You've been
+   * brilliant. Good luck with everything!".
+   *
+   * @bucket Course parameter — Wrap-up & offboarding (G6 / F_offboarding).
+   */
+  journeyExitClosing?: string;
+  /**
    * #1403 — First-call course intro spoken AFTER the welcomeMessage +
    * acknowledgement gate. Supports `{courseName}` token.
    *

--- a/apps/admin/prisma/seed-ielts-course.ts
+++ b/apps/admin/prisma/seed-ielts-course.ts
@@ -166,6 +166,24 @@ export async function main(prisma: PrismaClient): Promise<void> {
         // tunable via the Course Pane Inspector.
         welcomeMessage: "Welcome to your I E L T S coaching session",
         onboardingClosingLine: "Click start when you are ready",
+        // PR #2266 S1 — 8 more FOH copy knobs lifted from useJourneyChat
+        // + WelcomeSurveyFlow. Each falls back to canonical defaults in
+        // lib/learner/onboarding-copy-defaults.ts when left blank; IELTS
+        // seeds reasonable course-specific copy.
+        goalsPreamble: "Here's what we'll work on together:",
+        aboutYouIntro:
+          "Hello! I'm your I E L T S study partner. {teacherName} Before we dive in, I'd love to learn a bit about you.",
+        preTestIntro:
+          "Now let's do a quick knowledge check on I E L T S Speaking — just {questionCount} questions. Don't worry about getting them right; this just helps me calibrate to where you're starting from.",
+        preTestClosing:
+          "Brilliant! I've got what I need. Let's begin your first I E L T S Speaking practice — you'll do great.",
+        postTestIntro:
+          "One last thing — let's see how much your I E L T S Speaking confidence has grown. {questionCount} questions, same skills we've been working on.",
+        postTestClosing: "Brilliant! Let's wrap up with some quick feedback.",
+        journeyExitIntro:
+          "You've finished your I E L T S Speaking sessions — amazing work! Before you go, I'd love to hear how it went.",
+        journeyExitClosing:
+          "Thanks so much for your feedback! You've been brilliant. Good luck with your I E L T S Speaking test!",
         // IELTS Speaking Practice is a structured course with 5 authored
         // modules (Baseline, Part 1, Part 2, Part 3, Mock Exam). The
         // pipeline reads `lessonPlanMode === "structured"` to keep

--- a/apps/admin/tests/components/journey-tab/JourneyLhMenu.test.tsx
+++ b/apps/admin/tests/components/journey-tab/JourneyLhMenu.test.tsx
@@ -78,9 +78,12 @@ describe("JourneyLhMenu — Slice C (#1721) bucket-grained menu", () => {
         onToggleFilter={vi.fn()}
       />,
     );
-    // A_intake count: 8 base + Slice 13 added 2 (question text editors) + PR #2265 added onboardingClosingLine = 11.
+    // A_intake count: 8 base + Slice 13 added 2 (question text editors)
+    // + PR #2265 added onboardingClosingLine = 11. PR #2266 S1 added
+    // 4 more G1 FOH copy knobs (goalsPreamble + aboutYouIntro +
+    // preTestIntro + preTestClosing) = 15.
     const row = screen.getByTestId("hf-journey-bucket-row-A_intake");
-    expect(row.textContent).toMatch(/11/);
+    expect(row.textContent).toMatch(/15/);
   });
 });
 

--- a/apps/admin/tests/lib/journey/cascade-classification-coverage.test.ts
+++ b/apps/admin/tests/lib/journey/cascade-classification-coverage.test.ts
@@ -149,7 +149,8 @@ const EXPECTED_CASCADE_RESOLVABLE_COUNT = 10;
 // fix/onboarding-greeting-cascade — `onboardingClosingLine` lands as
 // course-only (Playbook layer only, no upstream Domain column today).
 // 77 → 78 course-only.
-const EXPECTED_COURSE_ONLY_COUNT = 78;
+// PR #2266 S1 — 8 FOH copy knobs added as course-only. 78 → 86.
+const EXPECTED_COURSE_ONLY_COUNT = 86;
 // S8 + S7 + S3 (this PR) — 9 → 12 producer-only contracts; the three new
 // G8 module-scoped knobs follow the existing IELTS-cohort pattern (no
 // upstream Domain/System cascade by design — module-scoped storage path).
@@ -159,7 +160,8 @@ const EXPECTED_GAP_COUNT = 0;
 
 // S8 + S7 + S3 — 106 → 109 total contracts.
 // fix/onboarding-greeting-cascade — 109 → 110 (onboardingClosingLine).
-const EXPECTED_TOTAL_COUNT = 110;
+// PR #2266 S1 — 110 → 118 (8 FOH copy knobs).
+const EXPECTED_TOTAL_COUNT = 118;
 
 // ────────────────────────────────────────────────────────────
 // Classification

--- a/apps/admin/tests/lib/journey/control-data-shape-coverage.test.ts
+++ b/apps/admin/tests/lib/journey/control-data-shape-coverage.test.ts
@@ -176,6 +176,11 @@ const DECLARED_DATA_SHAPE: Record<string, DataShape> = {
   intakeKnowledgeCheckMode: "enum-string",
   intakeSkipIfReturning: "boolean",
   onboardingClosingLine: "string",
+  // PR #2266 S1 — 4 G1 FOH copy strings.
+  goalsPreamble: "string",
+  aboutYouIntro: "string",
+  preTestIntro: "string",
+  preTestClosing: "string",
 
   // ── G2 — Call 1 opening ────────────────────────────────────────
   firstCallMode: "enum-string",
@@ -234,6 +239,11 @@ const DECLARED_DATA_SHAPE: Record<string, DataShape> = {
   npsStop: "stop-config",
 
   // ── G6 — End of course / offboarding ───────────────────────────
+  // PR #2266 S1 — 4 G6 FOH copy strings.
+  postTestIntro: "string",
+  postTestClosing: "string",
+  journeyExitIntro: "string",
+  journeyExitClosing: "string",
   offboardingFlowPhases: "phases-list",
   offboardingSummaryEnabled: "boolean",
   offboardingSummaryCadence: "enum-string",

--- a/apps/admin/tests/lib/journey/registry-completeness.test.ts
+++ b/apps/admin/tests/lib/journey/registry-completeness.test.ts
@@ -95,9 +95,10 @@ describe("Journey setting registry — Phase 0 completeness (AC §6 issue #1676)
     // intakeGoalsQuestion text contracts so educators can edit the
     // intake prompts. G1 7 → 9.
     // onboardingClosingLine added in fix/onboarding-greeting-cascade —
-    // course-only knob for the FOH onboarding closing CTA, paired with
-    // the existing welcomeMessage cascade reuse. G1 9 → 10.
-    expect(JOURNEY_SETTINGS_BY_GROUP.G1.length).toBe(10);
+    // course-only knob for the FOH onboarding closing CTA. PR #2266 S1
+    // added 4 more G1 course-only knobs (goalsPreamble + aboutYouIntro
+    // + preTestIntro + preTestClosing). G1 9 → 10 → 14.
+    expect(JOURNEY_SETTINGS_BY_GROUP.G1.length).toBe(14);
     expect(JOURNEY_SETTINGS_BY_GROUP.G2.length).toBe(10);
     expect(JOURNEY_SETTINGS_BY_GROUP.G3.length).toBe(4);
     // #1871 — voiceProsodyMode added (I_scoring / G4). 27 -> 28.
@@ -108,7 +109,9 @@ describe("Journey setting registry — Phase 0 completeness (AC §6 issue #1676)
     // (storagePath was unrepresentable in the applier — trigger is now
     // edited only via the midJourneyStop compound editor). G5 6 → 5.
     expect(JOURNEY_SETTINGS_BY_GROUP.G5.length).toBe(5);
-    expect(JOURNEY_SETTINGS_BY_GROUP.G6.length).toBe(10);
+    // PR #2266 S1 — 4 G6 course-only knobs (postTestIntro + postTestClosing
+    // + journeyExitIntro + journeyExitClosing). G6 10 → 14.
+    expect(JOURNEY_SETTINGS_BY_GROUP.G6.length).toBe(14);
     // #1747 — Theme 7 talkTimeBudgets bumped G7 6 → 7; Lane 3 catch-up bumped further.
     // Story #2105 — lessonPlanMode surfaced as a contract so the
     // Continuous + Strict-Prerequisites conflict can be declared
@@ -132,7 +135,8 @@ describe("Journey setting registry — Phase 0 completeness (AC §6 issue #1676)
     //   + 1 (S8 moduleScoreReadoutMode) + 1 (S7 moduleScaffoldsByStallType)
     //   + 1 (S3 moduleLearnerShellOverride) = 98
     //   + 1 (G1 onboardingClosingLine — FOH onboarding closing CTA) = 99
-    expect(JOURNEY_SETTINGS.length).toBe(99);
+    //   + 8 (PR #2266 S1 — 4 G1 + 4 G6 FOH copy knobs) = 107
+    expect(JOURNEY_SETTINGS.length).toBe(107);
   });
 
   it("(9) VOICE_SETTINGS.length === 11", () => {

--- a/apps/admin/tests/lib/journey/registry-schema-coverage.test.ts
+++ b/apps/admin/tests/lib/journey/registry-schema-coverage.test.ts
@@ -72,6 +72,15 @@ const APPLIES_TO_ALL: readonly string[] = [
   "intakeKnowledgeCheckMode",
   "intakeSkipIfReturning",
   "onboardingClosingLine",
+  // PR #2266 S1 — 4 G1 + 4 G6 FOH onboarding copy knobs.
+  "goalsPreamble",
+  "aboutYouIntro",
+  "preTestIntro",
+  "preTestClosing",
+  "postTestIntro",
+  "postTestClosing",
+  "journeyExitIntro",
+  "journeyExitClosing",
 
   // ── B_call1_opening (9 of 10 — firstCallModuleVisibility is structured-only)
   "firstCallMode",

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,9 +1,9 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-23T10:47:44.048Z",
+  "generatedAt": "2026-06-23T22:25:19.761Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1897,
+  "fileCount": 1898,
   "edgeCount": 4485,
   "skippedEdges": 1,
   "edges": [
@@ -25178,6 +25178,11 @@
       "path": "lib/learner-scope.ts",
       "inDegree": 58,
       "outDegree": 1
+    },
+    {
+      "path": "lib/learner/onboarding-copy-defaults.ts",
+      "inDegree": 0,
+      "outDegree": 0
     },
     {
       "path": "lib/learner/profile.ts",

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-23T10:47:44.389Z",
+  "generatedAt": "2026-06-23T22:25:20.130Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-23T10:47:42.827Z",
+  "generatedAt": "2026-06-23T22:25:18.466Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-23T10:47:44.770Z",
+  "generatedAt": "2026-06-23T22:25:20.541Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/parameter-inventory.json
+++ b/docs/kb/generated/parameter-inventory.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-23T10:47:46.260Z",
+  "generatedAt": "2026-06-23T22:25:22.075Z",
   "generator": "scripts/capture/parameter-inventory.ts",
   "parameterCount": 163,
   "active": 148,

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,6 +1,6 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-23T10:47:43.343Z",
+  "generatedAt": "2026-06-23T22:25:19.003Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {


### PR DESCRIPTION
## Summary

Continues PR #2265's FOH onboarding cascade work. Lifts 8 hardcoded learner-facing strings out of \`hooks/useJourneyChat.ts\` (and their verbatim duplicates in \`components/student/WelcomeSurveyFlow.tsx\`) into the JourneySettingContract registry so educators can tune them per course via the Course Pane Inspector.

Closes 8 of 28 hardcoded strings tracked in #2266. S2 (StudentOnboarding 6 strings) + S3 (ChatSurvey 9 tone-locked) follow as separate PRs.

## 8 new course-only contracts

| ID | Bucket | Replaces |
|---|---|---|
| \`goalsPreamble\` | G1 / A_intake | "Here's what we'll work on:" |
| \`aboutYouIntro\` | G1 / A_intake | About-You survey greeting (dedup'd between useJourneyChat + WelcomeSurveyFlow) |
| \`preTestIntro\` | G1 / A_intake | Pre-test intro (dedup'd) |
| \`preTestClosing\` | G1 / A_intake | Pre-test closing (dedup'd) |
| \`postTestIntro\` | G6 / H_closing | Post-test intro |
| \`postTestClosing\` | G6 / H_closing | Post-test closing |
| \`journeyExitIntro\` | G6 / H_closing | Final-survey intro |
| \`journeyExitClosing\` | G6 / H_closing | Final thank-you (last learner touchpoint) |

## Lattice survey

| Pillar | Outcome |
|---|---|
| Chain Contracts | n/a — no cross-stage boundary |
| Guards | No bare writes; lint clean |
| Cascade | All 8 classified \`course-only\` (Playbook layer only, no Domain column today). Future Domain promotion is a follow-on. |
| Rules | Extends PR #2265's pattern: same lib reader, same fallback chain, same APPLIES_TO_ALL convention |
| Coverage | 5 ratchets bumped consciously with reason comments |

Shared-defaults module at \`lib/learner/onboarding-copy-defaults.ts\` is now the single source of truth — both consumers import it. Eliminates the 3-string verbatim duplication called out in #2266's audit (\`WelcomeSurveyFlow.tsx:71/87/93\` were copies of \`useJourneyChat.ts:110/117/119\`). \`applyCopyTokens\` helper substitutes \`{subject}\` / \`{teacherName}\` / \`{questionCount}\` tokens.

Both consumers fall back to the canonical default literal when the cascade returns null — un-tuned courses behave identically to pre-cascade.

## Verified by

- \`npx vitest run tests/lib/journey/\` — 23 files / 204 tests passing
- \`npx vitest run tests/components/journey-tab/JourneyLhMenu.test.tsx\` — A_intake count chip bumped 11 → 15
- \`npx vitest run tests/api/student-progress-modules.test.ts tests/api/student-progress-course-complete.test.ts\` — 222 tests passing
- \`./node_modules/.bin/tsc --noEmit\` — 43 errors total = baseline (no new errors on changed files)
- Pre-push hook: tsc + lint clean on changed files
- Type definitions in \`lib/types/json-fields.ts\` added with @bucket JSDoc
- Lib reader signature extended; existing 2-field call site still type-checks via the bundle's extended shape

## Test plan

- [ ] CI green on all 6 checks
- [ ] Merge
- [ ] \`/vm-pull\` on hf-dev VM
- [ ] FOH sim for an IELTS-enrolled caller: confirm new copy renders ("I E L T S study partner", "Good luck with your I E L T S Speaking test!")
- [ ] Course Pane → Journey tab → "Sign-up & pre-call profile" → 4 new editable fields visible
- [ ] Course Pane → Journey tab → "Wrap-up & offboarding" (H_closing) → 4 new editable fields visible

## Coverage ratchet bumps

| Test | Bump |
|---|---|
| registry-completeness | G1 10→14, G6 10→14, total 99→107 |
| registry-schema-coverage | +8 paths in APPLIES_TO_ALL |
| cascade-classification-coverage | course-only 78→86, total 110→118 |
| control-data-shape-coverage | +8 "string" declarations |
| JourneyLhMenu | A_intake count chip 11→15 |

## IELTS Speaking Practice seed

Seeds course-specific copy ("I E L T S study partner" framing, "your I E L T S Speaking test" closing) so re-seeding hf_sandbox picks up the IELTS variants. Existing playbooks not affected by re-seed; will need a follow-on apply script (per the PR #2265 pattern) when operator wants the new copy on hf_sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)