### PR TITLE
fix(test): part2 cue schedule expects phase:"p2_monologue" on 60s cue

### DIFF
--- a/apps/admin/lib/wizard/__tests__/detect-authored-modules.test.ts
+++ b/apps/admin/lib/wizard/__tests__/detect-authored-modules.test.ts
@@ -137,7 +137,10 @@ describe("detectAuthoredModules — IELTS v2.3 per-module settings", () => {
     const part2 = result.modules.find((m) => m.id === "part2")!;
     expect(part2.settings!.scheduledCues).toEqual([
       { at: 45, text: "15 seconds left" },
-      { at: 60, text: "Your two minutes start now" },
+      // #1762 Story C — 60s cue carries phase:"p2_monologue" so the
+      // Session.metadata.phaseBoundaries write surface knows the
+      // prep→monologue boundary is at this cue (not just a text label).
+      { at: 60, text: "Your two minutes start now", phase: "p2_monologue" },
     ]);
     expect(part2.settings!.minSpeakingSec).toBe(120);
   });

--- a/apps/admin/tests/scripts/backfill-module-settings.test.ts
+++ b/apps/admin/tests/scripts/backfill-module-settings.test.ts
@@ -119,7 +119,10 @@ describe("computeBackfillPlan — IELTS v2.3 against a clean Playbook", () => {
     expect(part2.settings!.minSpeakingSec).toBe(120);
     expect(part2.settings!.scheduledCues).toEqual([
       { at: 45, text: "15 seconds left" },
-      { at: 60, text: "Your two minutes start now" },
+      // #1762 Story C — 60s cue carries phase:"p2_monologue" so the
+      // Session.metadata.phaseBoundaries write surface knows the
+      // prep→monologue boundary lives here.
+      { at: 60, text: "Your two minutes start now", phase: "p2_monologue" },
     ]);
   });
 

--- a/docs/kb/generated/coupling-graph.json
+++ b/docs/kb/generated/coupling-graph.json
@@ -1,10 +1,10 @@
 {
   "$schema": "coupling-graph/v1",
-  "generatedAt": "2026-06-23T22:25:19.761Z",
+  "generatedAt": "2026-06-24T13:05:44.692Z",
   "generator": "scripts/capture/coupling-graph.ts",
   "note": "Tier-2 generated KB. Per-file import edges across apps/admin/{lib,app,scripts}. External modules stripped. Do not hand-edit — re-run the generator.",
-  "fileCount": 1898,
-  "edgeCount": 4485,
+  "fileCount": 1900,
+  "edgeCount": 4487,
   "skippedEdges": 1,
   "edges": [
     {
@@ -17680,12 +17680,20 @@
       "to": "lib/prisma.ts"
     },
     {
+      "from": "scripts/drain-stale-ielts-skill-callertargets.ts",
+      "to": "lib/prisma.ts"
+    },
+    {
       "from": "scripts/fix-cio-cto-playbooks.ts",
       "to": "lib/goals/strategies/types.ts"
     },
     {
       "from": "scripts/fix-cio-cto-playbooks.ts",
       "to": "lib/registry/canonical-domain-group.ts"
+    },
+    {
+      "from": "scripts/forensic-probe-stale-ielts-callertargets.ts",
+      "to": "lib/prisma.ts"
     },
     {
       "from": "scripts/generate-ai-capabilities.ts",
@@ -25601,7 +25609,7 @@
     },
     {
       "path": "lib/prisma.ts",
-      "inDegree": 688,
+      "inDegree": 690,
       "outDegree": 0
     },
     {
@@ -27115,6 +27123,11 @@
       "outDegree": 0
     },
     {
+      "path": "scripts/drain-stale-ielts-skill-callertargets.ts",
+      "inDegree": 0,
+      "outDegree": 1
+    },
+    {
       "path": "scripts/enrich-beh-parameters.ts",
       "inDegree": 0,
       "outDegree": 0
@@ -27133,6 +27146,11 @@
       "path": "scripts/fix-orphaned-calls.ts",
       "inDegree": 0,
       "outDegree": 0
+    },
+    {
+      "path": "scripts/forensic-probe-stale-ielts-callertargets.ts",
+      "inDegree": 0,
+      "outDegree": 1
     },
     {
       "path": "scripts/generate-ai-capabilities.ts",
@@ -27443,7 +27461,7 @@
   "highCoupling": [
     {
       "path": "lib/prisma.ts",
-      "inDegree": 688,
+      "inDegree": 690,
       "outDegree": 0
     },
     {

--- a/docs/kb/generated/demo-knobs.json
+++ b/docs/kb/generated/demo-knobs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "demo-knobs/v1",
-  "generatedAt": "2026-06-23T22:25:20.130Z",
+  "generatedAt": "2026-06-24T13:05:45.041Z",
   "knobs": [
     {
       "knobKey": "BEH-RESPONSE-LEN",

--- a/docs/kb/generated/model-map.json
+++ b/docs/kb/generated/model-map.json
@@ -1,6 +1,6 @@
 {
   "$schema": "model-map/v1",
-  "generatedAt": "2026-06-23T22:25:18.466Z",
+  "generatedAt": "2026-06-24T13:05:43.372Z",
   "generator": "scripts/capture/model-map.ts",
   "schemaPath": "apps/admin/prisma/schema.prisma",
   "note": "Tier-2 generated KB. proposedClass is a HEURISTIC unless reviewed:true. Human ratifications live in docs/kb/model-map-overrides.json and are reapplied by the generator on each run. Do not hand-edit this JSON — edit the overrides file.",

--- a/docs/kb/generated/operator-surfaces.json
+++ b/docs/kb/generated/operator-surfaces.json
@@ -1,6 +1,6 @@
 {
   "$schema": "operator-surfaces/v1",
-  "generatedAt": "2026-06-23T22:25:20.541Z",
+  "generatedAt": "2026-06-24T13:05:45.442Z",
   "generator": "scripts/capture/operator-surfaces.ts",
   "note": "Tier-2 generated KB. Only routes tagged @operator-surface yes. Do not hand-edit — re-run the generator (npm run kb:operator-surfaces).",
   "surfaces": [

--- a/docs/kb/generated/parameter-inventory.json
+++ b/docs/kb/generated/parameter-inventory.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-23T22:25:22.075Z",
+  "generatedAt": "2026-06-24T13:05:47.024Z",
   "generator": "scripts/capture/parameter-inventory.ts",
   "parameterCount": 163,
   "active": 148,
@@ -909,7 +909,7 @@
         "lib/measurement/neutral-target.ts",
         "lib/prompt/composition/transforms/quickstart.ts"
       ],
-      "classification": "covered"
+      "classification": "promptInjection-dispatcher"
     },
     {
       "parameterId": "BEH-RHYTHM-ATTENTION",
@@ -1002,7 +1002,7 @@
         "lib/chat/unified-assistant-prompt.ts",
         "lib/prompt/composition/transforms/quickstart.ts"
       ],
-      "classification": "covered"
+      "classification": "promptInjection-dispatcher"
     },
     {
       "parameterId": "BEH-VERBAL-ELABORATION",

--- a/docs/kb/generated/parameter-inventory.md
+++ b/docs/kb/generated/parameter-inventory.md
@@ -10,8 +10,8 @@ Auto-generated from `apps/admin/docs-archive/bdd-specs/behavior-parameters.regis
 |---|---:|
 | Active parameters | 148 |
 | Deprecated | 15 |
-| Covered by consumer file | 113 |
-| Covered by promptInjection dispatcher | 14 |
+| Covered by consumer file | 111 |
+| Covered by promptInjection dispatcher | 16 |
 | **Producer-only (gap)** | **21** |
 | **Total** | **163** |
 
@@ -100,7 +100,7 @@ Producer-only entries are parameters with neither a code-level consumer nor a re
 | `BEH-LEARNING-VELOCITY-ADAPTATION` | covered | H/L | learning_velocity_adaptation | `lib/pipeline/engagement-targets-manifest.ts` |
 | `BEH-PAUSE-FOR-QUESTIONS` | covered | H/L | pause-for-questions | `lib/pipeline/engagement-targets-manifest.ts` |
 | `BEH-TONE-ASSERT` | covered | H/L | TONE_ASSERT | `lib/pipeline/engagement-targets-manifest.ts` |
-| `BEH-TURN-LENGTH` | covered | H/L | — | `lib/chat/unified-assistant-prompt.ts`, `lib/prompt/composition/transforms/quickstart.ts` |
+| `BEH-TURN-LENGTH` | promptInjection-dispatcher | H/L | — | `lib/chat/unified-assistant-prompt.ts`, `lib/prompt/composition/transforms/quickstart.ts` |
 | `BEH-WARMTH` | covered | H/L | BEH-CONVERSATIONAL-TONE, warmth_actual | `app/api/cascade/resolve/route.ts`, `app/api/chat/factual-grounding-intercept.ts`, `app/api/x/seed-domains/route.ts`, +7 more |
 | `check-for-understanding` | covered | H/L | — | `lib/pipeline/engagement-targets-manifest.ts` |
 | `CONV_PACE` | deprecated | H/L | — | `lib/chat/admin-tools.ts`, `lib/pipeline/prosody-consumer.ts`, `lib/pipeline/prosody-types.ts` |
@@ -195,7 +195,7 @@ Producer-only entries are parameters with neither a code-level consumer nor a re
 | `BEH-NEUROTICISM-ADAPTATION` | covered | H/L | neuroticism_adaptation | `lib/prompt/composition/transforms/instructions.ts`, `lib/prompt/composition/transforms/personality.ts` |
 | `BEH-OPENNESS-ADAPTATION` | covered | H/L | openness_adaptation | `lib/prompt/composition/transforms/instructions.ts`, `lib/prompt/composition/transforms/personality.ts` |
 | `BEH-PAUSE-TOLERANCE` | covered | H/L | — | `lib/chat/unified-assistant-prompt.ts`, `lib/measurement/neutral-target.ts`, `lib/prompt/composition/transforms/quickstart.ts` |
-| `BEH-RESPONSE-LEN` | covered | H/L | — | `app/api/chat/route.ts`, `lib/chat/admin-tool-handlers.ts`, `lib/chat/admin-tools.ts`, +4 more |
+| `BEH-RESPONSE-LEN` | promptInjection-dispatcher | H/L | — | `app/api/chat/route.ts`, `lib/chat/admin-tool-handlers.ts`, `lib/chat/admin-tools.ts`, +4 more |
 
 ## `reinforcement` (6)
 

--- a/docs/kb/generated/route-inventory.json
+++ b/docs/kb/generated/route-inventory.json
@@ -1,6 +1,6 @@
 {
   "$schema": "route-inventory/v1",
-  "generatedAt": "2026-06-23T22:25:19.003Z",
+  "generatedAt": "2026-06-24T13:05:43.885Z",
   "generator": "scripts/capture/route-inventory.ts",
   "note": "Tier-2 generated KB. tenantSignals are HEURISTIC hints, not a tenant-safety verdict. `possiblyUnscoped` = accepts a callerId param with no scope helper → review first in Phase 2. Do not hand-edit — re-run the generator.",
   "summary": {


### PR DESCRIPTION
## Summary

Updates 2 tests' expectations to match the IELTS v2.3 fixture's `phase: "p2_monologue"` field on the 60s cue. The fixture has carried this field since #1762 Story C (Session.metadata.phaseBoundaries); the tests were never updated to match.

Unblocks Test Suite CI for main + every open PR.

## Verified by

Live verification on `fix/part2-phase-test-update` (commit 1f8502f6) — both target tests pass:

\`\`\`
npx vitest run tests/scripts/backfill-module-settings.test.ts lib/wizard/__tests__/detect-authored-modules.test.ts
  ✓ lib/wizard/__tests__/detect-authored-modules.test.ts (34 tests) 17ms
  ✓ tests/scripts/backfill-module-settings.test.ts (11 tests) 20ms
  Tests 45 passed (45)
\`\`\`

**Main is broken on these 2 tests** — confirmed live:
- main `c50a62c4` Test Suite run 28095366153 → FAIL on both
- main `c50a62c4` BDD run 28095366074 → PASS (different workflow; doesn't run these tests)
- PR #2307 Test Suite → FAIL on the same 2 tests (rerun produced identical failure)
- PR #2312 Test Suite → FAIL on the same 2 tests

The "flaky" interpretation in earlier triage was wrong — these failures are deterministic on `c50a62c4`.

## Root cause

`apps/admin/lib/wizard/__tests__/fixtures/course-reference-ielts-v2.3.md` declares (per #1762 Story C):

\`\`\`yaml
scheduledCues:
  - { at: 45, text: "15 seconds left" }
  - { at: 60, text: "Your two minutes start now", phase: "p2_monologue" }
\`\`\`

The `phase` field is intentional — `Session.metadata.phaseBoundaries` is written from it so the prep→monologue transition is observable downstream.

Schema declares the union: `Array<{ at: number; text: string; phase?: string }>` (`apps/admin/lib/wizard/course-ref-template-schema.ts:201`).

Detector `lib/wizard/detect-module-settings.ts::isScheduledCueArray` type-checks `at` + `text` and ALLOWS extra keys through (correct — `phase` is part of the schema). So the runtime correctly produces:

\`\`\`
{ at: 60, text: "Your two minutes start now", phase: "p2_monologue" }
\`\`\`

Both tests asserted exact equality without `phase`. Test expectations now match the fixture + schema.

## Why tests-only

No runtime / schema / detector change. Tests asserted an out-of-date shape — fixture had moved on.

## Test plan

- [x] vitest pass locally
- [ ] CI green (in-flight)
- [ ] Once merged: PR #2307 + #2312 rebase to clear their Test Suite failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)