### PR TITLE
feat(ielts): tune skill EMA calibration for real-user cadence

### DIFF
--- a/apps/admin/prisma/seed-ielts-course.ts
+++ b/apps/admin/prisma/seed-ielts-course.ts
@@ -288,7 +288,16 @@ export async function main(prisma: PrismaClient): Promise<void> {
           maxDurationSeconds: 1800,
         },
         tierPresetId: "ielts-speaking",
-        skillScoringEmaHalfLifeDays: 14,
+        // Skill EMA calibration — the AGGREGATE-runner cascade reads these
+        // (aggregate-runner.ts:200-212). `minCallsToFull:1` removes the
+        // per-call cap that clamps call #1's CallerTarget to `callsUsed / N`
+        // (with N=4 default, first call was stuck at 0.25 regardless of the
+        // actual CallScore). Trusts call-1's scored value directly; the
+        // subsequent EMA smooths it. `halfLifeDays:3` keeps day-over-day
+        // real-user data smooth while letting per-week practice cadences
+        // visibly move the score (α ≈ 0.79 at 7-day gap).
+        skillScoringEmaHalfLifeDays: 3,
+        skillMinCallsToFull: 1,
         // ── CourseAssessmentPlan (epic #2176 / PR #2254 S1) ──
         // BDD-shaped: upfront baseline + end mock. Speaking is examiner-
         // mode, conversational — contentKind:"topic-prompt" (not mcq).


### PR DESCRIPTION
## Summary

Tune the IELTS Speaking Practice playbook's skill EMA cascade so caller scoring visibly moves for real users AND the demo scenario.

## Live evidence (hf_staging, Judy Leigh callId `2f665949-...`, 2026-07-02)

| Skill | Call 1 CallScore | Call 2 CallScore | CallerTarget after both calls |
|---|---|---|---|
| skill_fluency_and_coherence_fc | 0.38 | 0.48 | 0.25 (stuck) |
| skill_grammatical_range_and_accuracy_gra | 0.32 | 0.42 | 0.25 (stuck) |
| skill_lexical_resource_lr | 0.35 | 0.45 | 0.25 (stuck) |
| skill_pronunciation_p | 0.30 | 0.30 | 0.25 (stuck) |

Two defaults in the SKILL-AGG-001 cascade combined to freeze the CallerTarget rollup:
- `minCallsToFull: 4` — capped call 1's actual `0.38` down to `0.25` (`callsUsed / 4 = 0.25`).
- `emaHalfLifeDays: 14` — for calls 11 minutes apart, `α ≈ 0.0004`. Call 2's `0.48` blended in with `~0.04%` weight → `0.25009`.

## Fix

Set on `Playbook.config` (per-playbook override cascade already read by `aggregate-runner.ts:200-212`):

- `skillMinCallsToFull: 1` — trust call-1's scored value directly; the subsequent EMA smooths it.
- `skillScoringEmaHalfLifeDays: 3` — keeps day-over-day real-user data smooth while letting per-week practice cadences visibly move the score (`α ≈ 0.79` at a 7-day gap).

## Data path (per data-first-entry rule)

No code branch on pedagogy. Reads existing `Playbook.config.{skillScoringEmaHalfLifeDays,skillMinCallsToFull}` scalar knobs — the aggregate-runner cascade already honours these; the seed just wasn't providing them.

## Verified by

- Same JSON patch applied via UPDATE on hf_sandbox + hf_staging 2026-07-02 (immediate unblock).
- Judy's 4 IELTS CallerTargets reset on hf_staging so the next pipeline run rebuilds fresh from historical CallScores under the new cascade.
- Baseline scoring audit (MEMORY 2026-06-25): FC/LR/GRA scoring paths green — the ceiling was the visible failure, not the measurement.

## Test plan

- [x] `npx tsc --noEmit` — clean on the touched seed file
- [ ] Post-`/deploy → Full deploy`: seed run applies these values on hf_staging (matches the manual DB patch that's already live)
- [ ] Post-deploy: Judy's next call surfaces real CallerTarget values (0.30-0.48 range, not the frozen 0.25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)