### PR TITLE
fix(#2305): drain stale IELTS skill CallerTargets + add Query 15 detector

### DIFF
--- a/apps/admin/scripts/check-fk-consistency.ts
+++ b/apps/admin/scripts/check-fk-consistency.ts
@@ -711,6 +711,91 @@ async function runChecks(): Promise<CheckResult[]> {
     warnOnly: true,
   });
 
+  // Query 15 — #2305 — stale `CallerTarget.currentScore` for IELTS skill
+  // parameters where ZERO `CallScore` rows back the score for the same
+  // (callerId, parameterId).
+  //
+  // Per epic #2135's rule "NEVER land hardcoded or AI-guessed score
+  // defaults": every non-null `currentScore` MUST be derivable from at
+  // least one CallScore row written through the canonical
+  // `aggregate-runner.ts::accumulateSkillScores` path. Pre-#2138
+  // `lib/pipeline/prosody-consumer.ts` wrote `currentScore` directly under
+  // IELTS skill IDs without writing a paired CallScore — that path is
+  // retired but the stale rows remain. Same failure mode as Query 11
+  // (`AnalysisSpec.config.parameters[].id` dangling-FK) but on the
+  // measurement-output surface instead of the spec-config surface.
+  //
+  // Live evidence (2026-06-23 hf_sandbox): 39 of 149 IELTS skill
+  // CallerTarget rows carry non-null `currentScore` with zero matching
+  // CallScore rows — fabricated signal that corrupts EMA going forward
+  // until drained via `scripts/drain-stale-ielts-skill-callertargets.ts`.
+  //
+  // WARN-only initially while the drain is in flight. Promote to error
+  // severity once the incumbent debt is cleared on every hosted DB.
+  //
+  // CI's ephemeral DB has no CallerTarget seed → returns 0 by
+  // construction. Load-bearing run is via `npm run check:fk` against
+  // hosted DBs (DATABASE_URL_SANDBOX / DATABASE_URL_STAGING).
+  type StaleIeltsCallerTargetRow = {
+    caller_target_id: string;
+    caller_id: string;
+    caller_name: string | null;
+    parameter_id: string;
+    current_score: number | null;
+    last_scored_at: Date | null;
+  };
+  let staleIeltsCallerTargets: StaleIeltsCallerTargetRow[] = [];
+  try {
+    staleIeltsCallerTargets = await prisma.$queryRaw<StaleIeltsCallerTargetRow[]>`
+      SELECT
+        ct."id" AS caller_target_id,
+        ct."callerId" AS caller_id,
+        c."name" AS caller_name,
+        ct."parameterId" AS parameter_id,
+        ct."currentScore" AS current_score,
+        ct."lastScoredAt" AS last_scored_at
+      FROM "CallerTarget" ct
+      JOIN "Caller" c ON c."id" = ct."callerId"
+      WHERE ct."parameterId" IN (
+        'skill_fluency_and_coherence_fc',
+        'skill_lexical_resource_lr',
+        'skill_grammatical_range_and_accuracy_gra',
+        'skill_pronunciation_p'
+      )
+        AND ct."currentScore" IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM "CallScore" cs
+          WHERE cs."callerId" = ct."callerId"
+            AND cs."parameterId" = ct."parameterId"
+        )
+      ORDER BY ct."callerId", ct."parameterId";
+    `;
+  } catch (err) {
+    // Same defensive shape as Query 11 / Query 14 — tolerate failure with
+    // a warn so unrelated CI doesn't block.
+    console.warn(
+      `[fk-check] CallerTarget non-null without CallScore scan errored: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  results.push({
+    name: "callertarget-non-null-without-callscore",
+    description:
+      "#2305 — CallerTarget.currentScore is non-null for an IELTS skill parameterId but ZERO CallScore rows back the (callerId, parameterId). Pre-#2138 prosody-consumer wrote currentScore directly under IELTS skill IDs without a paired CallScore — that path was retired but the stale rows remain. Drain via `scripts/drain-stale-ielts-skill-callertargets.ts --apply`. WARN-only until the incumbent debt is cleared on every hosted DB; promote to error severity then.",
+    rows: staleIeltsCallerTargets.map((r) => ({
+      id: r.caller_target_id,
+      detail: {
+        callerId: r.caller_id,
+        callerName: r.caller_name ?? undefined,
+        parameterId: r.parameter_id,
+        currentScore: r.current_score ?? undefined,
+        lastScoredAt: r.last_scored_at?.toISOString() ?? undefined,
+      },
+    })),
+    warnOnly: true,
+  });
+
   return results;
 }
 

--- a/apps/admin/scripts/drain-stale-ielts-skill-callertargets.ts
+++ b/apps/admin/scripts/drain-stale-ielts-skill-callertargets.ts
@@ -1,0 +1,193 @@
+/**
+ * #2305 — Drain stale IELTS skill `CallerTarget.currentScore` rows.
+ *
+ * Per epic #2135's rule "NEVER land hardcoded or AI-guessed score
+ * defaults" + tech-lead verdict on #2305:
+ *
+ *   For every CallerTarget row keyed on an IELTS skill parameterId
+ *   AND currentScore IS NOT NULL:
+ *     - If 0 matching CallScore rows for the same (callerId, parameterId)
+ *       → currentScore is fabricated signal (pre-#2138 prosody-consumer
+ *         write that bypassed the canonical aggregate-runner path).
+ *       Action: set currentScore = NULL.
+ *     - If >=1 matching CallScore row
+ *       → legitimately scored. Leave untouched. Log as preserved.
+ *
+ * Idempotent. `--dry-run` is the default. `--apply` actually writes.
+ *
+ * The canonical CallerTarget writer is
+ * `lib/pipeline/aggregate-runner.ts::accumulateSkillScores`. Pre-#2138
+ * `lib/pipeline/prosody-consumer.ts:19-34,239` wrote currentScore directly
+ * under IELTS skill IDs (the retired path that produced this debt). Per
+ * the Lattice survey: `BehaviorTarget` has the
+ * `no-bare-behavior-target-write.mjs` chokepoint but `CallerTarget` does
+ * NOT have one — direct `prisma.callerTarget.update` is allowed here.
+ *
+ * Run command (operator, on hf-dev VM bound to hf_sandbox first):
+ *   cd ~/HF/apps/admin
+ *   npx tsx scripts/drain-stale-ielts-skill-callertargets.ts            # dry-run
+ *   npx tsx scripts/drain-stale-ielts-skill-callertargets.ts --apply    # commit
+ *
+ * After hf_sandbox: re-point DATABASE_URL at hf_staging and re-run.
+ * Verify Query 15 in `check-fk-consistency.ts` returns 0 violations
+ * post-drain.
+ *
+ * Exit codes:
+ *   0 — drain completed (dry-run or --apply)
+ *   1 — database unreachable / fatal error
+ */
+
+import { prisma } from "@/lib/prisma";
+
+const IELTS_SKILL_PARAMETER_IDS = [
+  "skill_fluency_and_coherence_fc",
+  "skill_lexical_resource_lr",
+  "skill_grammatical_range_and_accuracy_gra",
+  "skill_pronunciation_p",
+] as const;
+
+interface DrainArgs {
+  apply: boolean;
+}
+
+function parseArgs(argv: string[]): DrainArgs {
+  const apply = argv.includes("--apply");
+  return { apply };
+}
+
+async function drain(args: DrainArgs): Promise<void> {
+  const mode = args.apply ? "APPLY" : "DRY-RUN";
+  console.log(
+    `\n=== #2305 drain — stale IELTS skill CallerTarget rows (${mode}) ===\n`,
+  );
+  if (!args.apply) {
+    console.log(
+      "  Mode: dry-run (no writes). Pass --apply to actually NULL rows.\n",
+    );
+  }
+
+  // Fetch every non-null IELTS skill CallerTarget row.
+  const candidates = await prisma.callerTarget.findMany({
+    where: {
+      parameterId: { in: [...IELTS_SKILL_PARAMETER_IDS] },
+      currentScore: { not: null },
+    },
+    select: {
+      id: true,
+      callerId: true,
+      parameterId: true,
+      currentScore: true,
+      lastScoredAt: true,
+      updatedAt: true,
+      caller: { select: { name: true } },
+    },
+  });
+
+  console.log(`Candidates scanned: ${candidates.length}\n`);
+
+  let drained = 0;
+  let preserved = 0;
+  const drainedRows: Array<{
+    id: string;
+    callerId: string;
+    callerName: string | null;
+    parameterId: string;
+    currentScore: number | null;
+  }> = [];
+  const preservedRows: Array<{
+    id: string;
+    callerName: string | null;
+    parameterId: string;
+    matchingCallScores: number;
+  }> = [];
+
+  for (const row of candidates) {
+    const matchingScoreCount = await prisma.callScore.count({
+      where: { callerId: row.callerId, parameterId: row.parameterId },
+    });
+
+    if (matchingScoreCount === 0) {
+      // STALE — no CallScore backs this currentScore. Drain.
+      drainedRows.push({
+        id: row.id,
+        callerId: row.callerId,
+        callerName: row.caller?.name ?? null,
+        parameterId: row.parameterId,
+        currentScore: row.currentScore,
+      });
+
+      if (args.apply) {
+        // Direct prisma.callerTarget.update is allowed — CallerTarget has no
+        // chokepoint helper today (sibling BehaviorTarget does; CallerTarget
+        // does not — confirmed via Lattice survey 2026-06-23). Set null on
+        // currentScore; leave the rest of the row untouched (targetValue,
+        // confidence, decayHalfLife, etc. are operator-set or
+        // resolver-derived, not part of this drain).
+        await prisma.callerTarget.update({
+          where: { id: row.id },
+          data: { currentScore: null, lastScoredAt: null },
+        });
+      }
+
+      drained++;
+      console.log(
+        `  ${args.apply ? "DRAINED" : "WOULD-DRAIN"} ${row.id} ` +
+          `callerName=${row.caller?.name ?? "?"} ` +
+          `parameterId=${row.parameterId} ` +
+          `currentScore=${row.currentScore} (no CallScore backs this row)`,
+      );
+    } else {
+      // Legitimately scored. Leave untouched.
+      preservedRows.push({
+        id: row.id,
+        callerName: row.caller?.name ?? null,
+        parameterId: row.parameterId,
+        matchingCallScores: matchingScoreCount,
+      });
+      preserved++;
+      console.log(
+        `  PRESERVED ${row.id} ` +
+          `callerName=${row.caller?.name ?? "?"} ` +
+          `parameterId=${row.parameterId} ` +
+          `currentScore=${row.currentScore} (${matchingScoreCount} CallScore rows back this — legitimately scored)`,
+      );
+    }
+  }
+
+  console.log("");
+  console.log("=== Summary ===\n");
+  console.log(`  Total scanned:                  ${candidates.length}`);
+  console.log(`  Drained stale rows:             ${drained}${args.apply ? "" : " (would-drain — dry-run)"}`);
+  console.log(`  Preserved legitimately-scored:  ${preserved}`);
+  console.log("");
+
+  if (!args.apply && drained > 0) {
+    console.log(
+      `Re-run with --apply to commit the ${drained} stale-row NULL update.\n`,
+    );
+  }
+  if (args.apply) {
+    console.log(
+      "Drain complete. Re-run Query 15 in `npm run check:fk` to verify 0 violations.\n",
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  try {
+    await drain(args);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[drain-stale-ielts-skill-callertargets] FAILED: ${message}\n` +
+        "  Likely cause: database unreachable. Confirm DATABASE_URL is set and the bound DB is reachable.",
+    );
+    process.exit(1);
+  } finally {
+    await prisma.$disconnect().catch(() => undefined);
+  }
+}
+
+void main();

--- a/apps/admin/scripts/forensic-probe-stale-ielts-callertargets.ts
+++ b/apps/admin/scripts/forensic-probe-stale-ielts-callertargets.ts
@@ -1,0 +1,215 @@
+/**
+ * #2305 — Forensic probe for stale IELTS skill CallerTarget rows.
+ *
+ * READ-ONLY. Samples 5 of the non-null IELTS skill CallerTarget rows on
+ * the connected DB and prints, per row:
+ *   - caller name + id
+ *   - parameterId
+ *   - currentScore + lastScoredAt + updatedAt + createdAt
+ *   - CallScore count for this exact (callerId, parameterId)
+ *   - CallScore count for ANY parameterId on this caller (sanity context)
+ *
+ * Aggregate: of all non-null IELTS skill CallerTarget rows, how many
+ * have at least one matching CallScore (legitimately scored) vs zero
+ * (stale — the #2305 fingerprint).
+ *
+ * Tech-lead verdict (READY TO BUILD,
+ * https://github.com/WANDERCOLTD/HF/issues/2305#issuecomment-4788268055):
+ * the sole canonical writer of `CallerTarget.currentScore` is
+ * `lib/pipeline/aggregate-runner.ts::accumulateSkillScores`. Pre-#2138
+ * `lib/pipeline/prosody-consumer.ts` (retired) wrote currentScore
+ * directly under IELTS skill IDs without writing a paired CallScore —
+ * that path is the suspected origin of the stale rows.
+ *
+ * Run command (operator, on hf-dev VM bound to hf_sandbox):
+ *   cd ~/HF/apps/admin
+ *   npx tsx scripts/forensic-probe-stale-ielts-callertargets.ts
+ *
+ * To run against hf_staging, point DATABASE_URL at the staging secret
+ * before invocation.
+ *
+ * Exit codes:
+ *   0 — probe ran successfully (the row counts are the report; non-zero
+ *       stale counts are NOT a failure here — they're the finding)
+ *   1 — database unreachable / probe itself errored
+ */
+
+import { prisma } from "@/lib/prisma";
+
+const IELTS_SKILL_PARAMETER_IDS = [
+  "skill_fluency_and_coherence_fc",
+  "skill_lexical_resource_lr",
+  "skill_grammatical_range_and_accuracy_gra",
+  "skill_pronunciation_p",
+] as const;
+
+interface SampleRow {
+  callerTargetId: string;
+  callerId: string;
+  callerName: string | null;
+  parameterId: string;
+  currentScore: number | null;
+  lastScoredAt: Date | null;
+  updatedAt: Date;
+  createdAt: Date;
+}
+
+async function probe(): Promise<void> {
+  console.log(
+    "\n=== #2305 forensic probe — stale IELTS skill CallerTarget rows ===\n",
+  );
+
+  // Aggregate counts first — overall picture before sampling.
+  const totalIeltsRows = await prisma.callerTarget.count({
+    where: {
+      parameterId: { in: [...IELTS_SKILL_PARAMETER_IDS] },
+      currentScore: { not: null },
+    },
+  });
+
+  console.log(`Total non-null IELTS skill CallerTarget rows: ${totalIeltsRows}`);
+
+  if (totalIeltsRows === 0) {
+    console.log(
+      "\n  ✓ No non-null IELTS skill CallerTarget rows on this DB. Nothing to investigate.\n",
+    );
+    return;
+  }
+
+  // For each non-null row, determine whether there's a matching CallScore.
+  // Group classification:
+  //   - "legitimate": >= 1 CallScore row with same (callerId, parameterId)
+  //   - "stale":      0 CallScore rows with same (callerId, parameterId)
+  const allRows = await prisma.callerTarget.findMany({
+    where: {
+      parameterId: { in: [...IELTS_SKILL_PARAMETER_IDS] },
+      currentScore: { not: null },
+    },
+    select: {
+      id: true,
+      callerId: true,
+      parameterId: true,
+      currentScore: true,
+      lastScoredAt: true,
+      updatedAt: true,
+      createdAt: true,
+      caller: { select: { name: true } },
+    },
+  });
+
+  let legitimateCount = 0;
+  let staleCount = 0;
+  for (const row of allRows) {
+    const scoreCount = await prisma.callScore.count({
+      where: { callerId: row.callerId, parameterId: row.parameterId },
+    });
+    if (scoreCount > 0) {
+      legitimateCount++;
+    } else {
+      staleCount++;
+    }
+  }
+
+  console.log(`  legitimately scored (>=1 CallScore match): ${legitimateCount}`);
+  console.log(`  stale (0 CallScore match):                  ${staleCount}`);
+  console.log("");
+
+  // Sample 5 STALE rows for the per-row detail report (the #2305 fingerprint).
+  // If there are fewer than 5 stale rows, fall through to legitimate rows so
+  // the operator still sees concrete examples.
+  const sampleCount = Math.min(5, allRows.length);
+  const samples: SampleRow[] = [];
+
+  // Prefer stale rows for the sample (they're what the story is about).
+  for (const row of allRows) {
+    if (samples.length >= sampleCount) break;
+    const scoreCount = await prisma.callScore.count({
+      where: { callerId: row.callerId, parameterId: row.parameterId },
+    });
+    if (scoreCount === 0) {
+      samples.push({
+        callerTargetId: row.id,
+        callerId: row.callerId,
+        callerName: row.caller?.name ?? null,
+        parameterId: row.parameterId,
+        currentScore: row.currentScore,
+        lastScoredAt: row.lastScoredAt,
+        updatedAt: row.updatedAt,
+        createdAt: row.createdAt,
+      });
+    }
+  }
+  // Top up with legitimate rows if needed.
+  if (samples.length < sampleCount) {
+    for (const row of allRows) {
+      if (samples.length >= sampleCount) break;
+      const already = samples.find((s) => s.callerTargetId === row.id);
+      if (already) continue;
+      samples.push({
+        callerTargetId: row.id,
+        callerId: row.callerId,
+        callerName: row.caller?.name ?? null,
+        parameterId: row.parameterId,
+        currentScore: row.currentScore,
+        lastScoredAt: row.lastScoredAt,
+        updatedAt: row.updatedAt,
+        createdAt: row.createdAt,
+      });
+    }
+  }
+
+  console.log(`=== Per-row sample (n=${samples.length}, stale-first) ===\n`);
+  for (const s of samples) {
+    const matchingScores = await prisma.callScore.count({
+      where: { callerId: s.callerId, parameterId: s.parameterId },
+    });
+    const anyScores = await prisma.callScore.count({
+      where: { callerId: s.callerId },
+    });
+    const verdict = matchingScores === 0 ? "STALE" : "legitimate";
+    console.log(`  • [${verdict}] callerName=${s.callerName ?? "?"}`);
+    console.log(`      callerId           = ${s.callerId}`);
+    console.log(`      callerTargetId     = ${s.callerTargetId}`);
+    console.log(`      parameterId        = ${s.parameterId}`);
+    console.log(`      currentScore       = ${s.currentScore}`);
+    console.log(`      lastScoredAt       = ${s.lastScoredAt?.toISOString() ?? "null"}`);
+    console.log(`      createdAt          = ${s.createdAt.toISOString()}`);
+    console.log(`      updatedAt          = ${s.updatedAt.toISOString()}`);
+    console.log(`      matchingCallScores = ${matchingScores}`);
+    console.log(`      anyCallerScores    = ${anyScores}`);
+    console.log("");
+  }
+
+  console.log("=== Summary ===\n");
+  console.log(`  Total non-null IELTS skill CallerTarget rows: ${totalIeltsRows}`);
+  console.log(`    legitimately scored: ${legitimateCount}`);
+  console.log(`    stale (drain target): ${staleCount}`);
+  console.log("");
+  console.log(
+    "Next step: paste these counts into the PR body and run the drain script in --dry-run mode.",
+  );
+  console.log(
+    "  npx tsx scripts/drain-stale-ielts-skill-callertargets.ts          # dry-run (default)",
+  );
+  console.log(
+    "  npx tsx scripts/drain-stale-ielts-skill-callertargets.ts --apply  # actually NULL",
+  );
+  console.log("");
+}
+
+async function main(): Promise<void> {
+  try {
+    await probe();
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[forensic-probe] FAILED: ${message}\n` +
+        "  Likely cause: database unreachable. Confirm DATABASE_URL is set and the bound DB is reachable.",
+    );
+    process.exit(1);
+  } finally {
+    await prisma.$disconnect().catch(() => undefined);
+  }
+}
+
+void main();


### PR DESCRIPTION
Closes #2305

Tech-lead verdict (READY TO BUILD): https://github.com/WANDERCOLTD/HF/issues/2305#issuecomment-4788268055

## Summary

39 of 149 IELTS skill `CallerTarget` rows on hf_sandbox carry non-null `currentScore` with ZERO matching `CallScore` rows for the same `(callerId, parameterId)`. They originate from the pre-#2138 `lib/pipeline/prosody-consumer.ts:19-34,239` path that wrote `currentScore` directly under IELTS skill IDs without writing a paired `CallScore` row. That path was retired, but the stale data remains. Per epic #2135's rule "NEVER land hardcoded or AI-guessed score defaults", these rows are fabricated signal that corrupts EMA going forward.

This PR delivers approach A + B from the TL review:

- **A — drain:** an idempotent `--dry-run`-default drain script that NULLs `currentScore` (+ `lastScoredAt`) ONLY for rows where the `CallScore` count is 0; legitimately-scored rows are preserved with a logged reason.
- **B — Query 15:** WARN-only structural gate added to `apps/admin/scripts/check-fk-consistency.ts`, mirroring Query 14's pattern, so the regression class can't re-enter post-drain.

A separate forensic-probe script lets the operator verify the population before draining.

## Files

| File | Purpose |
|---|---|
| `apps/admin/scripts/forensic-probe-stale-ielts-callertargets.ts` (new) | Read-only sample of 5 rows + aggregate stale-vs-legitimate counts. Operator runs FIRST. |
| `apps/admin/scripts/drain-stale-ielts-skill-callertargets.ts` (new) | Idempotent drain. `--dry-run` is default; `--apply` commits. Per-row log + summary. |
| `apps/admin/scripts/check-fk-consistency.ts` (+85 lines) | Query 15 `callertarget-non-null-without-callscore`, WARN-only. |

## Verified by

- **Lattice survey** (per `.claude/rules/lattice-survey.md`):
  - Sole canonical writer of `CallerTarget.currentScore`: `lib/pipeline/aggregate-runner.ts::accumulateSkillScores`. Tech-lead-confirmed in the issue review.
  - Pre-#2138 `lib/pipeline/prosody-consumer.ts:19-34,239` wrote `currentScore` directly under IELTS skill IDs — retired path, suspected origin of stale rows.
  - **No chokepoint helper for `CallerTarget` today.** Sibling `BehaviorTarget` has `eslint-rules/no-bare-behavior-target-write.mjs`; `CallerTarget` does NOT. Direct `prisma.callerTarget.update` is allowed here.
  - UI null-safety confirmed by tech-lead review: `SkillBandStripCard.tsx:136` filters null; `track-progress.ts:187` returns null gracefully.
- **Pre-push checks pass:** `tsc: 43 errors (== baseline 43)`, `lint: no errors in changed files`.
- **No data touched by this PR.** Scripts are for the operator to run; this PR doesn't run them.

## Operator run sequence

All commands run from `apps/admin/` on the hf-dev VM. The DB the script writes against is determined by `DATABASE_URL`.

### 1. Forensic probe (on hf_sandbox)

```bash
cd ~/HF/apps/admin
npx tsx scripts/forensic-probe-stale-ielts-callertargets.ts
```

Paste the printed counts + 5-row sample into this PR as a comment. Confirm the live count matches the #2305 framing (~39 of 149 stale).

### 2. Drain dry-run (on hf_sandbox)

```bash
npx tsx scripts/drain-stale-ielts-skill-callertargets.ts
```

Reviews would-drain vs preserved per-row decisions. No writes happen.

### 3. Drain apply (on hf_sandbox)

```bash
npx tsx scripts/drain-stale-ielts-skill-callertargets.ts --apply
```

Commits the NULL updates. Idempotent — re-running drains 0 additional rows.

### 4. Verify Query 15 is clean on hf_sandbox

```bash
npm run check:fk
```

Expect `✓ callertarget-non-null-without-callscore — 0 rows` post-drain.

### 5. Repeat 1–4 on hf_staging

Re-point `DATABASE_URL` at the staging secret (per `docs/CLOUD-DEPLOYMENT.md` patterns) and re-run.

## Test plan

- [ ] Operator runs `forensic-probe-stale-ielts-callertargets.ts` on hf_sandbox; counts pasted into PR.
- [ ] Operator runs drain in `--dry-run` mode; row-level log reviewed.
- [ ] Operator runs drain with `--apply` on hf_sandbox; summary count matches dry-run.
- [ ] `npm run check:fk` returns `0 rows` for `callertarget-non-null-without-callscore` post-drain on hf_sandbox.
- [ ] Repeat on hf_staging.
- [ ] Spot-check IELTS lens UI (`SkillBandStripCard`) for a known-drained caller — value renders as "—" / not-yet-scored, no UI errors.

## Out of scope

- Not modifying `aggregate-runner.ts` (canonical writer; correct).
- Not modifying `prosody-consumer.ts` (#2138's surface; separate concern).
- Not adding a `CallerTarget` ESLint chokepoint (tracked separately if the pattern needs hardening).
- Not promoting Query 15 to ERROR severity — stays WARN-only until incumbent debt is cleared on every hosted DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)