### PR TITLE
feat(prompt): tutor over-speak guard — BEH-RESPONSE-LEN + BEH-TURN-LENGTH as prompt-injection

### DIFF
--- a/apps/admin/docs-archive/bdd-specs/behavior-parameters.registry.json
+++ b/apps/admin/docs-archive/bdd-specs/behavior-parameters.registry.json
@@ -1101,13 +1101,20 @@
       "definition": "How long the AI's typical responses are in a conversational exchange.",
       "domainGroup": "personality-adaptation",
       "defaultTarget": 0.5,
+      "promptInjection": {
+        "section": "STYLE",
+        "condition": "when-non-default",
+        "templateLow": "Keep your responses short — one point at a time. The learner needs space to speak; do not deliver paragraphs.",
+        "templateHigh": "Deliver fuller responses with multiple points per exchange. The learner expects substantive guidance, not single sentences.",
+        "threshold": 0.5
+      },
       "interpretationHigh": "Longer Turns: Extended responses with more content per exchange",
       "interpretationLow": "Short Turns: Brief responses that encourage quick back-and-forth dialogue",
       "usage": {
-        "compose": "transform-direct",
+        "compose": "prompt-injection",
         "measurement": {
           "kind": "operator-only",
-          "reason": "Sets tutor response length; tutor-emit directive expressed via prompt composition. Not learner-derivable from transcript."
+          "reason": "Sets tutor response length; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript — SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
         }
       }
     },
@@ -1233,13 +1240,20 @@
       "definition": "How much content the AI delivers in each conversational turn.",
       "domainGroup": "engagement",
       "defaultTarget": 0.5,
+      "promptInjection": {
+        "section": "STYLE",
+        "condition": "when-non-default",
+        "templateLow": "Aim for short turns — under 15 seconds when possible. Hand the floor back to the learner quickly.",
+        "templateHigh": "Allow yourself longer turns when explaining or expanding a concept — up to 30 seconds is fine.",
+        "threshold": 0.5
+      },
       "interpretationHigh": "Extended: Longer, more content-rich turns with multiple points per exchange",
       "interpretationLow": "Brief: Short, punchy turns that keep the conversation fast-paced",
       "usage": {
-        "compose": "transform-direct",
+        "compose": "prompt-injection",
         "measurement": {
           "kind": "operator-only",
-          "reason": "Sets tutor turn length / content density per turn; tutor-emit directive. Not learner-state derivable."
+          "reason": "Sets tutor turn length / content density per turn; tutor-emit directive expressed via prompt composition (param drives BEHAVIOR_TARGETS section via parametersAsDirectives). Not learner-derivable from transcript — SUPERVISE-stage compliance check (did the AI follow the directive?) is a separate concern from learner-state measurement."
         }
       }
     },


### PR DESCRIPTION
## Goal

Close the tutor over-speak guard gap (IELTS pre-voice testing checklist Unit 1 / Unit 2): the IELTS tutor today delivers paragraph-length responses with no structural prompt-side directive constraining response length or turn length, because the two parameters (`BEH-RESPONSE-LEN`, `BEH-TURN-LENGTH`) already existed as registry rows but weren't routed through the `parametersAsDirectives` dispatcher (#1907).

Refs #2277 (IELTS market test readiness — data sweep).

## Why

Both parameters had:
- ✅ Canonical Parameter row in registry JSON
- ✅ BehaviorTarget cascade support (System → Domain → Course → Caller)
- ✅ Operator-editable target value
- ❌ NO prompt-side consumer — `usage.compose: "transform-direct"` with no actual transform reading them

The `parametersAsDirectives` dispatcher already reads ANY Parameter row carrying a `promptInjection` block and emits the directive at compose time. Sibling rows `BEH-RHYTHM-ATTENTION` + `BEH-VERBAL-ELABORATION` use exactly this pattern. This PR closes the reuse gap with a 5-minute JSON edit — no runtime code needed.

## What changed

Two registry rows in `apps/admin/docs-archive/bdd-specs/behavior-parameters.registry.json`:

| Parameter | Before | After |
|---|---|---|
| `BEH-RESPONSE-LEN` | `compose: "transform-direct"`, no `promptInjection` | `compose: "prompt-injection"` + `promptInjection { section: "STYLE", condition: when-non-default, templateLow/High, threshold: 0.5 }` |
| `BEH-TURN-LENGTH` | `compose: "transform-direct"`, no `promptInjection` | Same shape, turn-length templates |

Templates:
- **BEH-RESPONSE-LEN low**: "Keep your responses short — one point at a time. The learner needs space to speak; do not deliver paragraphs."
- **BEH-RESPONSE-LEN high**: "Deliver fuller responses with multiple points per exchange. The learner expects substantive guidance, not single sentences."
- **BEH-TURN-LENGTH low**: "Aim for short turns — under 15 seconds when possible. Hand the floor back to the learner quickly."
- **BEH-TURN-LENGTH high**: "Allow yourself longer turns when explaining or expanding a concept — up to 30 seconds is fine."

`usage.measurement` stays `operator-only` on both (tutor-emit directive; not learner-state derivable from transcript). Reason text upgraded to the canonical >40-char form matching the sibling rows.

## Verified by

**Lattice survey** (per `.claude/rules/lattice-survey.md`):
- Surface: registry JSON row (data, not code).
- Writers: `prisma/seed-from-specs.ts` only. No sibling-writer drift risk.
- Readers: `lib/prompt/composition/transforms/parametersAsDirectives.ts` (#1907 dispatcher) reads any Parameter row with a `promptInjection` block.
- Risk shapes: sibling-writer drift NONE; default-deny gates N/A; cascade respect N/A (cascade reads BehaviorTarget value, unchanged); convention conflict — confirmed `prompt-injection` compose + `operator-only` measurement is the canonical combo via sibling rows BEH-RHYTHM-ATTENTION (line 1115) + BEH-VERBAL-ELABORATION (line 1247) + BEH-SPATIAL-METAPHOR (line 1170) + BEH-TERMINOLOGY-FORMAL (line 1208).

**Tests** (all green, no ratchet shift):
- `tests/lib/registry/parameter-usage-coverage.test.ts` — 6/6 pass (schema invariants)
- `tests/lib/measurement/parameter-measurement-coverage.test.ts` — 6/6 pass (substantive cross-check; both rows stay `operator-only`)
- `tests/lib/measurement/parameter-coverage.test.ts` — 5/5 pass (consumer coverage)

**Type-check**: `npx tsc --noEmit` reports 38 errors, all pre-existing (`.ratchet.json::tsc_errors` baseline = 39). No new errors introduced — JSON data file, no TS impact.

## Test plan

- [ ] CI green
- [ ] Post-merge: re-seed registry (`npm run db:seed`) on hf-dev VM, then verify a composed-prompt output for an IELTS Playbook with `responseLength` target ≤ 0.4 includes the templateLow directive in the STYLE section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)