### PR TITLE
fix(admin): Preview pane walks every onboarding phase

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx
@@ -738,19 +738,13 @@ function buildTranscript(flow: SessionFlowResp | null): PreviewItem[] {
   }
 
   if (sf.onboarding.phases.length > 0) {
-    const firstPhase = sf.onboarding.phases[0];
-    items.push({
-      kind: "bubble", side: "bot", lens: "onboarding", lensLabel: "Edit Onboarding",
-      caption: `Phase 1 of ${sf.onboarding.phases.length} — ${firstPhase.phase}`,
-      text: firstPhase.goals?.[0] || `(first onboarding phase: ${firstPhase.phase})`,
-    });
-    if (sf.onboarding.phases.length > 1) {
+    sf.onboarding.phases.forEach((phase, i) => {
       items.push({
         kind: "bubble", side: "bot", lens: "onboarding", lensLabel: "Edit Onboarding",
-        caption: `Then phases: ${sf.onboarding.phases.slice(1).map(p => p.phase).join(" → ")}`,
-        text: "(walks through the remaining phases before the first teaching segment)",
+        caption: `Phase ${i + 1} of ${sf.onboarding.phases.length} — ${phase.phase}`,
+        text: phase.goals?.[0] || `(onboarding phase: ${phase.phase})`,
       });
-    }
+    });
   } else {
     // #1418 — distinguish "explicitly disabled" from "never configured".
     // Pre-fix both states landed here with the same INIT-001 fallback


### PR DESCRIPTION
## Summary

The journey-tab Preview pane was rendering a hardcoded summary bubble for every onboarding phase past the first:

> `(walks through the remaining phases before the first teaching segment)`

Operator surfaced this from the Course Editor (IELTS Speaking Practice → Journey → Cat 1 phases). The cascade resolved `onboardingFlowPhases` correctly (chip showed `Course-only`), but `buildTranscript()` only emitted bubbles for phase 1 + a single summary bubble for the rest.

Fix: loop over `sf.onboarding.phases` and emit one bubble per phase (phase label + first goal), mirroring the `OnboardingRenderer` pattern at `components/shared/preview-renderers/OnboardingRenderer.tsx:50-61`.

Before:
- Phase 1 bubble (goal #1)
- "(walks through the remaining phases...)" hardcoded summary

After:
- Phase 1 bubble (goal #1)
- Phase 2 bubble (goal #1)
- Phase N bubble (goal #1)

## Verified by

- `apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx:740-748` — replaced lines 740-753, -10 / +4 LOC
- 91/91 vitest passed across `tests/components/preview-lens/`, `tests/components/preview-renderers/`, `tests/components/modules-tab/PreviewLens.shell-preview.test.tsx`
- `npx tsc --noEmit` clean for PreviewLens.tsx (pre-existing main-branch type errors elsewhere unchanged)
- No tests asserted the removed hardcoded strings (`grep -rn 'walks through the remaining phases\|first onboarding phase' tests/` → 0 hits)

## Test plan

- [ ] Open Course Editor → Journey tab on any course with multi-phase `onboardingFlowPhases`
- [ ] Confirm Preview pane shows one bubble per phase with phase label + first goal
- [ ] Confirm "walks through the remaining phases" placeholder is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)