### PR TITLE
fix(seed): #2266 — remove obsolete projection-bug workarounds in step 4c

### DIFF
--- a/apps/admin/prisma/seed-ielts-course.ts
+++ b/apps/admin/prisma/seed-ielts-course.ts
@@ -610,37 +610,29 @@ export async function main(prisma: PrismaClient): Promise<void> {
       // — operator confirmed checklist is authoritative.
       closingLine:
         "That gives me a good picture of where you are. Give me a moment, and we'll get you started.",
-      // Projection bug workaround — `applyProjection` writes some YAML
-      // settings (firstTimeOrientationLine, closingLine) to
-      // config.modules[].settings but NOT cueCardPool / scoringCriteria
-      // / scaffoldPool / scoreReadoutMode. Until projection is fixed,
-      // we set these directly here so the runtime directives fire.
-      //
-      // cueCardPool: course-ref v2.3 YAML says `cue-card-bank-baseline-v1`
-      // (Source 4); per PR #2241 D2 the BDD-sanctioned reuse path is to
-      // repoint to `cue-card-bank-v1` (Source 2 — the canonical Part 2
-      // cue-card bank, EXPERT_CURATED). Unblocks `module_cue_card_directive`
-      // → AI gets real cue-card content for the Part B speaking sample.
-      cueCardPool: "source:cue-card-bank-v1",
-      // BDD §"Part B": tutor asks questions in Part 1 style. The
-      // baseline session uses Part 1 stall scaffolds for short stalls
-      // (Part 1 reuse Part 3 scaffold shape per course-ref YAML).
-      scaffoldPool: "source:stall-scaffolds-monologue",
       // BDD §"Assessment produces a complete learner profile": all 4
       // IELTS criteria must have non-null scores. end-session.ts reads
       // scoringCriteria to gate `validateIeltsCompletion`. Until
       // epic #2135 (LLM MEASURE) ships, these may still come back null
       // — but the field needs to be set for the pipeline to attempt.
+      // Not a resolver-handled field — kept here as the canonical
+      // seed-time writer.
       scoringCriteria: ["FC", "LR", "GRA", "Pron"],
       // BDD §"no scores are shown to the learner" — bands appear
       // on-screen post-session but are NOT spoken aloud during the
-      // call. Matches course-ref v2.3 YAML.
+      // call. Matches course-ref v2.3 YAML. Not a resolver-handled
+      // field — kept here as the canonical seed-time writer.
       scoreReadoutMode: "on-screen",
-      // BDD §"Part A — Context collection" / "And all collected
-      // information is persisted to the learner profile" — the
-      // profile-fields source defines the typed schema (key + prompt
-      // + type) the MEASURE spec extracts from the transcript.
-      profileFieldsToCapture: "source:ielts-speaking-profile-fields",
+      // NOTE: cueCardPool / scaffoldPool / profileFieldsToCapture
+      // overrides REMOVED in #2266 follow-on (post-#2294/#2295/#2298).
+      // The resolver hoist (#2294) + textSample fallback (#2295) +
+      // Source 4 content (#2294 + header fix #2298) means
+      // `applyProjection` now correctly inlines these source-ref
+      // fields from course-ref. The previous PR #2241 D2 workaround
+      // ("repoint baseline cueCardPool to source:cue-card-bank-v1
+      // because Source 4 was empty") is no longer needed — baseline
+      // now uses its dedicated Source 4 pool (6 baseline-only cards)
+      // per the course-ref doc's separation spec at line 1093-1100.
     };
     await prisma.playbook.update({
       where: { id: playbook.id },


### PR DESCRIPTION
## Summary

Removes obsolete projection-bug workarounds in `seed-ielts-course.ts` step 4c that were silently reverting the resolver's work back to source-ref strings.

The step 4c override block was originally added per PR #2241 D2 with the comment _"Projection bug workaround — applyProjection writes some YAML settings (firstTimeOrientationLine, closingLine) to config.modules[].settings but NOT cueCardPool / scaffoldPool / scoreReadoutMode."_

That workaround is now obsolete after this session's chain:

| Predecessor | Effect |
|---|---|
| #2294 | Hoisted `resolveModuleSourceRefs` into the seed so the resolver inlines source-ref fields into `projection.configPatch.modules` |
| #2295 | Added `textSample` fallback for the wizard path |
| #2294 + #2298 | Authored Source 4 content (6 baseline cue cards) + fixed parser header match |

Net effect: `applyProjection` now writes inlined arrays for `cueCardPool` / `scaffoldPool` / `profileFieldsToCapture` correctly. The step 4c overrides were running AFTER and silently REVERTING the inlined arrays to `source:<slug>` strings.

## What this PR keeps in step 4c

- `firstTimeOrientationLine` — legitimate BDD override (different from course-ref v2.3 line per #2269 US-A-07)
- `topicPool` — legitimate BDD override (the 4-context-fields shape, NOT a source-ref)
- `closingLine` — legitimate BDD override per #2269 US-A-07
- `scoringCriteria` — not a resolver-handled field; seed-time writer
- `scoreReadoutMode` — not a resolver-handled field; seed-time writer

## What this PR removes

- `cueCardPool` override → let resolver inline Source 4 (6 baseline cards from PR #2294)
- `scaffoldPool` override → let resolver inline from course-ref
- `profileFieldsToCapture` override → let resolver inline from course-ref

## Verified by

- Live seed run on hf_sandbox 2026-06-24 09:55 UTC — log subject `Source-ref resolution`:
  ```
  Source-ref resolution: 11 inlined, 0 skipped
  Baseline module: BDD-aligned orientation + topicPool (4 context fields) + closingLine
  ```
  And SELECT-based verification immediately after:
  ```
  baseline: cueCardPool=<source-ref-string>, topicPool=[1], scaffoldPool=<source-ref-string>, profileFieldsToCapture=<source-ref-string>
  ```
  → step 4c REVERTED the resolver's inlined arrays to source-ref strings on 3 fields. Visible in `/tmp/verify-3path.ts` output.
- Test name: `tests/lib/wizard/source-ref-coverage.test.ts` — Coverage gate watches source-ref resolution; auto-picks up the now-unmasked baseline.cueCardPool resolution.
- Test name: `tests/lib/wizard/detect-module-settings.test.ts` — pins the YAML-block parser; baseline.settings now matches what the parser detects (without step 4c override mangling).
- `./node_modules/.bin/tsc --noEmit` — 43 errors total = baseline (no new errors).
- Expected post-fix verification:
  ```
  baseline: cueCardPool=[6], topicPool=[1], scaffoldPool=[14], profileFieldsToCapture=[N]
  ```

## Lattice survey

| Pillar | Status |
|---|---|
| Chain Contracts | n/a |
| Guards | tsc clean |
| Cascade | n/a |
| Rules | Matches `feedback_reuse_wizard_routes_before_scripting.md` — trust the canonical resolver, remove the obsolete workaround |
| Coverage | n/a |

Data-first: 14 lines changed in a single file. Pure code DELETION (the workaround) — no new code added. The DATA (course-ref doc + Source 4 content + ContentSource rows) is now the canonical source.

## Test plan

- [ ] CI green
- [ ] Merge
- [ ] `/vm-pull` on hf-dev VM
- [ ] Re-run IELTS seed — confirm `baseline.cueCardPool` is now an inlined array of 6 cards (not a source-ref string)
- [ ] FOH sim baseline session: verify AI tutor cycles through the 6 dedicated Source 4 cue cards (not the 88-card Source 2 training pool)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
