### PR TITLE
chore(migrations): restore 1735_orientation_shown deleted by #1768

### DIFF
--- a/apps/admin/prisma/migrations/20260616133830_1735_orientation_shown/migration.sql
+++ b/apps/admin/prisma/migrations/20260616133830_1735_orientation_shown/migration.sql
@@ -1,0 +1,14 @@
+-- #1735 (epic #1700 Theme 1 G8 consumer D) — orientation-shown gate column.
+--
+-- Adds the `orientationShown` flag to `CallerModuleProgress`. Default false
+-- so existing rows pre-#1735 backfill cleanly (every prior caller is
+-- treated as "hasn't seen orientation yet", which is acceptable — the
+-- orientation line will fire once and never again).
+--
+-- Read by the composer (`transforms/instructions.ts::resolveModuleOrientationLine`)
+-- gated by `HF_FLAG_IELTS_MODULE_SETTINGS`. Written by `endSession`'s
+-- `evaluateOrientationShown` block on first successful completion of a
+-- module that has `moduleFirstTimeOrientationLine` set.
+
+ALTER TABLE "CallerModuleProgress"
+  ADD COLUMN "orientationShown" BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary

PR #1779 added migration `20260616133830_1735_orientation_shown` which created `CallerModuleProgress.orientationShown`. The migration ran on hf_staging on 2026-06-16. PR #1768 then deleted the migration directory without adding a replacement, leaving the column orphaned in `schema.prisma` with no migration creating it.

The deploy-gate now flags this as divergence: hf_staging carries a `_prisma_migrations` row for `20260616133830_1735_orientation_shown` with no matching local migration file. This blocks `/deploy dev full` at Gate 4 (migration status).

This PR restores the original migration directory + SQL byte-identical from commit `2da75b96` (PR #1779).

Resolution behaviour:
- **hf_staging**: migration record matches → `prisma migrate deploy` skips it → no DB change
- **Fresh DB**: original `ALTER TABLE ... ADD COLUMN` runs as designed → column created

## Verified by

- `git show 2da75b96:apps/admin/prisma/migrations/20260616133830_1735_orientation_shown/migration.sql` — byte-identical recovery
- Column `orientationShown` still present in `apps/admin/prisma/schema.prisma:3007` — restoring the migration aligns the migration history with the schema
- Deploy-gate Gate 4 output (this session): `The migration from the database are not found locally in prisma/migrations: 20260616133830_1735_orientation_shown` — direct citation of the divergence this PR resolves

## Test plan

- [ ] Re-run `/deploy dev full` deploy-gate post-merge — Gate 4 should now report clean
- [ ] On a fresh PILOT/PROD database (when provisioned), `prisma migrate deploy` runs this migration and creates the column

🤖 Generated with [Claude Code](https://claude.com/claude-code)