### PR TITLE
feat(ielts): baseline orientation + closing aligned with BDD Unit 1

### DIFF
--- a/apps/admin/lib/wizard/__tests__/fixtures/course-reference-ielts-v2.3.md
+++ b/apps/admin/lib/wizard/__tests__/fixtures/course-reference-ielts-v2.3.md
@@ -190,12 +190,13 @@ settings:
   questionTarget: { min: 0, target: 0 }   # examiner-driven; questions per Part are scripted, not a learner-target
   cueCardPool: source:cue-card-bank-baseline-v1   # Source 4 — Baseline Assessment topic pool (Part 2 sub-pool)
   closingLine: |
-    That's the end of your Baseline. I'll share your focus area on screen.
+    That gives me a good picture of where you are. Give me a moment, and we'll get you started.
   firstTimeOrientationLine: |
     This is a relaxed first call, not a test, so I can hear you speak English
     and give you an honest starting point. We'll do all three Parts at exam
     pace — Part 1, then a cue card with one minute to prepare, then a few
-    follow-up questions. About twenty minutes total.
+    follow-up questions. About twenty minutes total. If you're ever unsure
+    about anything — just ask me.
   scheduledCues: []             # Baseline uses the warmer framing — no aloud cue countdown
   scaffoldPool: source:stall-scaffolds-monologue   # examiner-mode silence rules; Part 2 long-turn nudges only
   profileFieldsToCapture: source:ielts-speaking-profile-fields   # Source 14 — per-key {prompt, type} metadata


### PR DESCRIPTION
## Summary

Data-only edit aligning the canonical IELTS course-reference fixture (`course-reference-ielts-v2.3.md`) with two BDD-required phrasings in `HF-IELTS-Pre-Voice-Testing-Checklist.md` Unit 1:

- **A2**: `firstTimeOrientationLine` appends *"If you're ever unsure about anything — just ask me."*
- **C1**: `closingLine` replaced with BDD-verbatim *"That gives me a good picture of where you are. Give me a moment, and we'll get you started."*
- **L1-L3**: previous `closingLine` leaked *"focus area on screen"* — new text omits the score leak per BDD (`no scores shown to learner`)

## Why fixture-only

`seed-ielts-course.ts` already writes BOTH BDD-aligned values (landed via #2269 / #2294 / #2295 / #2298). The canonical fixture had not been updated to match. Without this fix, any future wizard-projected playbook from `course-reference-ielts-v2.3.md` would silently re-introduce the drift. This PR closes the source-of-truth gap.

## Verified by

- ✅ `tests/lib/wizard/fixture-type-coverage` — 12 vitests pass
- ✅ `tests/lib/courses/courses-template-version-coverage` — 6 vitests pass
- ✅ `tests/lib/wizard/detect-module-settings` — 15 vitests pass (orientation contains-checks for `"This is a relaxed first call"` + `"About twenty minutes total."` still satisfied)
- ✅ Grep audit: no tests / code / snapshots reference the old `"That's the end of your Baseline"` or `"share your focus area on screen"` strings
- ✅ Live DB unaffected by this PR (seed-ielts-course.ts already had the correct values; verification re-seed will confirm)

## Test plan

- [x] Local vitests green (fixture-type-coverage + courses-template-version-coverage + detect-module-settings)
- [ ] Post-merge: SSH hf-dev → `git pull` → `npx tsx prisma/seed-ielts-course.ts` → verify SQL shows `closingLine` = `"That gives me a good picture..."` and `firstTimeOrientationLine` contains `"just ask me."` on baseline module of IELTS playbook

## CI Docs Skip

cosmetic: fixture YAML content edit; no CI/infra surface touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)