### PR TITLE
feat(ielts): Part 2 prep cues — wire phase tag on prep→monologue boundary

### DIFF
--- a/apps/admin/lib/wizard/__tests__/fixtures/course-reference-ielts-v2.3.md
+++ b/apps/admin/lib/wizard/__tests__/fixtures/course-reference-ielts-v2.3.md
@@ -276,8 +276,8 @@ settings:
     You'll get one minute to prepare. Cover all the bullets and try to
     use a range of tenses — past, present, future — in one turn.
   scheduledCues:
-    - { at: 45, text: "15 seconds left" }          # end of 1-min prep phase
-    - { at: 60, text: "Your two minutes start now" }   # monologue begin
+    - { at: 45, text: "15 seconds left" }                                   # end of 1-min prep phase (still p2_prep)
+    - { at: 60, text: "Your two minutes start now", phase: "p2_monologue" } # prep → monologue boundary (#1762 Story C — Session.metadata.phaseBoundaries)
   scaffoldPool: source:stall-scaffolds-monologue   # Source 6
   profileFieldsToCapture: []
   prepSilenceSec: 60            # examiner silence during prep
@@ -367,8 +367,8 @@ settings:
     follow-up questions. About twenty minutes total. I'll share your
     indicative bands at the end.
   scheduledCues:
-    - { at: 45, text: "15 seconds left" }          # Part 2 prep phase end
-    - { at: 60, text: "Your two minutes start now" }   # Part 2 monologue begin
+    - { at: 45, text: "15 seconds left" }                                   # Part 2 prep phase end (still p2_prep)
+    - { at: 60, text: "Your two minutes start now", phase: "p2_monologue" } # Part 2 monologue begin (#1762 Story C — Session.metadata.phaseBoundaries)
   scaffoldPool: source:stall-scaffolds-monologue   # examiner mode throughout; Part 2 long-turn stalls only
   profileFieldsToCapture: []
   prepSilenceSec: 60            # Part 2 prep phase inside Mock

--- a/apps/admin/tests/lib/wizard/detect-module-settings.test.ts
+++ b/apps/admin/tests/lib/wizard/detect-module-settings.test.ts
@@ -58,7 +58,7 @@ describe("detectModuleSettings — IELTS v2.3 happy path", () => {
     );
     expect(part2!.scheduledCues).toEqual([
       { at: 45, text: "15 seconds left" },
-      { at: 60, text: "Your two minutes start now" },
+      { at: 60, text: "Your two minutes start now", phase: "p2_monologue" },
     ]);
     // The closingLine should NOT be emitted as `moduleClosingLine`
     // (the parser strips the `module` prefix when present, but the v2.3

--- a/docs/external/ielts/ielts-speaking/Upload Docs/course-ref.md
+++ b/docs/external/ielts/ielts-speaking/Upload Docs/course-ref.md
@@ -273,8 +273,8 @@ settings:
     You'll get one minute to prepare. Cover all the bullets and try to
     use a range of tenses — past, present, future — in one turn.
   scheduledCues:
-    - { at: 45, text: "15 seconds left" }          # end of 1-min prep phase
-    - { at: 60, text: "Your two minutes start now" }   # monologue begin
+    - { at: 45, text: "15 seconds left" }                                   # end of 1-min prep phase (still p2_prep)
+    - { at: 60, text: "Your two minutes start now", phase: "p2_monologue" } # prep → monologue boundary (#1762 Story C — Session.metadata.phaseBoundaries)
   scaffoldPool: source:stall-scaffolds-monologue   # Source 6
   profileFieldsToCapture: []
   prepSilenceSec: 60            # examiner silence during prep
@@ -363,8 +363,8 @@ settings:
     follow-up questions. About twenty minutes total. I'll share your
     indicative bands at the end.
   scheduledCues:
-    - { at: 45, text: "15 seconds left" }          # Part 2 prep phase end
-    - { at: 60, text: "Your two minutes start now" }   # Part 2 monologue begin
+    - { at: 45, text: "15 seconds left" }                                   # Part 2 prep phase end (still p2_prep)
+    - { at: 60, text: "Your two minutes start now", phase: "p2_monologue" } # Part 2 monologue begin (#1762 Story C — Session.metadata.phaseBoundaries)
   scaffoldPool: source:stall-scaffolds-monologue   # examiner mode throughout; Part 2 long-turn stalls only
   profileFieldsToCapture: []
   prepSilenceSec: 60            # Part 2 prep phase inside Mock


### PR DESCRIPTION
## Goal

Refs #2277 — IELTS market test readiness, data sweep.

Author the prep→monologue phase tag on the existing 60s tutor cue in the IELTS Part 2 module + Mock module so the cue-scheduler runtime (#1762 Story C) writes a phase boundary to `Session.metadata.phaseBoundaries` when the monologue starts.

## Why

Pre-voice testing checklist Unit 3 names 5 cues during the Part 2 prep + monologue phases:

| Cue | Status |
|---|---|
| `15 seconds left` at t=45s | already authored — no change needed |
| `Your two minutes start now` at t=60s | already authored — this PR adds `phase: "p2_monologue"` |
| Topic prompt at t=0 (`Think of a memory…` / `Think of one example…`) | OUT OF SCOPE — chat-feed only, see Caveat below |
| PPF sentences (3-line chat-feed overlay at t=0) | OUT OF SCOPE — chat-feed only |
| Note-taking instruction at t=0 | OUT OF SCOPE — chat-feed only |

The 2 tutor cues were already authored in both the production course-ref and the v2.3 test fixture. The only DATA delta this PR needs is the `phase` tag — once attached, the cue-scheduler's existing #1762 Story C path writes a `phaseBoundary` to `Session.metadata.phaseBoundaries` when the cue fires. That makes the prep→monologue transition operator-observable in downstream analytics (e.g. attributing FC + Pron scoring to the monologue 2-minute window).

## What changed

Mirror edit in both authoring surfaces:
- `docs/external/ielts/ielts-speaking/Upload Docs/course-ref.md` — production source the IELTS seed reads (`apps/admin/prisma/seed-ielts-course.ts:78`)
- `apps/admin/lib/wizard/__tests__/fixtures/course-reference-ielts-v2.3.md` — test fixture mirror

Both files: add `phase: "p2_monologue"` to the t=60s cue on Module 3 (Part 2) AND on the Mock module (which runs Part 2 inside the full simulation).

Plus a one-line test update at `tests/lib/wizard/detect-module-settings.test.ts` to reflect the new shape on the Part 2 happy-path assertion.

## Caveat — PPF + note-instruction + topic-prompt didn't fit this rail

The cue-scheduler dispatches via `provider.sayMessage()` — TTS / voice audio only (verified at `apps/admin/lib/voice/cue-scheduler.ts:215`). The 3 chat-feed items the checklist names (topic prompt, PPF sentences, note-taking instruction) need a separate rail — likely a `Playbook.config.modules[i].settings.prepCueCards` or sibling field consumed by a chat-feed overlay component. That's a code+data story, not pure data, and is out of scope here. Recommend filing as a follow-on of #2277.

## Verified by

- Lattice survey result: cue-scheduler routes via `provider.sayMessage()` (TTS); PPF + note-instruction items need chat-feed rail and are NOT covered by this PR. Existing `register-module-cues.ts:64-116` reads `Playbook.config.modules[].settings.scheduledCues` at session-start, propagates `phase` field to the dispatcher unchanged (line 122-124).
- `npx vitest run tests/lib/wizard/fixture-type-coverage.test.ts` — 12 passed
- `npx vitest run tests/lib/courses/courses-template-version-coverage.test.ts` — 6 passed
- `npx vitest run tests/lib/seed-ielts-fixture.test.ts` — 11 passed
- `npx vitest run tests/lib/wizard/detect-module-settings.test.ts` — 15 passed (updated 1 expectation to match new shape)
- `npx vitest run tests/lib/voice/cue-scheduler.test.ts tests/lib/voice/register-module-cues.test.ts tests/lib/voice/cue-scheduler-runner.test.ts` — 19 passed
- `npx vitest run tests/lib/wizard/source-ref-coverage.test.ts tests/lib/sim-chat/bdd-typed-unions-coverage.test.ts` — 19 passed
- `npx tsc --noEmit` — 38 errors (below 43 baseline; zero new errors from this PR)

## Test plan

- [ ] On next IELTS Speaking re-seed (hf_sandbox or staging), confirm `Playbook.config.modules[2].settings.scheduledCues[1].phase === "p2_monologue"`
- [ ] Run a live Part 2 session past the 60s mark; confirm `Session.metadata.phaseBoundaries` carries the `p2_monologue` row at the expected `startSec`
- [ ] Confirm AppLog `voice.cue_scheduler.fired` carries the cue and `voice.cue.phase_boundary_persist_failed` is NOT emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)