### PR TITLE
feat(admin): Preview status banners + per-phase tag pill

### DIFF
--- a/apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx
+++ b/apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx
@@ -560,6 +560,28 @@ function buildTranscript(flow: SessionFlowResp | null): PreviewItem[] {
     || sf.intake.aboutYou.enabled
     || (sf.intake.knowledgeCheck.enabled && (sf.intake.knowledgeCheck.deliveryMode ?? "mcq") === "mcq");
 
+  // Status banner: pre-call survey ON vs OFF — operator can see at a glance
+  // whether the learner skips the survey entirely.
+  if (!anyIntake) {
+    items.push({
+      kind: "divider",
+      label: "🔕 Pre-call survey: OFF — learner skips intake + goes straight to Call 1",
+      lens: "intake",
+      lensLabel: "Turn intake survey on/off",
+    });
+  } else {
+    const enabledCount =
+      (sf.intake.goals.enabled ? 1 : 0)
+      + (sf.intake.aboutYou.enabled ? 1 : 0)
+      + (sf.intake.knowledgeCheck.enabled ? 1 : 0);
+    items.push({
+      kind: "divider",
+      label: `🔔 Pre-call survey: ${enabledCount} question${enabledCount === 1 ? "" : "s"} enabled`,
+      lens: "intake",
+      lensLabel: "Toggle intake questions",
+    });
+  }
+
   if (anyIntake) {
     items.push({
       kind: "divider",
@@ -738,10 +760,22 @@ function buildTranscript(flow: SessionFlowResp | null): PreviewItem[] {
   }
 
   if (sf.onboarding.phases.length > 0) {
+    items.push({
+      kind: "divider",
+      label: `▶ Call 1 onboarding — ${sf.onboarding.phases.length} phase${sf.onboarding.phases.length === 1 ? "" : "s"} (greet → rapport → goals → …)`,
+      lens: "onboarding",
+      lensLabel: "Edit onboarding phases",
+    });
     sf.onboarding.phases.forEach((phase, i) => {
+      // Each phase carries a `.phase` discriminator (e.g. "greeting",
+      // "rapport", "goals", "rest_of_call"). Surface it as a coloured
+      // pill via the caption so the operator immediately sees which
+      // sub-phase this bubble represents — vs reading the `.phase`
+      // value out of the body text.
+      const phaseTag = (phase.phase || "phase").toUpperCase();
       items.push({
         kind: "bubble", side: "bot", lens: "onboarding", lensLabel: "Edit Onboarding",
-        caption: `Phase ${i + 1} of ${sf.onboarding.phases.length} — ${phase.phase}`,
+        caption: `[${phaseTag}] · Phase ${i + 1} of ${sf.onboarding.phases.length}`,
         text: phase.goals?.[0] || `(onboarding phase: ${phase.phase})`,
       });
     });


### PR DESCRIPTION
## Summary

Three small UI tweaks in \`PreviewLens.tsx\` to make the journey-tab Preview less mysterious:

1. **Status banner** at top of the pre-call survey block — '🔕 Pre-call survey: OFF' (all 3 toggles false) or '🔔 Pre-call survey: N questions enabled'. Deep-links to intake lens.
2. **Status divider** before the onboarding-phases block — '▶ Call 1 onboarding — N phases'. Deep-links to onboarding lens.
3. **Per-phase tag pill** in each onboarding bubble caption — '[GREETING] · Phase 1 of 5' instead of 'Phase 1 of 5 — greeting'.

## Why

PR #2325 fixed Preview to walk every onboarding phase. Operator couldn't see at a glance whether the survey was actually firing or which sub-phase each bubble belonged to (2026-06-25 demo session).

## Test plan

- [ ] Open \`/x/courses/<id>\` → Journey tab → confirm banner reflects toggle state when intake toggles flipped via the journey-setting Inspector
- [ ] Confirm phase pills are visible ('[GREETING] · Phase 1 of 5')
- [ ] Banner + divider deep-link to the right lens on click
- [ ] No console errors

## Verified by

- **Type-check** ran in-session:
  \`\`\`
  cd apps/admin && npx tsc --noEmit 2>&1 | grep PreviewLens
  (empty output — PreviewLens.tsx is clean)
  \`\`\`

- **Existing test coverage**: \`apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx\` is consumed by Journey tab + Modules tab Preview lenses. Existing render contract preserved — only \`buildTranscript()\` output extended (new dividers + caption tweak) using the existing \`PreviewDivider\` and \`PreviewBubble\` types. No new type members.

- **HTTP probe**: the route reading session-flow data is \`GET /api/courses/[courseId]/session-flow\` — already in production via PR #2325. No new route surface added. Confirmed via:
  \`\`\`
  curl -sS http://localhost:3000/api/courses/20b21160-0516-49c9-a8da-105772f41e64/session-flow
  → { ok: true, sessionFlow: { intake, onboarding, ... } }
  \`\`\`
  My changes read \`sf.intake.{goals,aboutYou,knowledgeCheck}.enabled\` + \`sf.onboarding.phases[].phase\` which the existing endpoint already returns.

- **Scope**: single file diff — \`apps/admin/app/x/courses/[courseId]/_components/PreviewLens.tsx\` (one read).

- **Data-path declaration** (per \`.claude/rules/data-first-entry.md\`): Engine path. Pure UI rendering tweak — no \`PlaybookConfig\` field added, no \`JOURNEY_SETTINGS\` registry entry, no \`AnalysisSpec\` change.