### PR TITLE
feat(x): ?embedded=1 strips admin chrome for IELTS market test demos

### DIFF
--- a/apps/admin/app/layout.tsx
+++ b/apps/admin/app/layout.tsx
@@ -26,6 +26,7 @@ import { StatusBar } from '@/components/shared/StatusBar';
 import { UserAvatar, computeInitials } from '@/components/shared/UserAvatar';
 import { UserContextMenu } from '@/components/shared/UserContextMenu';
 import { useResponsive } from '@/hooks/useResponsive';
+import { useEmbeddedMode } from '@/hooks/useEmbeddedMode';
 import { useSession } from 'next-auth/react';
 import { Menu, PanelLeft } from 'lucide-react';
 import './globals.css';
@@ -102,6 +103,14 @@ function LayoutInner({ children }: { children: React.ReactNode }) {
 
   // Embed mode - render without sidebar/chrome (for iframes)
   const isEmbed = searchParams.get('embed') === '1';
+
+  // MT-embedded mode (#2277) — IELTS market-test prospects visit
+  // `/x/sim/<callerId>?embedded=1` and see a clean simulator (no
+  // sidebar, no Cmd+K, no top-nav). Sticky via the `hf-embedded` cookie
+  // so subsequent navs in the same session stay embedded. Distinct
+  // from `?embed=1` (singular, iframe path) — the two are orthogonal
+  // and EITHER suppresses chrome.
+  const isMtEmbedded = useEmbeddedMode();
 
   // Auth pages (login, etc.) - render without sidebar
   const isAuthPage = pathname?.startsWith('/login');
@@ -225,8 +234,10 @@ function LayoutInner({ children }: { children: React.ReactNode }) {
 
   const layoutHeight = '100dvh';
 
-  // Auth pages, embed mode, and sim pages render without sidebar/chrome
-  if (isAuthPage || isEmbed || isSimPage) {
+  // Auth pages, embed mode, sim pages, and MT-embedded mode render
+  // without sidebar/chrome. MT-embedded (#2277) covers any /x/** path
+  // the operator has opted into for a market-test demo.
+  if (isAuthPage || isEmbed || isSimPage || isMtEmbedded) {
     return <>{children}</>;
   }
 

--- a/apps/admin/app/x/sim/[callerId]/page.tsx
+++ b/apps/admin/app/x/sim/[callerId]/page.tsx
@@ -7,6 +7,7 @@ import { useResponsive } from '@/hooks/useResponsive';
 import { WhatsAppHeader } from '@/components/sim/WhatsAppHeader';
 import { CallerVoiceSurface } from '@/components/callers/CallerVoiceSurface';
 import { FirstCallPinGate } from '@/components/identity/FirstCallPinGate';
+import { useEmbeddedMode } from '@/hooks/useEmbeddedMode';
 import { deriveParameterMap } from '@/lib/agent-tuner/derive';
 import type { AgentTunerPill } from '@/lib/agent-tuner/types';
 
@@ -58,6 +59,13 @@ export default function SimConversationPage() {
   const { data: session, status: sessionStatus } = useSession();
   const { isDesktop } = useResponsive();
   const isStudent = session?.user?.role === 'STUDENT';
+  // #2277 — MT-embedded mode: when the operator-supervised URL carries
+  // `?embedded=1`, the root layout already strips sidebar/topnav. We
+  // ALSO flip `<CallerVoiceSurface layout="embedded">` so SimChat
+  // renders its clean `sim-embedded` shell (no exam-shell overlay, no
+  // results overlay, no transcript-review return) — prospects see a
+  // pure chat surface.
+  const isMtEmbedded = useEmbeddedMode();
   // Admin "preview as learner" — `?as=learner` flips the PIN gate on
   // for an OPERATOR+ session so the auth surface can be demo'd without
   // signing out.
@@ -178,11 +186,11 @@ export default function SimConversationPage() {
   return (
     <CallerVoiceSurface
       callerId={callerId}
-      layout="standalone"
+      layout={isMtEmbedded ? 'embedded' : 'standalone'}
       sessionGoal={sessionGoal}
       targetOverrides={targetOverrides}
       forceFirstCall={forceFirstCall}
-      onBack={isDesktop ? undefined : () => router.push('/x/sim')}
+      onBack={isDesktop || isMtEmbedded ? undefined : () => router.push('/x/sim')}
       onCallEnd={
         isStudent
           ? (info) => {

--- a/apps/admin/hooks/useEmbeddedMode.ts
+++ b/apps/admin/hooks/useEmbeddedMode.ts
@@ -1,0 +1,91 @@
+/**
+ * useEmbeddedMode (#2277) — IELTS market-test embedded-chrome detection.
+ *
+ * MT prospects visit `/x/sim/<callerId>?embedded=1` and see a clean
+ * simulator: no left sidebar, no Cmd+K palette, no top-nav. The flag
+ * is **sticky** via a session cookie (`hf-embedded=1`) so once the
+ * operator-controlled URL carries the param, every subsequent nav in
+ * the same browser session stays embedded.
+ *
+ * Lifecycle:
+ *   - `?embedded=1` → write cookie, return `true`
+ *   - `?embedded=0` → clear cookie, return `false`
+ *   - no param, cookie present → return `true`
+ *   - no param, no cookie → return `false`
+ *
+ * Backward compat: the root layout already supports `?embed=1` (singular)
+ * as an iframe-friendly flag — that path is left untouched. This hook is
+ * the *new* MT-facing surface; ANY truthy result from either flag should
+ * suppress admin chrome.
+ *
+ * SSR / pre-hydration: returns `false` during the first render (server
+ * has no access to client cookies, and `useSearchParams()` returns null
+ * in some Next 16 contexts). The effect fires post-mount and the parent
+ * re-renders. The flicker is one frame of admin chrome on first paint —
+ * acceptable for an MT demo that operators preload before handing off
+ * to the prospect.
+ */
+
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+
+const COOKIE_NAME = "hf-embedded";
+const COOKIE_VALUE = "1";
+// 30-day TTL — matches the NextAuth session cookie window used elsewhere
+// in the app. MT demos are operator-supervised single-session affairs;
+// the cookie is per-browser-profile not per-tab so the operator can reset
+// by clearing site data.
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+
+function readCookie(): boolean {
+  if (typeof document === "undefined") return false;
+  const cookies = document.cookie.split(";");
+  for (const c of cookies) {
+    const [k, v] = c.trim().split("=");
+    if (k === COOKIE_NAME && v === COOKIE_VALUE) return true;
+  }
+  return false;
+}
+
+function writeCookie(): void {
+  if (typeof document === "undefined") return;
+  document.cookie = `${COOKIE_NAME}=${COOKIE_VALUE}; path=/; max-age=${COOKIE_MAX_AGE_SECONDS}; samesite=lax`;
+}
+
+function clearCookie(): void {
+  if (typeof document === "undefined") return;
+  document.cookie = `${COOKIE_NAME}=; path=/; max-age=0; samesite=lax`;
+}
+
+/**
+ * Returns `true` when the current page should render in MT-embedded
+ * mode (no admin chrome, no Cmd+K, no top-nav, no left sidebar).
+ *
+ * Reads from query param (`?embedded=1` or `?embedded=0`) first;
+ * falls back to the sticky `hf-embedded=1` cookie. Mutates the cookie
+ * as a side-effect when the query param is present.
+ */
+export function useEmbeddedMode(): boolean {
+  const searchParams = useSearchParams();
+  const [isEmbedded, setIsEmbedded] = useState<boolean>(false);
+
+  useEffect(() => {
+    const param = searchParams?.get("embedded");
+    if (param === "1") {
+      writeCookie();
+      setIsEmbedded(true);
+      return;
+    }
+    if (param === "0") {
+      clearCookie();
+      setIsEmbedded(false);
+      return;
+    }
+    // No explicit param — fall back to cookie.
+    setIsEmbedded(readCookie());
+  }, [searchParams]);
+
+  return isEmbedded;
+}

--- a/apps/admin/tests/hooks/useEmbeddedMode.test.tsx
+++ b/apps/admin/tests/hooks/useEmbeddedMode.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * #2277 — useEmbeddedMode hook.
+ *
+ * Pinned acceptance:
+ *   1. `?embedded=1` → returns true + writes cookie
+ *   2. `?embedded=0` → returns false + clears cookie
+ *   3. No param + cookie present → returns true (sticky)
+ *   4. No param + no cookie → returns false
+ *   5. `?embedded=1` then nav without param → still true (cookie sticks)
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+import { useEmbeddedMode } from "@/hooks/useEmbeddedMode";
+
+// Mock next/navigation's useSearchParams so the hook can read a
+// programmable query param surface.
+const searchParamsRef: { current: URLSearchParams } = {
+  current: new URLSearchParams(),
+};
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => searchParamsRef.current,
+}));
+
+function setParam(value: string | null) {
+  const p = new URLSearchParams();
+  if (value !== null) p.set("embedded", value);
+  searchParamsRef.current = p;
+}
+
+function clearAllCookies() {
+  document.cookie.split(";").forEach((c) => {
+    const eqPos = c.indexOf("=");
+    const name = eqPos > -1 ? c.substring(0, eqPos) : c;
+    document.cookie = `${name.trim()}=; path=/; max-age=0`;
+  });
+}
+
+function readEmbeddedCookie(): boolean {
+  const cookies = document.cookie.split(";");
+  for (const c of cookies) {
+    const [k, v] = c.trim().split("=");
+    if (k === "hf-embedded" && v === "1") return true;
+  }
+  return false;
+}
+
+describe("useEmbeddedMode", () => {
+  beforeEach(() => {
+    clearAllCookies();
+    setParam(null);
+  });
+
+  it("returns true and writes cookie when ?embedded=1", async () => {
+    setParam("1");
+    const { result } = renderHook(() => useEmbeddedMode());
+    await waitFor(() => expect(result.current).toBe(true));
+    expect(readEmbeddedCookie()).toBe(true);
+  });
+
+  it("returns false and clears cookie when ?embedded=0", async () => {
+    // Prime the cookie first.
+    document.cookie = "hf-embedded=1; path=/";
+    expect(readEmbeddedCookie()).toBe(true);
+    setParam("0");
+    const { result } = renderHook(() => useEmbeddedMode());
+    await waitFor(() => expect(result.current).toBe(false));
+    expect(readEmbeddedCookie()).toBe(false);
+  });
+
+  it("returns true from sticky cookie when no param present", async () => {
+    document.cookie = "hf-embedded=1; path=/";
+    setParam(null);
+    const { result } = renderHook(() => useEmbeddedMode());
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it("returns false when neither param nor cookie", async () => {
+    setParam(null);
+    const { result } = renderHook(() => useEmbeddedMode());
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+
+  it("stays embedded across subsequent navigations once cookie is set", async () => {
+    // First render with the activating param.
+    setParam("1");
+    const { result, rerender } = renderHook(() => useEmbeddedMode());
+    await waitFor(() => expect(result.current).toBe(true));
+
+    // Subsequent nav drops the param — cookie should keep the mode.
+    setParam(null);
+    rerender();
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it("ignores arbitrary values like ?embedded=true", async () => {
+    setParam("true");
+    const { result } = renderHook(() => useEmbeddedMode());
+    // No param=1 → no cookie write; no cookie present → false.
+    await waitFor(() => expect(result.current).toBe(false));
+    expect(readEmbeddedCookie()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `?embedded=1` query-param support to `/x/**` so IELTS MT prospects visiting `/x/sim/<callerId>?embedded=1` see a clean simulator (no sidebar, no Cmd+K, no top-nav).
- Sticky via `hf-embedded=1` cookie (30d TTL) so subsequent navs in the same session stay embedded. `?embedded=0` clears the cookie.
- Reuses SimChat's existing `isEmbedded` mode (`components/sim/SimChat.tsx:1276`) by flipping `<CallerVoiceSurface layout="embedded">` when the flag is set.
- Backward-compat with the pre-existing `?embed=1` (singular, iframe path) — both orthogonally suppress chrome.

Closes #2277.

## What changed

| File | Change |
|---|---|
| `apps/admin/hooks/useEmbeddedMode.ts` | NEW. Hook reads `?embedded=1\|0` + sticky `hf-embedded` cookie. |
| `apps/admin/app/layout.tsx` | Adds embedded check to chrome-strip branch (sits alongside existing `isEmbed` / `isSimPage` / `isAuthPage`). |
| `apps/admin/app/x/sim/[callerId]/page.tsx` | Passes `layout="embedded"` to `CallerVoiceSurface` when embedded — SimChat then renders its clean `sim-embedded` shell. |
| `apps/admin/tests/hooks/useEmbeddedMode.test.tsx` | NEW. 6 vitests pin param=1/0, sticky cookie, sticky-across-nav, non-canonical-ignored. |

## Verified by

- **Lattice survey:** read `app/layout.tsx` (existing `?embed=1` at L104; chrome-strip branch at L229), `app/x/sim/[callerId]/page.tsx` (passes `layout="standalone"` at L181), `components/sim/SimChat.tsx` (L1276 `isEmbedded = mode === 'embedded'` — already wired; L2575 returns clean `sim-embedded` div), `components/callers/CallerVoiceSurface.tsx` (L391 `mode={layout}` flows layout → SimChat). Sibling-writer risk: none — `?embed=1` (singular, iframe path) and `?embedded=1` (plural, MT path) use distinct param names + distinct cookie names; either suppresses chrome. Convention conflict: none. Cascade respect: hook is a thin read-through, no parallel resolver.
- **6/6 vitest cases** pass in `tests/hooks/useEmbeddedMode.test.tsx` (param=1 sets cookie, param=0 clears, sticky across nav with no param, ignores non-canonical values like `?embedded=true`).
- **tsc clean:** 0 errors introduced (43 → 43 baseline; pre-push gate passed after Prisma client regenerated in worktree).
- **Lint clean:** pre-push eslint check passed on changed files.

## Test plan

- [ ] On hf-dev VM, log in as OPERATOR and visit `/x/sim/<callerId>` (no param) — confirm admin sidebar + Cmd+K + top-nav render as today.
- [ ] Visit `/x/sim/<callerId>?embedded=1` — confirm clean simulator (no left sidebar, no Cmd+K palette mount, no top-nav, no status bar).
- [ ] Navigate to a different `/x/**` URL in the same browser session — confirm chrome stays stripped (cookie sticky).
- [ ] Visit `/x/sim/<callerId>?embedded=0` — confirm chrome returns AND cookie cleared (`document.cookie` no longer has `hf-embedded`).
- [ ] Visit again with no param — confirm admin chrome (cookie cleared).
- [ ] As STUDENT or `?as=learner`, confirm the FirstCallPinGate still mounts BEFORE embedded mode (gate is page-level and reads PIN status before layout decides).

🤖 Generated with [Claude Code](https://claude.com/claude-code)